### PR TITLE
[auto] Translate JAVA API Reference to Japanese

### DIFF
--- a/japanese/java/_index.md
+++ b/japanese/java/_index.md
@@ -1,0 +1,14 @@
+---
+title: "Aspose.Note for Java"
+type: docs
+weight: 11
+url: /ja/java/
+description: "Aspose.Note for Java API リファレンスには、サンプル、コードスニペット、API ドキュメントが含まれています。パッケージ、クラス、インターフェイス、その他の API 詳細を提供します。"
+is_root: true
+---
+
+## Packages
+| パッケージ | 説明 |
+| --- | --- |
+| [com.aspose.note](./com.aspose.note) | この \\`\\`\\` com.aspose.note \\`\\`\\` 名前空間には、ドキュメント構造を表すクラスが含まれています。 |
+| [com.aspose.note.fonts](./com.aspose.note.fonts) | この \\`\\`\\` com.aspose.note.fonts \\`\\`\\` 名前空間には、ドキュメントのフォント環境を操作する機能を提供するクラスが含まれています。 |

--- a/japanese/java/com.aspose.note.fonts/_index.md
+++ b/japanese/java/com.aspose.note.fonts/_index.md
@@ -1,0 +1,25 @@
+---
+title: "com.aspose.note.fonts"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "この com.aspose.note.fonts 名前空間には、ドキュメントのフォント環境を操作する機能を提供するクラスが含まれています。"
+type: docs
+weight: 27
+url: /ja/java/com.aspose.note.fonts/
+---
+
+
+この `com.aspose.note.fonts` 名前空間には、ドキュメントのフォント環境を操作する機能を提供するクラスが含まれています。
+
+
+## クラス
+
+| クラス | 説明 |
+| --- | --- |
+| [DocumentFontsSubsystem](../com.aspose.note.fonts/documentfontssubsystem) | Aspose.Note.Fonts.FontsSubsystem のシンプルな実装です。 |
+| [FontsSubsystem](../com.aspose.note.fonts/fontssubsystem) | com.aspose.note.IFontsSubsystem インターフェイスを実装する基底クラスです。 |
+
+## インターフェイス
+
+| インターフェイス | 説明 |
+| --- | --- |
+| [IFontsSubsystem](../com.aspose.note.fonts/ifontssubsystem) | ドキュメントを保存する際に Aspose.Note がフォントを取得する方法を制御したい場合は、このインターフェイスを実装してください。 |

--- a/japanese/java/com.aspose.note.fonts/documentfontssubsystem/_index.md
+++ b/japanese/java/com.aspose.note.fonts/documentfontssubsystem/_index.md
@@ -1,0 +1,229 @@
+---
+title: "DocumentFontsSubsystem"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "Aspose.Note.Fonts.FontsSubsystem のシンプルな実装です。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.note.fonts/documentfontssubsystem/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.fonts.FontsSubsystem](../../com.aspose.note.fonts/fontssubsystem)
+```
+public class DocumentFontsSubsystem extends FontsSubsystem
+```
+
+Aspose.Note.Fonts.FontsSubsystem のシンプルな実装です。OS から FontFamily オブジェクトを取得します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentFontsSubsystem(InputStream defaultFontStream, Map&lt;String,String&gt; fontsSubstitutions)](#DocumentFontsSubsystem-java.io.InputStream-java.util.Map-java.lang.String-java.lang.String--) | [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) クラスの新しいインスタンスを初期化します。 |
+| [DocumentFontsSubsystem(InputStream defaultFontStream)](#DocumentFontsSubsystem-java.io.InputStream-) | [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) クラスの新しいインスタンスを初期化します。 |
+| [DocumentFontsSubsystem(String defaultFontFile, Map&lt;String,String&gt; fontsSubstitutions)](#DocumentFontsSubsystem-java.lang.String-java.util.Map-java.lang.String-java.lang.String--) | [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) クラスの新しいインスタンスを初期化します。 |
+| [DocumentFontsSubsystem(String defaultFontFile)](#DocumentFontsSubsystem-java.lang.String-) | [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) クラスの新しいインスタンスを初期化します。 |
+| [DocumentFontsSubsystem(Map&lt;String,String&gt; fontsSubstitutions)](#DocumentFontsSubsystem-java.util.Map-java.lang.String-java.lang.String--) | [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) クラスの新しいインスタンスを初期化します。 |
+| [DocumentFontsSubsystem()](#DocumentFontsSubsystem--) | [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getDefault()](#getDefault--) | 静的なデフォルトインスタンスを取得または設定します。 |
+| [setDefault(DocumentFontsSubsystem value)](#setDefault-com.aspose.note.fonts.DocumentFontsSubsystem-) | 静的なデフォルトインスタンスを取得または設定します。 |
+| [usingDefaultFont(String defaultFontName)](#usingDefaultFont-java.lang.String-) | 指定されたデフォルトフォント名を使用して新しい DocumentFontsSubsystem インスタンスを作成します。 |
+| [usingDefaultFont(String defaultFontName, Map&lt;String,String&gt; fontsSubstitutions)](#usingDefaultFont-java.lang.String-java.util.Map-java.lang.String-java.lang.String--) | 指定されたデフォルトフォント名を使用して新しい DocumentFontsSubsystem インスタンスを作成します。 |
+| [usingDefaultFontFromFile(String filePath)](#usingDefaultFontFromFile-java.lang.String-) | 指定されたデフォルトフォント名を使用して新しい DocumentFontsSubsystem インスタンスを作成します。 |
+| [usingDefaultFontFromFile(String filePath, Map&lt;String,String&gt; fontsSubstitutions)](#usingDefaultFontFromFile-java.lang.String-java.util.Map-java.lang.String-java.lang.String--) | 指定されたファイルからフォントをデフォルトとして使用し、新しい DocumentFontsSubsystem インスタンスを作成します。 |
+| [usingDefaultFontFromStream(InputStream defaultFontStream)](#usingDefaultFontFromStream-java.io.InputStream-) | 指定されたストリームからフォントをデフォルトとして使用し、新しい DocumentFontsSubsystem インスタンスを作成します。 |
+| [usingDefaultFontFromStream(InputStream defaultFontStream, Map&lt;String,String&gt; fontsSubstitutions)](#usingDefaultFontFromStream-java.io.InputStream-java.util.Map-java.lang.String-java.lang.String--) | 指定されたストリームからフォントをデフォルトとして使用し、新しい DocumentFontsSubsystem インスタンスを作成します。 |
+### DocumentFontsSubsystem(InputStream defaultFontStream, Map&lt;String,String&gt; fontsSubstitutions) {#DocumentFontsSubsystem-java.io.InputStream-java.util.Map-java.lang.String-java.lang.String--}
+```
+public DocumentFontsSubsystem(InputStream defaultFontStream, Map<String,String> fontsSubstitutions)
+```
+
+
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) クラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| defaultFontStream | java.io.InputStream | デフォルトフォントを含むストリームです。 |
+| fontsSubstitutions | java.util.Map&lt;java.lang.String,java.lang.String&gt; | フォント置換です。 |
+
+### DocumentFontsSubsystem(InputStream defaultFontStream) {#DocumentFontsSubsystem-java.io.InputStream-}
+```
+public DocumentFontsSubsystem(InputStream defaultFontStream)
+```
+
+
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) クラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| defaultFontStream | java.io.InputStream | デフォルトフォントを含むストリームです。 |
+
+### DocumentFontsSubsystem(String defaultFontFile, Map&lt;String,String&gt; fontsSubstitutions) {#DocumentFontsSubsystem-java.lang.String-java.util.Map-java.lang.String-java.lang.String--}
+```
+public DocumentFontsSubsystem(String defaultFontFile, Map<String,String> fontsSubstitutions)
+```
+
+
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) クラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| defaultFontFile | java.lang.String | デフォルトフォントを含むファイルへのパスです。 |
+| fontsSubstitutions | java.util.Map&lt;java.lang.String,java.lang.String&gt; | フォント置換です。 |
+
+### DocumentFontsSubsystem(String defaultFontFile) {#DocumentFontsSubsystem-java.lang.String-}
+```
+public DocumentFontsSubsystem(String defaultFontFile)
+```
+
+
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) クラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| defaultFontFile | java.lang.String | デフォルトフォントを含むファイルへのパスです。 |
+
+### DocumentFontsSubsystem(Map&lt;String,String&gt; fontsSubstitutions) {#DocumentFontsSubsystem-java.util.Map-java.lang.String-java.lang.String--}
+```
+public DocumentFontsSubsystem(Map<String,String> fontsSubstitutions)
+```
+
+
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) クラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| fontsSubstitutions | java.util.Map&lt;java.lang.String,java.lang.String&gt; | フォント置換です。 |
+
+### DocumentFontsSubsystem() {#DocumentFontsSubsystem--}
+```
+public DocumentFontsSubsystem()
+```
+
+
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) クラスの新しいインスタンスを初期化します。
+
+### getDefault() {#getDefault--}
+```
+public static DocumentFontsSubsystem getDefault()
+```
+
+
+静的なデフォルトインスタンスを取得または設定します。
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem)
+### setDefault(DocumentFontsSubsystem value) {#setDefault-com.aspose.note.fonts.DocumentFontsSubsystem-}
+```
+public static void setDefault(DocumentFontsSubsystem value)
+```
+
+
+静的なデフォルトインスタンスを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) |  |
+
+### usingDefaultFont(String defaultFontName) {#usingDefaultFont-java.lang.String-}
+```
+public static DocumentFontsSubsystem usingDefaultFont(String defaultFontName)
+```
+
+
+指定されたデフォルトフォント名を使用して新しい DocumentFontsSubsystem インスタンスを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| defaultFontName | java.lang.String | デフォルトフォント名です。 |
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) - [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+### usingDefaultFont(String defaultFontName, Map&lt;String,String&gt; fontsSubstitutions) {#usingDefaultFont-java.lang.String-java.util.Map-java.lang.String-java.lang.String--}
+```
+public static DocumentFontsSubsystem usingDefaultFont(String defaultFontName, Map<String,String> fontsSubstitutions)
+```
+
+
+指定されたデフォルトフォント名を使用して新しい DocumentFontsSubsystem インスタンスを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| defaultFontName | java.lang.String | デフォルトフォント名です。 |
+| fontsSubstitutions | java.util.Map&lt;java.lang.String,java.lang.String&gt; | フォント置換です。 |
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) - [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+### usingDefaultFontFromFile(String filePath) {#usingDefaultFontFromFile-java.lang.String-}
+```
+public static DocumentFontsSubsystem usingDefaultFontFromFile(String filePath)
+```
+
+
+指定されたデフォルトフォント名を使用して新しい DocumentFontsSubsystem インスタンスを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| filePath | java.lang.String | デフォルトフォント名を含むファイルです。 |
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) - [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+### usingDefaultFontFromFile(String filePath, Map&lt;String,String&gt; fontsSubstitutions) {#usingDefaultFontFromFile-java.lang.String-java.util.Map-java.lang.String-java.lang.String--}
+```
+public static DocumentFontsSubsystem usingDefaultFontFromFile(String filePath, Map<String,String> fontsSubstitutions)
+```
+
+
+指定されたファイルからフォントをデフォルトとして使用し、新しい DocumentFontsSubsystem インスタンスを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| filePath | java.lang.String | デフォルトフォント名を含むファイルです。 |
+| fontsSubstitutions | java.util.Map&lt;java.lang.String,java.lang.String&gt; | フォント置換です。 |
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) - [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+### usingDefaultFontFromStream(InputStream defaultFontStream) {#usingDefaultFontFromStream-java.io.InputStream-}
+```
+public static DocumentFontsSubsystem usingDefaultFontFromStream(InputStream defaultFontStream)
+```
+
+
+指定されたストリームからフォントをデフォルトとして使用し、新しい DocumentFontsSubsystem インスタンスを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| defaultFontStream | java.io.InputStream | デフォルトフォント名を含むストリームです。 |
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) - [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+### usingDefaultFontFromStream(InputStream defaultFontStream, Map&lt;String,String&gt; fontsSubstitutions) {#usingDefaultFontFromStream-java.io.InputStream-java.util.Map-java.lang.String-java.lang.String--}
+```
+public static DocumentFontsSubsystem usingDefaultFontFromStream(InputStream defaultFontStream, Map<String,String> fontsSubstitutions)
+```
+
+
+指定されたストリームからフォントをデフォルトとして使用し、新しい DocumentFontsSubsystem インスタンスを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| defaultFontStream | java.io.InputStream | デフォルトフォント名を含むストリームです。 |
+| fontsSubstitutions | java.util.Map&lt;java.lang.String,java.lang.String&gt; | フォント置換です。 |
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) - [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).

--- a/japanese/java/com.aspose.note.fonts/fontssubsystem/_index.md
+++ b/japanese/java/com.aspose.note.fonts/fontssubsystem/_index.md
@@ -1,0 +1,107 @@
+---
+title: "FontsSubsystem"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "com.aspose.note.IFontsSubsystem インターフェイスを実装する基底クラスです。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.note.fonts/fontssubsystem/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.note.fonts.IFontsSubsystem](../../com.aspose.note.fonts/ifontssubsystem)
+```
+public abstract class FontsSubsystem implements IFontsSubsystem
+```
+
+com.aspose.note.IFontsSubsystem インターフェイスを実装する基底クラス。デフォルトフォントとフォントの置換機能を提供します。派生クラスで com.aspose.note.FontsSubsystem.fetchFontFamily の protected メンバー関数をオーバーライドして、Font オブジェクトの取得ロジックを実装します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addFont(InputStream stream)](#addFont-java.io.InputStream-) | フォントを追加します。 |
+| [addFont(String file)](#addFont-java.lang.String-) | フォントを追加します。 |
+| [addFontSubstitution(String substituted, String substitution)](#addFontSubstitution-java.lang.String-java.lang.String-) | フォントの置換を追加します。 |
+| [getDefaultFont()](#getDefaultFont--) | デフォルトフォントを取得します。 |
+| [getFontFamily(String fontName)](#getFontFamily-java.lang.String-) | フォントを取得します。 |
+| [loadFontsFromFolder(String folder)](#loadFontsFromFolder-java.lang.String-) | 指定されたフォルダーからすべての TrueType フォントを内部コレクションにロードします。 |
+### addFont(InputStream stream) {#addFont-java.io.InputStream-}
+```
+public final void addFont(InputStream stream)
+```
+
+
+フォントを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | フォントを含むストリームです。 |
+
+### addFont(String file) {#addFont-java.lang.String-}
+```
+public final void addFont(String file)
+```
+
+
+フォントを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ファイル | java.lang.String | フォントを含むファイルへのパスです。 |
+
+### addFontSubstitution(String substituted, String substitution) {#addFontSubstitution-java.lang.String-java.lang.String-}
+```
+public final void addFontSubstitution(String substituted, String substitution)
+```
+
+
+フォントの置換を追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 置換された | java.lang.String | 置換されたフォント名です。 |
+| 置換 | java.lang.String | 置換フォント名です。 |
+
+### getDefaultFont() {#getDefaultFont--}
+```
+public Font getDefaultFont()
+```
+
+
+デフォルトフォントを取得します。
+
+**Returns:**
+java.awt.Font
+### getFontFamily(String fontName) {#getFontFamily-java.lang.String-}
+```
+public Font getFontFamily(String fontName)
+```
+
+
+フォントを取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| fontName | java.lang.String | フォント名です。 |
+
+**Returns:**
+java.awt.Font - フォントです。
+### loadFontsFromFolder(String folder) {#loadFontsFromFolder-java.lang.String-}
+```
+public final void loadFontsFromFolder(String folder)
+```
+
+
+指定されたフォルダーからすべての TrueType フォントを内部コレクションにロードします。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| フォルダー | java.lang.String | フォントを含むフォルダーです。 |
+

--- a/japanese/java/com.aspose.note.fonts/ifontssubsystem/_index.md
+++ b/japanese/java/com.aspose.note.fonts/ifontssubsystem/_index.md
@@ -1,0 +1,33 @@
+---
+title: "IFontsSubsystem"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ドキュメントを保存する際に Aspose.Note がフォントを取得する方法を制御したい場合は、このインターフェイスを実装してください。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.note.fonts/ifontssubsystem/
+---
+```
+public interface IFontsSubsystem
+```
+
+ドキュメントを保存する際に Aspose.Note がフォントを取得する方法を制御したい場合は、このインターフェイスを実装してください。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getFontFamily(String fontName)](#getFontFamily-java.lang.String-) | フォントを取得します。 |
+### getFontFamily(String fontName) {#getFontFamily-java.lang.String-}
+```
+public abstract Font getFontFamily(String fontName)
+```
+
+
+フォントを取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| fontName | java.lang.String | フォント名です。 |
+
+**Returns:**
+java.awt.Font - フォントです。

--- a/japanese/java/com.aspose.note/_index.md
+++ b/japanese/java/com.aspose.note/_index.md
@@ -1,0 +1,123 @@
+---
+title: "com.aspose.note"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "この com.aspose.note 名前空間には、ドキュメント構造を表すクラスが含まれています。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.note/
+---
+
+
+この `com.aspose.note` 名前空間には、ドキュメント構造を表すクラスが含まれています。
+
+
+## クラス
+
+| クラス | 説明 |
+| --- | --- |
+| [AlwaysSplitObjectsAlgorithm](../com.aspose.note/alwayssplitobjectsalgorithm) | オブジェクトが元のページに収まらない場合、複数の部分に分割します。 |
+| [AttachedFile](../com.aspose.note/attachedfile) | 添付ファイルを表します。 |
+| [BinarizationMethod](../com.aspose.note/binarizationmethod) | 画像の二値化方法を指定します。 |
+| [CheckBox](../com.aspose.note/checkbox) | 完了と未完了の状態を切り替えることができるタグの基底クラスです。 |
+| [ColorMode](../com.aspose.note/colormode) | 画像のカラーモードです。 |
+| [CompositeNode&lt;T&gt;](../com.aspose.note/compositenode) | 他のノードを含むことができるノードの基本ジェネリッククラスです。 |
+| [CompositeNodeBase](../com.aspose.note/compositenodebase) | 他のノードを含むことができるノードの非ジェネリッククラスです。 |
+| [CssSavingArgs](../com.aspose.note/csssavingargs) | CssSaving イベントのデータを提供します。 |
+| [DefaultMsOneNoteValuesAccessor](../com.aspose.note/defaultmsonenotevaluesaccessor) |  |
+| [DisplayUnitsConverter](../com.aspose.note/displayunitsconverter) | このクラスには値を変換するメソッドが含まれています。 |
+| [Document](../com.aspose.note/document) | Aspose.Note ドキュメントを表します。 |
+| [DocumentPrintAttributeSet](../com.aspose.note/documentprintattributeset) | AttributeSet 用のユーザーフレンドリーなインターフェイスを備えたヘルパークラスを表します。 |
+| [DocumentVisitor](../com.aspose.note/documentvisitor) | 指定されたノードをルートとするサブツリーを反復処理するための抽象クラスです。 |
+| [ExtendedApsDocument](../com.aspose.note/extendedapsdocument) | ページをページセットに変換して構成された完全な OneNote ドキュメントを表します。 |
+| [ExtendedApsGlyphs](../com.aspose.note/extendedapsglyphs) | 標準 ApsGlyphs のラッパーを表し、描画動作の一部を拡張します。 |
+| [ExtendedApsImage](../com.aspose.note/extendedapsimage) | 標準 ApsImage のラッパーを表し、描画動作の一部を拡張します。 |
+| [ExtendedApsNode](../com.aspose.note/extendedapsnode) | 標準 ApsNode のラッパーを表し、描画動作の一部を拡張します。 |
+| [ExtendedApsPage](../com.aspose.note/extendedapspage) | 標準 ApsGlyphs のラッパーを表し、描画動作の一部を拡張します。 |
+| [ExtendedApsPath](../com.aspose.note/extendedapspath) | 標準 ApsPath のラッパーを表し、描画動作の一部を拡張します。 |
+| [ExtendedCompositeNode](../com.aspose.note/extendedcompositenode) | `IExtendedApsNode` インスタンスをいくつか組み合わせます。 |
+| [FileFormat](../com.aspose.note/fileformat) | OneNote ファイル形式を表します。 |
+| [FontSavingArgs](../com.aspose.note/fontsavingargs) | FontSaving イベントのデータを提供します。 |
+| [HtmlSaveOptions](../com.aspose.note/htmlsaveoptions) | ドキュメントを HTML 形式で保存する際に追加オプションを指定できます。 |
+| [Image](../com.aspose.note/image) | 画像を表します。 |
+| [ImageBinarizationOptions](../com.aspose.note/imagebinarizationoptions) | 画像の二値化オプションです。 |
+| [ImageSaveOptions](../com.aspose.note/imagesaveoptions) | ドキュメントページを画像にレンダリングする際に追加オプションを指定できます。 |
+| [ImageSavingArgs](../com.aspose.note/imagesavingargs) | ImageSaving イベントのデータを提供します。 |
+| [IndentatedNode&lt;T,Self&gt;](../com.aspose.note/indentatednode) | 子ノードの相対インデントを持つノードの基本クラスです。 |
+| [InkDrawing](../com.aspose.note/inkdrawing) | 任意の描画コンテンツを含むインクノードを表します。 |
+| [InkNode](../com.aspose.note/inknode) | すべてのインクノードの共通インターフェイスを表します。 |
+| [InkParagraph](../com.aspose.note/inkparagraph) | 斜体のような追加プロパティを持つ手書きテキストを含むインクノードを表します。 |
+| [InkWord](../com.aspose.note/inkword) | 手書きテキストを含むインクノードを表します。 |
+| [KeepPartAndCloneSolidObjectToNextPageAlgorithm](../com.aspose.note/keeppartandclonesolidobjecttonextpagealgorithm) | オブジェクトの上部をページの下部に追加し、元のページに収まらない場合はオブジェクト全体を次のページにクローンします。 |
+| [KeepSolidObjectsAlgorithm](../com.aspose.note/keepsolidobjectsalgorithm) | 元のページに収まらない場合、オブジェクト全体を次のページへ移動します。 |
+| [License](../com.aspose.note/license) | コンポーネントをライセンスするためのメソッドを提供します。 |
+| [LicenseExceptions](../com.aspose.note/licenseexceptions) |  |
+| [LoadOptions](../com.aspose.note/loadoptions) | ドキュメントの読み込みに使用されるオプションです。 |
+| [LocaleOptions](../com.aspose.note/localeoptions) | LocaleOptions 型は Aspose.Note のロケール構成を指定します。 |
+| [Loop](../com.aspose.note/loop) | ループを表します。 |
+| [Margins](../com.aspose.note/margins) | ノードの余白の寸法を指定します。 |
+| [Metered](../com.aspose.note/metered) | メーターキーを設定するためのメソッドを提供します。 |
+| [Node](../com.aspose.note/node) | Aspose.Note ドキュメントのすべてのノードの基底クラスです。 |
+| [NodeType](../com.aspose.note/nodetype) | ノードのタイプを指定します。 |
+| [NoteCheckBox](../com.aspose.note/notecheckbox) | 完了と未完了の状態を切り替えることができるノートタグを表します。 |
+| [NoteTag](../com.aspose.note/notetag) | ノートタグを表します。 |
+| [NoteTask](../com.aspose.note/notetask) | ノートタスクを表します。 |
+| [Notebook](../com.aspose.note/notebook) | Aspose.Note ノートブックを表します。 |
+| [NotebookImageSaveOptions](../com.aspose.note/notebookimagesaveoptions) | ノートブックページを画像にレンダリングする際に追加オプションを指定できます。 |
+| [NotebookLoadOptions](../com.aspose.note/notebookloadoptions) | ノートブックの読み込みに使用されるオプションです。 |
+| [NotebookOneSaveOptions](../com.aspose.note/notebookonesaveoptions) | ノートブックを OneNote 形式で保存する際に追加オプションを指定できます。 |
+| [NotebookPdfSaveOptions](../com.aspose.note/notebookpdfsaveoptions) | ノートブックページを PDF にレンダリングする際に追加オプションを指定できます。 |
+| [NotebookSaveOptions](../com.aspose.note/notebooksaveoptions) | 特定の形式向けのノートブック保存オプションを表す抽象基底クラスです。 |
+| [NotebookSaveOptionsGeneric&lt;TDocumentSaveOptions&gt;](../com.aspose.note/notebooksaveoptionsgeneric) | 特定の形式向けのノートブック保存オプションを表し、すべてのドキュメント子ノードに共通の保存オプションを提供する抽象基底クラスです。 |
+| [NumberFormat](../com.aspose.note/numberformat) | 自動番号付けオブジェクトのグループに使用できる番号形式を指定します。 |
+| [NumberList](../com.aspose.note/numberlist) | 番号付きまたは箇条書きリストを表します。 |
+| [OneSaveOptions](../com.aspose.note/onesaveoptions) | ドキュメントを OneNote 形式で保存する際に追加オプションを指定できます。 |
+| [Outline](../com.aspose.note/outline) | アウトラインを表します。 |
+| [OutlineElement](../com.aspose.note/outlineelement) | OutlineElement を表します。 |
+| [OutlineGroup](../com.aspose.note/outlinegroup) | OutlineGroup を表します。 |
+| [Page](../com.aspose.note/page) | ページを表します。 |
+| [PageHistory](../com.aspose.note/pagehistory) | ページ履歴を表します。 |
+| [PageSavingArgs](../com.aspose.note/pagesavingargs) | PageSaving イベントのデータを提供します。 |
+| [PageSettings](../com.aspose.note/pagesettings) | ページのレイアウト設定を表します。 |
+| [PageSizeType](../com.aspose.note/pagesizetype) | ページノードタイプのサイズを指定します。 |
+| [PageSplittingAlgorithm](../com.aspose.note/pagesplittingalgorithm) | オブジェクトが元のページに収まらない場合に分割するための基底クラスです。 |
+| [ParagraphStyle](../com.aspose.note/paragraphstyle) | テキストスタイル設定は、[RichText.\#getStyles](../com.aspose.note/richtext\#getStyles) コレクションに一致する TextStyle オブジェクトが存在しない場合、またはこのオブジェクトが必要な設定を指定していない場合に使用されます。 |
+| [PdfImageCompression](../com.aspose.note/pdfimagecompression) | PDF ファイル内の画像に適用される圧縮タイプを指定します。 |
+| [PdfSaveOptions](../com.aspose.note/pdfsaveoptions) | ドキュメントページを PDF にレンダリングする際に、追加オプションを指定できるようにします。 |
+| [PrintOptions](../com.aspose.note/printoptions) | ドキュメントの印刷に使用されるオプションです。 |
+| [ResourceExportType](../com.aspose.note/resourceexporttype) |  |
+| [ResourceSavingArgs](../com.aspose.note/resourcesavingargs) | ResourceSaving イベントのデータを提供します。 |
+| [RevisionSummary](../com.aspose.note/revisionsummary) | ノードのリビジョンの要約を表します。 |
+| [RichText](../com.aspose.note/richtext) | リッチテキストを表します。 |
+| [SaveFormat](../com.aspose.note/saveformat) | ドキュメントが保存される形式を示します。 |
+| [SaveFormatConverter](../com.aspose.note/saveformatconverter) | 保存形式コンバータです。 |
+| [SaveOptions](../com.aspose.note/saveoptions) | 特定の形式に対するドキュメント保存オプションを表す抽象基底クラスです。 |
+| [Style&lt;T&gt;](../com.aspose.note/style) | このクラスは、[ParagraphStyle](../com.aspose.note/paragraphstyle) と [TextStyle](../com.aspose.note/textstyle) クラスの共通プロパティを含みます。 |
+| [Table](../com.aspose.note/table) | テーブルを表します。 |
+| [TableCell](../com.aspose.note/tablecell) | テーブルセルを表します。 |
+| [TableColumn](../com.aspose.note/tablecolumn) | テーブル列を表します。 |
+| [TableRow](../com.aspose.note/tablerow) | テーブル行を表します。 |
+| [TagStatus](../com.aspose.note/tagstatus) | ノートタグノードのステータスを指定します。 |
+| [TextRun](../com.aspose.note/textrun) | 関連付けられたスタイルを持つテキストの一部を表すクラスです。 |
+| [TextStyle](../com.aspose.note/textstyle) | テキストのスタイルを指定します。 |
+| [TiffCompression](../com.aspose.note/tiffcompression) | ドキュメントを TIFF 形式で保存する際に使用する圧縮タイプを指定します。 |
+| [Title](../com.aspose.note/title) | タイトルを表します。 |
+
+## インターフェイス
+
+| インターフェイス | 説明 |
+| --- | --- |
+| [ICompositeNode](../com.aspose.note/icompositenode) | 他のノードを含むことができるノードのインターフェイスです。 |
+| [ICompositeNodeT&lt;T&gt;](../com.aspose.note/icompositenodet) | 他のノードを含むことができるノードのインターフェイスです。 |
+| [ICssSavingCallback](../com.aspose.note/icsssavingcallback) | HTML にドキュメントを保存する際に Aspose.Note が CSS（カスケーディングスタイルシート）を保存する方法を制御したい場合は、このインターフェイスを実装してください。 |
+| [IFontSavingCallback](../com.aspose.note/ifontsavingcallback) | HTML にドキュメントを保存する際に Aspose.Note がフォントを保存する方法を制御したい場合は、このインターフェイスを実装してください。 |
+| [IImageSavingCallback](../com.aspose.note/iimagesavingcallback) | HTML にドキュメントを保存する際に Aspose.Note が画像を保存する方法を制御したい場合は、このインターフェイスを実装してください。 |
+| [IIndentatedNode](../com.aspose.note/iindentatednode) | 子ノードに対して相対インデントを持つノードのインターフェイスです。 |
+| [INode](../com.aspose.note/inode) | Aspose.Note ドキュメントのすべてのノードのインターフェイスです。 |
+| [INoteTag](../com.aspose.note/inotetag) | ノートタグのインターフェイス（例： |
+| [INotebookChildNode](../com.aspose.note/inotebookchildnode) | Aspose.Note ノートブックの子要素を表します。 |
+| [IOutlineChildNode](../com.aspose.note/ioutlinechildnode) | アウトラインノードのすべての子ノードのインターフェイスです。 |
+| [IOutlineElementChildNode](../com.aspose.note/ioutlineelementchildnode) | アウトライン要素ノードのすべての子ノードのインターフェイスです。 |
+| [IPageChildNode](../com.aspose.note/ipagechildnode) | ページノードのすべての子ノードのインターフェイスです。 |
+| [IPageSavingCallback](../com.aspose.note/ipagesavingcallback) | Aspose.Note が個別のページを保存する方法を制御したい場合は、このインターフェイスを実装してください。 |
+| [ITag](../com.aspose.note/itag) | あらゆる種類のタグのインターフェイスです。 |
+| [ITaggable](../com.aspose.note/itaggable) | タグでマークできるノードのインターフェイスです。 |

--- a/japanese/java/com.aspose.note/alwayssplitobjectsalgorithm/_index.md
+++ b/japanese/java/com.aspose.note/alwayssplitobjectsalgorithm/_index.md
@@ -1,0 +1,27 @@
+---
+title: "AlwaysSplitObjectsAlgorithm"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "オブジェクトが元のページに収まらない場合、オブジェクトを複数の部分に分割します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.note/alwayssplitobjectsalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm)
+```
+public class AlwaysSplitObjectsAlgorithm extends PageSplittingAlgorithm
+```
+
+オブジェクトが元のページに収まらない場合、複数の部分に分割します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [AlwaysSplitObjectsAlgorithm()](#AlwaysSplitObjectsAlgorithm--) |  |
+### AlwaysSplitObjectsAlgorithm() {#AlwaysSplitObjectsAlgorithm--}
+```
+public AlwaysSplitObjectsAlgorithm()
+```
+
+

--- a/japanese/java/com.aspose.note/attachedfile/_index.md
+++ b/japanese/java/com.aspose.note/attachedfile/_index.md
@@ -1,0 +1,497 @@
+---
+title: "AttachedFile"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "添付ファイルを表します。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.note/attachedfile/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node)
+
+**All Implemented Interfaces:**
+[com.aspose.note.IPageChildNode](../../com.aspose.note/ipagechildnode), [com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode), [com.aspose.note.ITaggable](../../com.aspose.note/itaggable)
+```
+public class AttachedFile extends Node implements IPageChildNode, IOutlineElementChildNode, ITaggable
+```
+
+添付ファイルを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [AttachedFile(String path)](#AttachedFile-java.lang.String-) | `AttachedFile` クラスの新しいインスタンスを初期化します。 |
+| [AttachedFile(String path, InputStream icon, System.Drawing.Imaging.ImageFormat iconFormat)](#AttachedFile-java.lang.String-java.io.InputStream-com.aspose.ms.System.Drawing.Imaging.ImageFormat-) | `AttachedFile` クラスの新しいインスタンスを初期化します。 |
+| [AttachedFile(String fileName, InputStream attachedFileStream)](#AttachedFile-java.lang.String-java.io.InputStream-) | `AttachedFile` クラスの新しいインスタンスを初期化します。 |
+| [AttachedFile(String fileName, InputStream attachedFileStream, InputStream icon, System.Drawing.Imaging.ImageFormat iconFormat)](#AttachedFile-java.lang.String-java.io.InputStream-java.io.InputStream-com.aspose.ms.System.Drawing.Imaging.ImageFormat-) | `AttachedFile` クラスの新しいインスタンスを初期化します。 |
+| [AttachedFile()](#AttachedFile--) | `AttachedFile` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | ノードのビジターを受け入れます。 |
+| [getAlignment()](#getAlignment--) | 配置を取得します。 |
+| [getAlternativeTextDescription()](#getAlternativeTextDescription--) | 添付ファイルのアイコンの代替テキストとしての本文を取得または設定します。 |
+| [getAlternativeTextTitle()](#getAlternativeTextTitle--) | 添付ファイルのアイコンの代替テキストのタイトルを取得または設定します。 |
+| [getBytes()](#getBytes--) | 埋め込みファイルのバイナリ データを取得します。 |
+| [getExtension()](#getExtension--) | 埋め込みファイルの拡張子を取得します。 |
+| [getFileName()](#getFileName--) | 埋め込みファイルの名前を取得します。 |
+| [getFilePath()](#getFilePath--) | 元ファイルへのパスを取得します。 |
+| [getHeight()](#getHeight--) | 埋め込みファイルアイコンの元の高さを取得します。 |
+| [getHorizontalOffset()](#getHorizontalOffset--) | 水平オフセットを取得します。 |
+| [getIcon()](#getIcon--) | 埋め込みファイルに関連付けられたアイコンのバイナリ データを取得します。 |
+| [getIconExtension()](#getIconExtension--) | アイコンの拡張子を取得します。 |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 最終更新時刻を取得します。 |
+| [getMaxHeight()](#getMaxHeight--) | 埋め込みファイル アイコンを表示するための最大高さを取得します。 |
+| [getMaxWidth()](#getMaxWidth--) | 埋め込みファイル アイコンを表示するための最大幅を取得します。 |
+| [getParsingErrorInfo()](#getParsingErrorInfo--) | ファイルにアクセス中に発生したエラーに関するデータを取得します。 |
+| [getTags()](#getTags--) | 添付ファイルのタグ一覧を取得します。 |
+| [getText()](#getText--) | 埋め込みファイルのテキスト表現を取得します。 |
+| [getVerticalOffset()](#getVerticalOffset--) | 垂直オフセットを取得します。 |
+| [getWidth()](#getWidth--) | 埋め込みファイル アイコンの元の幅を取得します。 |
+| [isPrintout()](#isPrintout--) | ファイルのビューが印刷物かどうかを示す値を取得します。 |
+| [isSizeSetByUser()](#isSizeSetByUser--) | アイコンのサイズの値がユーザーによって明示的に更新されたかどうかを示す値を取得します。 |
+| [setAlignment(int value)](#setAlignment-int-) | 配置を設定します。 |
+| [setAlternativeTextDescription(String value)](#setAlternativeTextDescription-java.lang.String-) | 添付ファイルのアイコンの代替テキストとしての本文を取得または設定します。 |
+| [setAlternativeTextTitle(String value)](#setAlternativeTextTitle-java.lang.String-) | 添付ファイルのアイコンの代替テキストのタイトルを取得または設定します。 |
+| [setHorizontalOffset(float value)](#setHorizontalOffset-float-) | 水平オフセットを設定します。 |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 最終更新日時を設定します。 |
+| [setMaxHeight(float value)](#setMaxHeight-float-) | 埋め込みファイル アイコンを表示するための最大高さを設定します。 |
+| [setMaxWidth(float value)](#setMaxWidth-float-) | 埋め込みファイル アイコンを表示するための最大幅を設定します。 |
+| [setPrintout(boolean value)](#setPrintout-boolean-) | ファイルのビューが印刷物かどうかを示す値を設定します。 |
+| [setSizeSetByUser(boolean value)](#setSizeSetByUser-boolean-) | アイコンのサイズの値がユーザーによって明示的に更新されたかどうかを示す値を設定します。 |
+| [setText(String value)](#setText-java.lang.String-) | 埋め込みファイルのテキスト表現を設定します。 |
+| [setVerticalOffset(float value)](#setVerticalOffset-float-) | 垂直オフセットを設定します。 |
+### AttachedFile(String path) {#AttachedFile-java.lang.String-}
+```
+public AttachedFile(String path)
+```
+
+
+`AttachedFile` クラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| パス | java.lang.String | `AttachedFile` を作成する元となるファイルへのパスを含む文字列です。 |
+
+### AttachedFile(String path, InputStream icon, System.Drawing.Imaging.ImageFormat iconFormat) {#AttachedFile-java.lang.String-java.io.InputStream-com.aspose.ms.System.Drawing.Imaging.ImageFormat-}
+```
+public AttachedFile(String path, InputStream icon, System.Drawing.Imaging.ImageFormat iconFormat)
+```
+
+
+`AttachedFile` クラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| パス | java.lang.String | `AttachedFile` を作成する元となるファイルへのパスを含む文字列です。 |
+| アイコン | java.io.InputStream | 添付ファイル用のアイコンです。 |
+| アイコン形式 | com.aspose.ms.System.Drawing.Imaging.ImageFormat |  |
+
+### AttachedFile(String fileName, InputStream attachedFileStream) {#AttachedFile-java.lang.String-java.io.InputStream-}
+```
+public AttachedFile(String fileName, InputStream attachedFileStream)
+```
+
+
+`AttachedFile` クラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ファイル名 | java.lang.String | 添付ファイルの名前。 |
+| attachedFileStream | java.io.InputStream | 添付ファイルのバイトを含むストリーム。 |
+
+### AttachedFile(String fileName, InputStream attachedFileStream, InputStream icon, System.Drawing.Imaging.ImageFormat iconFormat) {#AttachedFile-java.lang.String-java.io.InputStream-java.io.InputStream-com.aspose.ms.System.Drawing.Imaging.ImageFormat-}
+```
+public AttachedFile(String fileName, InputStream attachedFileStream, InputStream icon, System.Drawing.Imaging.ImageFormat iconFormat)
+```
+
+
+`AttachedFile` クラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ファイル名 | java.lang.String | 添付ファイルの名前。 |
+| attachedFileStream | java.io.InputStream | 添付ファイルのバイトを含むストリーム。 |
+| アイコン | java.io.InputStream | 添付ファイル用のアイコンです。 |
+| アイコン形式 | com.aspose.ms.System.Drawing.Imaging.ImageFormat | 添付ファイルアイコンの形式。 |
+
+### AttachedFile() {#AttachedFile--}
+```
+public AttachedFile()
+```
+
+
+`AttachedFile` クラスの新しいインスタンスを初期化します。
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+ノードのビジターを受け入れます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor` から派生したクラスのオブジェクト。 |
+
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+配置を取得します。
+
+**Returns:**
+int
+### getAlternativeTextDescription() {#getAlternativeTextDescription--}
+```
+public final String getAlternativeTextDescription()
+```
+
+
+添付ファイルのアイコンの代替テキストとしての本文を取得または設定します。
+
+**Returns:**
+java.lang.String
+### getAlternativeTextTitle() {#getAlternativeTextTitle--}
+```
+public final String getAlternativeTextTitle()
+```
+
+
+添付ファイルのアイコンの代替テキストのタイトルを取得または設定します。
+
+**Returns:**
+java.lang.String
+### getBytes() {#getBytes--}
+```
+public byte[] getBytes()
+```
+
+
+埋め込みファイルのバイナリ データを取得します。
+
+**Returns:**
+byte[]
+### getExtension() {#getExtension--}
+```
+public String getExtension()
+```
+
+
+埋め込みファイルの拡張子を取得します。
+
+**Returns:**
+java.lang.String
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+埋め込みファイルの名前を取得します。
+
+**Returns:**
+java.lang.String
+### getFilePath() {#getFilePath--}
+```
+public String getFilePath()
+```
+
+
+元ファイルへのパスを取得します。
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public float getHeight()
+```
+
+
+埋め込みファイルアイコンの元の高さを取得します。
+
+**Returns:**
+float
+### getHorizontalOffset() {#getHorizontalOffset--}
+```
+public float getHorizontalOffset()
+```
+
+
+水平オフセットを取得します。
+
+**Returns:**
+float
+### getIcon() {#getIcon--}
+```
+public byte[] getIcon()
+```
+
+
+埋め込みファイルに関連付けられたアイコンのバイナリ データを取得します。
+
+**Returns:**
+byte[]
+### getIconExtension() {#getIconExtension--}
+```
+public String getIconExtension()
+```
+
+
+アイコンの拡張子を取得します。
+
+**Returns:**
+java.lang.String
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+最終更新時刻を取得します。
+
+**Returns:**
+java.util.Date
+### getMaxHeight() {#getMaxHeight--}
+```
+public float getMaxHeight()
+```
+
+
+埋め込みファイル アイコンを表示するための最大高さを取得します。
+
+**Returns:**
+float
+### getMaxWidth() {#getMaxWidth--}
+```
+public float getMaxWidth()
+```
+
+
+埋め込みファイル アイコンを表示するための最大幅を取得します。
+
+**Returns:**
+float
+### getParsingErrorInfo() {#getParsingErrorInfo--}
+```
+public final ParsingErrorInfo getParsingErrorInfo()
+```
+
+
+ファイルにアクセス中に発生したエラーに関するデータを取得します。
+
+**Returns:**
+[ParsingErrorInfo](../../com.aspose.note.infrastructure/parsingerrorinfo)
+### getTags() {#getTags--}
+```
+public final System.Collections.Generic.List<ITag> getTags()
+```
+
+
+添付ファイルのタグ一覧を取得します。
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List&lt;com.aspose.note.ITag&gt;
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+埋め込みファイルのテキスト表現を取得します。文字列は値10（改行）または13（復帰）の文字を含んではいけません。
+
+**Returns:**
+java.lang.String
+### getVerticalOffset() {#getVerticalOffset--}
+```
+public float getVerticalOffset()
+```
+
+
+垂直オフセットを取得します。
+
+**Returns:**
+float
+### getWidth() {#getWidth--}
+```
+public float getWidth()
+```
+
+
+埋め込みファイル アイコンの元の幅を取得します。
+
+**Returns:**
+float
+### isPrintout() {#isPrintout--}
+```
+public boolean isPrintout()
+```
+
+
+ファイルのビューが印刷物かどうかを示す値を取得します。
+
+**Returns:**
+boolean
+### isSizeSetByUser() {#isSizeSetByUser--}
+```
+public boolean isSizeSetByUser()
+```
+
+
+アイコンのサイズの値がユーザーによって明示的に更新されたかどうかを示す値を取得します。
+
+**Returns:**
+boolean
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+配置を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int | Alignment の値。 |
+
+### setAlternativeTextDescription(String value) {#setAlternativeTextDescription-java.lang.String-}
+```
+public final void setAlternativeTextDescription(String value)
+```
+
+
+添付ファイルのアイコンの代替テキストとしての本文を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setAlternativeTextTitle(String value) {#setAlternativeTextTitle-java.lang.String-}
+```
+public final void setAlternativeTextTitle(String value)
+```
+
+
+添付ファイルのアイコンの代替テキストのタイトルを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setHorizontalOffset(float value) {#setHorizontalOffset-float-}
+```
+public void setHorizontalOffset(float value)
+```
+
+
+水平オフセットを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float | Offsets の値。 |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+最終更新日時を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Date | Date の値。 |
+
+### setMaxHeight(float value) {#setMaxHeight-float-}
+```
+public void setMaxHeight(float value)
+```
+
+
+埋め込みファイル アイコンを表示するための最大高さを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float | 最大高さの値。 |
+
+### setMaxWidth(float value) {#setMaxWidth-float-}
+```
+public void setMaxWidth(float value)
+```
+
+
+埋め込みファイル アイコンを表示するための最大幅を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float | 最大幅の値。 |
+
+### setPrintout(boolean value) {#setPrintout-boolean-}
+```
+public void setPrintout(boolean value)
+```
+
+
+ファイルのビューが印刷物かどうかを示す値を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean | 新しい値。 |
+
+### setSizeSetByUser(boolean value) {#setSizeSetByUser-boolean-}
+```
+public void setSizeSetByUser(boolean value)
+```
+
+
+アイコンのサイズの値がユーザーによって明示的に更新されたかどうかを示す値を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean | 新しい値。 |
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public void setText(String value)
+```
+
+
+埋め込みファイルのテキスト表現を設定します。文字列は値10（改行）または13（復帰）の文字を含んではいけません。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | Text の値。 |
+
+### setVerticalOffset(float value) {#setVerticalOffset-float-}
+```
+public void setVerticalOffset(float value)
+```
+
+
+垂直オフセットを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float | Offset の値。 |
+

--- a/japanese/java/com.aspose.note/binarizationmethod/_index.md
+++ b/japanese/java/com.aspose.note/binarizationmethod/_index.md
@@ -1,0 +1,38 @@
+---
+title: "二値化方法"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "画像の二値化方法を指定します。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.note/binarizationmethod/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class BinarizationMethod extends System.Enum
+```
+
+画像の二値化方法を指定します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [FixedThreshold](#FixedThreshold) | 画像の二値化は、指定された固定閾値を使用して実行されます。 |
+| [Otsu](#Otsu) | 画像の二値化は、閾値を評価するために大津法を使用して適応的に実行されます。 |
+### FixedThreshold {#FixedThreshold}
+```
+public static final int FixedThreshold
+```
+
+
+画像の二値化は、指定された固定閾値を使用して実行されます。
+
+### Otsu {#Otsu}
+```
+public static final int Otsu
+```
+
+
+画像の二値化は、閾値を評価するために大津法を使用して適応的に実行されます。
+

--- a/japanese/java/com.aspose.note/checkbox/_index.md
+++ b/japanese/java/com.aspose.note/checkbox/_index.md
@@ -1,0 +1,131 @@
+---
+title: "CheckBox"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "完了と未完了の状態を切り替えることができるタグの基底クラスです。"
+type: docs
+weight: 13
+url: /ja/java/com.aspose.note/checkbox/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.note.TagExtended
+```
+public abstract class CheckBox extends TagExtended
+```
+
+完了と未完了の状態を切り替えることができるタグの基底クラスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getChecked()](#getChecked--) | CheckBox がチェックされた状態かどうかを示す値を取得します。 |
+| [getCompletedTime()](#getCompletedTime--) | 完了時間を取得または設定します。 |
+| [getCreationTime()](#getCreationTime--) | 作成時間を取得または設定します。 |
+| [getIcon()](#getIcon--) | アイコンを取得または設定します。 |
+| [getStatus()](#getStatus--) | ステータスを取得または設定します。 |
+| [setCompleted()](#setCompleted--) | 現在時刻を完了時刻として使用し、タグを完了状態に設定します。 |
+| [setCompleted(Date completedTime)](#setCompleted-java.util.Date-) | タグを完了状態に設定します。 |
+| [setCreationTime(Date value)](#setCreationTime-java.util.Date-) | 作成時間を取得または設定します。 |
+| [setOpen()](#setOpen--) | タグを開いた状態に設定します。 |
+### getChecked() {#getChecked--}
+```
+public final boolean getChecked()
+```
+
+
+CheckBox がチェックされた状態かどうかを示す値を取得します。
+
+**Returns:**
+boolean
+### getCompletedTime() {#getCompletedTime--}
+```
+public final Date getCompletedTime()
+```
+
+
+完了時間を取得または設定します。
+
+値: `Nullable\{DateTime\}`です。
+
+**Returns:**
+java.util.Date
+### getCreationTime() {#getCreationTime--}
+```
+public final Date getCreationTime()
+```
+
+
+作成時間を取得または設定します。
+
+値: java.util.Dateです。
+
+**Returns:**
+java.util.Date
+### getIcon() {#getIcon--}
+```
+public abstract int getIcon()
+```
+
+
+アイコンを取得または設定します。
+
+値: [TagIcon](../../com.aspose.note.infrastructure/tagicon)です。
+
+**Returns:**
+int
+### getStatus() {#getStatus--}
+```
+public final int getStatus()
+```
+
+
+ステータスを取得または設定します。
+
+値: [TagStatus](../../com.aspose.note/tagstatus)です。
+
+**Returns:**
+int
+### setCompleted() {#setCompleted--}
+```
+public final void setCompleted()
+```
+
+
+現在時刻を完了時刻として使用し、タグを完了状態に設定します。
+
+### setCompleted(Date completedTime) {#setCompleted-java.util.Date-}
+```
+public final void setCompleted(Date completedTime)
+```
+
+
+タグを完了状態に設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| completedTime | java.util.Date | 完了時刻です。 |
+
+### setCreationTime(Date value) {#setCreationTime-java.util.Date-}
+```
+public final void setCreationTime(Date value)
+```
+
+
+作成時間を取得または設定します。
+
+値: java.util.Dateです。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Date |  |
+
+### setOpen() {#setOpen--}
+```
+public void setOpen()
+```
+
+
+タグを開いた状態に設定します。
+

--- a/japanese/java/com.aspose.note/colormode/_index.md
+++ b/japanese/java/com.aspose.note/colormode/_index.md
@@ -1,0 +1,47 @@
+---
+title: "ColorMode"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "画像のカラーモードです。"
+type: docs
+weight: 14
+url: /ja/java/com.aspose.note/colormode/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class ColorMode extends System.Enum
+```
+
+画像のカラーモードです。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [BlackAndWhite](#BlackAndWhite) | 二値画像：黒と白のみが使用されます |
+| [GrayScale](#GrayScale) | グレースケール画像 |
+| [Normal](#Normal) | フルカラー画像 |
+### BlackAndWhite {#BlackAndWhite}
+```
+public static final int BlackAndWhite
+```
+
+
+二値画像：黒と白のみが使用されます
+
+### GrayScale {#GrayScale}
+```
+public static final int GrayScale
+```
+
+
+グレースケール画像
+
+### Normal {#Normal}
+```
+public static final int Normal
+```
+
+
+フルカラー画像
+

--- a/japanese/java/com.aspose.note/compositenode/_index.md
+++ b/japanese/java/com.aspose.note/compositenode/_index.md
@@ -1,0 +1,198 @@
+---
+title: "CompositeNode"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "他のノードを含むことができるノードの基本ジェネリッククラスです。"
+type: docs
+weight: 15
+url: /ja/java/com.aspose.note/compositenode/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase)
+
+**All Implemented Interfaces:**
+com.aspose.note.ICompositeNodeT
+```
+public abstract class CompositeNode<T> extends CompositeNodeBase implements ICompositeNodeT<T>
+```
+
+他のノードを含むことができるノードの基本ジェネリッククラスです。
+
+`T`: 複合ノード内の要素の型です。
+
+T :
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [&lt;T1&gt;appendChildFirst(T1 newChild)](#-T1-appendChildFirst-T1-) | このノードの子ノードリストの先頭にノードを追加します。 |
+| [&lt;T1&gt;appendChildLast(T1 newChild)](#-T1-appendChildLast-T1-) | このノードの子ノードリストの末尾にノードを追加します。 |
+| [&lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass)](#-T1-getChildNodes-java.lang.Class-T1--) | ノードのタイプで子ノードをすべて取得します。 |
+| [&lt;T1&gt;insertChild(int i, T1 newChild)](#-T1-insertChild-int-T1-) | このノードの子ノードリストの指定位置にノードを挿入します。 |
+| [&lt;T1&gt;removeChild(T1 oldChild)](#-T1-removeChild-T1-) | 子ノードを削除します。 |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | ノードのビジターを受け入れます。 |
+| [getFirstChild()](#getFirstChild--) | このノードの最初の子ノードを取得します。 |
+| [getLastChild()](#getLastChild--) | このノードの最後の子ノードを取得します。 |
+| [insertChildrenRange(int i, T[] newChildren)](#insertChildrenRange-int-T...-) | このノードの子ノードリストの指定位置からノードのシーケンスを挿入します。 |
+| [insertChildrenRange(int i, Iterable&lt;T&gt; newChildren)](#insertChildrenRange-int-java.lang.Iterable-T--) | このノードの子ノードリストの指定位置からノードのシーケンスを挿入します。 |
+| [isComposite()](#isComposite--) | ノードが複合かどうかを確認します。 |
+| [iterator()](#iterator--) | `CompositeNode\{T\}` の子ノードを列挙する列挙子を返します。 |
+### &lt;T1&gt;appendChildFirst(T1 newChild) {#-T1-appendChildFirst-T1-}
+```
+public T1 <T1>appendChildFirst(T1 newChild)
+```
+
+
+このノードの子ノードリストの先頭にノードを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| newChild | T1 | 追加するノードです。 |
+
+**Returns:**
+T1 - 追加されたノード。
+### &lt;T1&gt;appendChildLast(T1 newChild) {#-T1-appendChildLast-T1-}
+```
+public T1 <T1>appendChildLast(T1 newChild)
+```
+
+
+このノードの子ノードリストの末尾にノードを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| newChild | T1 | 追加するノードです。 |
+
+**Returns:**
+T1 - 追加されたノード。
+### &lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass) {#-T1-getChildNodes-java.lang.Class-T1--}
+```
+public List<T1> <T1>getChildNodes(Class<T1> typeParameterClass)
+```
+
+
+ノードのタイプで子ノードをすべて取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| typeParameterClass | java.lang.Class&lt;T1&gt; |  |
+
+**Returns:**
+java.util.List&lt;T1&gt; - 子ノードのリスト。
+
+`T1`: 返されたリスト内の要素の型です。
+### &lt;T1&gt;insertChild(int i, T1 newChild) {#-T1-insertChild-int-T1-}
+```
+public T1 <T1>insertChild(int i, T1 newChild)
+```
+
+
+このノードの子ノードリストの指定位置にノードを挿入します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| i | int | 挿入位置 |
+| newChild | T1 | 挿入するノードです。 |
+
+**Returns:**
+T1 - 追加されたノード。
+### &lt;T1&gt;removeChild(T1 oldChild) {#-T1-removeChild-T1-}
+```
+public T1 <T1>removeChild(T1 oldChild)
+```
+
+
+子ノードを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| oldChild | T1 | 削除するノードです。 |
+
+**Returns:**
+T1 - 削除されたノード。
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+ノードのビジターを受け入れます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor` から派生したクラスのオブジェクト。 |
+
+### getFirstChild() {#getFirstChild--}
+```
+public T getFirstChild()
+```
+
+
+このノードの最初の子ノードを取得します。
+
+**Returns:**
+T
+### getLastChild() {#getLastChild--}
+```
+public T getLastChild()
+```
+
+
+このノードの最後の子ノードを取得します。
+
+**Returns:**
+T
+### insertChildrenRange(int i, T[] newChildren) {#insertChildrenRange-int-T...-}
+```
+public final void insertChildrenRange(int i, T[] newChildren)
+```
+
+
+このノードの子ノードリストの指定位置からノードのシーケンスを挿入します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| i | int | 挿入位置 |
+| newChildren | T[] | 挿入されるノードのシーケンスです。 |
+
+### insertChildrenRange(int i, Iterable&lt;T&gt; newChildren) {#insertChildrenRange-int-java.lang.Iterable-T--}
+```
+public final void insertChildrenRange(int i, Iterable<T> newChildren)
+```
+
+
+このノードの子ノードリストの指定位置からノードのシーケンスを挿入します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| i | int | 挿入位置 |
+| newChildren | java.lang.Iterable&lt;T&gt; | 挿入されるノードのシーケンスです。 |
+
+### isComposite() {#isComposite--}
+```
+public final boolean isComposite()
+```
+
+
+ノードが複合かどうかをチェックします。true の場合、ノードは子ノードを持つことができます。
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public System.Collections.Generic.IGenericEnumerator<T> iterator()
+```
+
+
+`CompositeNode\{T\}` の子ノードを列挙する列挙子を返します。
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;T&gt; - `CompositeNode\{T\}` 用の `T:IEnumerator`1`。

--- a/japanese/java/com.aspose.note/compositenodebase/_index.md
+++ b/japanese/java/com.aspose.note/compositenodebase/_index.md
@@ -1,0 +1,19 @@
+---
+title: "CompositeNodeBase"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "他のノードを含むことができるノードの非ジェネリッククラスです。"
+type: docs
+weight: 16
+url: /ja/java/com.aspose.note/compositenodebase/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node)
+
+**All Implemented Interfaces:**
+[com.aspose.note.ICompositeNode](../../com.aspose.note/icompositenode)
+```
+public abstract class CompositeNodeBase extends Node implements ICompositeNode
+```
+
+他のノードを含むことができるノードの非ジェネリッククラスです。

--- a/japanese/java/com.aspose.note/csssavingargs/_index.md
+++ b/japanese/java/com.aspose.note/csssavingargs/_index.md
@@ -1,0 +1,16 @@
+---
+title: "CssSavingArgs"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "CssSaving イベントのデータを提供します。"
+type: docs
+weight: 17
+url: /ja/java/com.aspose.note/csssavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ResourceSavingArgs](../../com.aspose.note/resourcesavingargs)
+```
+public class CssSavingArgs extends ResourceSavingArgs
+```
+
+CssSaving イベントのデータを提供します。

--- a/japanese/java/com.aspose.note/defaultmsonenotevaluesaccessor/_index.md
+++ b/japanese/java/com.aspose.note/defaultmsonenotevaluesaccessor/_index.md
@@ -1,0 +1,62 @@
+---
+title: "DefaultMsOneNoteValuesAccessor"
+second_title: "Aspose.Note for Java API リファレンス"
+description: 
+type: docs
+weight: 18
+url: /ja/java/com.aspose.note/defaultmsonenotevaluesaccessor/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.internals.Accessor](../../com.aspose.note.internals/accessor)
+```
+public class DefaultMsOneNoteValuesAccessor extends Accessor
+```
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DefaultMsOneNoteValuesAccessor()](#DefaultMsOneNoteValuesAccessor--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getDefaultFontColor()](#getDefaultFontColor--) |  |
+| [getDefaultFontFamily()](#getDefaultFontFamily--) |  |
+| [getDefaultFontSizeInPoints()](#getDefaultFontSizeInPoints--) |  |
+### DefaultMsOneNoteValuesAccessor() {#DefaultMsOneNoteValuesAccessor--}
+```
+public DefaultMsOneNoteValuesAccessor()
+```
+
+
+### getDefaultFontColor() {#getDefaultFontColor--}
+```
+public static System.Drawing.Color getDefaultFontColor()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Drawing.Color
+### getDefaultFontFamily() {#getDefaultFontFamily--}
+```
+public static String getDefaultFontFamily()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getDefaultFontSizeInPoints() {#getDefaultFontSizeInPoints--}
+```
+public static int getDefaultFontSizeInPoints()
+```
+
+
+
+
+**Returns:**
+int

--- a/japanese/java/com.aspose.note/displayunitsconverter/_index.md
+++ b/japanese/java/com.aspose.note/displayunitsconverter/_index.md
@@ -1,0 +1,118 @@
+---
+title: "DisplayUnitsConverter"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "このクラスには値を変換するメソッドが含まれています。"
+type: docs
+weight: 19
+url: /ja/java/com.aspose.note/displayunitsconverter/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DisplayUnitsConverter
+```
+
+このクラスには値を変換するメソッドが含まれています。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [inchToPoint(float inches)](#inchToPoint-float-) | インチをポイントに変換します。 |
+| [millimeterToInch(float mm)](#millimeterToInch-float-) | ミリメートルをインチに変換します。 |
+| [millimeterToPoint(float mm)](#millimeterToPoint-float-) | ミリメートルをポイントに変換します。 |
+| [pixelToPoint(int pixels, float dpi)](#pixelToPoint-int-float-) | 指定されたピクセル解像度でピクセルをポイントに変換します。 |
+| [pointToInch(float points)](#pointToInch-float-) | ポイントをインチに変換します。 |
+| [pointToPixel(float points, float dpi)](#pointToPixel-float-float-) | 指定されたピクセル解像度でポイントをピクセルに変換します。 |
+### inchToPoint(float inches) {#inchToPoint-float-}
+```
+public static float inchToPoint(float inches)
+```
+
+
+インチをポイントに変換します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インチ | float | インチで変換する値です。 |
+
+**Returns:**
+float - `float`です。
+### millimeterToInch(float mm) {#millimeterToInch-float-}
+```
+public static float millimeterToInch(float mm)
+```
+
+
+ミリメートルをインチに変換します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| mm | float | ミリメートルで変換する値です。 |
+
+**Returns:**
+float - `float`です。
+### millimeterToPoint(float mm) {#millimeterToPoint-float-}
+```
+public static float millimeterToPoint(float mm)
+```
+
+
+ミリメートルをポイントに変換します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| mm | float | ミリメートルで変換する値です。 |
+
+**Returns:**
+float - `float`です。
+### pixelToPoint(int pixels, float dpi) {#pixelToPoint-int-float-}
+```
+public static float pixelToPoint(int pixels, float dpi)
+```
+
+
+指定されたピクセル解像度でピクセルをポイントに変換します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ピクセル | int | ピクセルで変換する値です。 |
+| dpi | float | 画面解像度です。 |
+
+**Returns:**
+float - `int`です。
+### pointToInch(float points) {#pointToInch-float-}
+```
+public static float pointToInch(float points)
+```
+
+
+ポイントをインチに変換します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ポイント | float | ポイントで変換する値です。 |
+
+**Returns:**
+float - `float`です。
+### pointToPixel(float points, float dpi) {#pointToPixel-float-float-}
+```
+public static int pointToPixel(float points, float dpi)
+```
+
+
+指定されたピクセル解像度でポイントをピクセルに変換します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ポイント | float | ポイントで変換する値です。 |
+| dpi | float | 画面解像度です。 |
+
+**Returns:**
+int - `int`です。

--- a/japanese/java/com.aspose.note/document/_index.md
+++ b/japanese/java/com.aspose.note/document/_index.md
@@ -1,0 +1,511 @@
+---
+title: "Document"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "Aspose.Note ドキュメントを表します。"
+type: docs
+weight: 20
+url: /ja/java/com.aspose.note/document/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode
+
+**All Implemented Interfaces:**
+[com.aspose.note.INotebookChildNode](../../com.aspose.note/inotebookchildnode)
+```
+public class Document extends CompositeNode<Page> implements INotebookChildNode
+```
+
+Aspose.Note ドキュメントを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Document()](#Document--) | `Document` クラスの新しいインスタンスを初期化します。 |
+| [Document(String filePath)](#Document-java.lang.String-) | `Document` クラスの新しいインスタンスを初期化します。 |
+| [Document(String filePath, LoadOptions loadOptions)](#Document-java.lang.String-com.aspose.note.LoadOptions-) | `Document` クラスの新しいインスタンスを初期化します。 |
+| [Document(InputStream inStream)](#Document-java.io.InputStream-) | `Document` クラスの新しいインスタンスを初期化します。 |
+| [Document(InputStream inStream, LoadOptions loadOptions)](#Document-java.io.InputStream-com.aspose.note.LoadOptions-) | `Document` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | ノードのビジターを受け入れます。 |
+| [detectLayoutChanges()](#detectLayoutChanges--) | 前回の `DetectLayoutChanges` 呼び出し以降にドキュメントレイアウトに加えられたすべての変更を検出します。 |
+| [getAutomaticLayoutChangesDetectionEnabled()](#getAutomaticLayoutChangesDetectionEnabled--) | Aspose.Note がレイアウト変更の検出を自動的に行うかどうかを示す値を取得します。 |
+| [getColor()](#getColor--) | 色を取得します。 |
+| [getCreationTime()](#getCreationTime--) | 作成時刻を取得します。 |
+| [getDisplayName()](#getDisplayName--) | 表示名を取得します。 |
+| [getFileFormat()](#getFileFormat--) | ファイル形式を取得します（OneNote 2010、OneNote Online）。 |
+| [getGuid()](#getGuid--) | オブジェクトのグローバルに一意な ID を取得します。 |
+| [getGuidInternal()](#getGuidInternal--) |  |
+| [getPageHistory(Page page)](#getPageHistory-com.aspose.note.Page-) | ドキュメントに表示される各ページの完全な履歴を含む `PageHistory` を取得します（最も古いものがインデックス 0）。 |
+| [isEncrypted(InputStream stream, Document[] document)](#isEncrypted-java.io.InputStream-com.aspose.note.Document---) | ストリームからのドキュメントが暗号化されているかどうかをチェックします。 |
+| [isEncrypted(InputStream stream, LoadOptions options, Document[] document)](#isEncrypted-java.io.InputStream-com.aspose.note.LoadOptions-com.aspose.note.Document---) | ストリームからのドキュメントが暗号化されているかどうかをチェックします。 |
+| [isEncrypted(InputStream stream, String password, Document[] document)](#isEncrypted-java.io.InputStream-java.lang.String-com.aspose.note.Document---) | ストリームからのドキュメントが暗号化されているかどうかをチェックします。 |
+| [isEncrypted(String filePath, Document[] document)](#isEncrypted-java.lang.String-com.aspose.note.Document---) | ファイルからのドキュメントが暗号化されているかどうかをチェックします。 |
+| [isEncrypted(String filePath, LoadOptions options, Document[] document)](#isEncrypted-java.lang.String-com.aspose.note.LoadOptions-com.aspose.note.Document---) | ファイルからのドキュメントが暗号化されているかどうかをチェックします。 |
+| [isEncrypted(String filePath, String password, Document[] document)](#isEncrypted-java.lang.String-java.lang.String-com.aspose.note.Document---) | ファイルからのドキュメントが暗号化されているかどうかをチェックします。 |
+| [print()](#print--) | デフォルトのプリンターを使用してドキュメントを印刷します。 |
+| [print(PrintOptions options)](#print-com.aspose.note.PrintOptions-) | デフォルトのプリンターを使用してドキュメントを印刷します。 |
+| [print(String printerName)](#print-java.lang.String-) | デフォルトのプリンターを使用してドキュメントを印刷します。 |
+| [print(AttributeSet printSettings)](#print-javax.print.attribute.AttributeSet-) | デフォルトのプリンターを使用してドキュメントを印刷します。 |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | OneNote ドキュメントをストリームに保存します。 |
+| [save(OutputStream stream, SaveOptions options)](#save-java.io.OutputStream-com.aspose.note.SaveOptions-) | 指定された保存オプションを使用して OneNote ドキュメントをストリームに保存します。 |
+| [save(OutputStream stream, int format)](#save-java.io.OutputStream-int-) | 指定された形式で OneNote ドキュメントをストリームに保存します。 |
+| [save(String fileName)](#save-java.lang.String-) | OneNote ドキュメントをファイルに保存します。 |
+| [save(String fileName, SaveOptions options)](#save-java.lang.String-com.aspose.note.SaveOptions-) | 指定された保存オプションを使用して OneNote ドキュメントをファイルに保存します。 |
+| [save(String fileName, int format)](#save-java.lang.String-int-) | 指定された形式で OneNote ドキュメントをファイルに保存します。 |
+| [setAutomaticLayoutChangesDetectionEnabled(boolean value)](#setAutomaticLayoutChangesDetectionEnabled-boolean-) | Aspose.Note がレイアウト変更の検出を自動的に行うかどうかを示す値を設定します。 |
+| [setColor(Color value)](#setColor-java.awt.Color-) | 色を設定します。 |
+| [setCreationTime(Date value)](#setCreationTime-java.util.Date-) | 作成時刻を設定します。 |
+| [setDisplayName(String value)](#setDisplayName-java.lang.String-) | 表示名を設定します。 |
+### Document() {#Document--}
+```
+public Document()
+```
+
+
+`Document` クラスの新しいインスタンスを初期化します。空白の OneNote ドキュメントを作成します。
+
+### Document(String filePath) {#Document-java.lang.String-}
+```
+public Document(String filePath)
+```
+
+
+`Document` クラスの新しいインスタンスを初期化します。ファイルから既存の OneNote ドキュメントを開きます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| filePath | java.lang.String | ファイル パスです。 |
+
+### Document(String filePath, LoadOptions loadOptions) {#Document-java.lang.String-com.aspose.note.LoadOptions-}
+```
+public Document(String filePath, LoadOptions loadOptions)
+```
+
+
+`Document` クラスの新しいインスタンスを初期化します。ファイルから既存の OneNote ドキュメントを開きます。暗号化パスワードなどの追加オプションを指定できます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| filePath | java.lang.String | ファイル パスです。 |
+| loadOptions | [LoadOptions](../../com.aspose.note/loadoptions) | ドキュメントのロードに使用されるオプションです。null にすることも可能です。 |
+
+### Document(InputStream inStream) {#Document-java.io.InputStream-}
+```
+public Document(InputStream inStream)
+```
+
+
+`Document` クラスの新しいインスタンスを初期化します。ストリームから既存の OneNote ドキュメントを開きます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| inStream | java.io.InputStream | ストリームです。 |
+
+### Document(InputStream inStream, LoadOptions loadOptions) {#Document-java.io.InputStream-com.aspose.note.LoadOptions-}
+```
+public Document(InputStream inStream, LoadOptions loadOptions)
+```
+
+
+`Document` クラスの新しいインスタンスを初期化します。ストリームから既存の OneNote ドキュメントを開きます。暗号化パスワードなどの追加オプションを指定できます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| inStream | java.io.InputStream | ストリームです。 |
+| loadOptions | [LoadOptions](../../com.aspose.note/loadoptions) | ドキュメントのロードに使用されるオプションです。null にすることも可能です。 |
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+ノードのビジターを受け入れます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor` から派生したクラスのオブジェクト。 |
+
+### detectLayoutChanges() {#detectLayoutChanges--}
+```
+public void detectLayoutChanges()
+```
+
+
+前回の `DetectLayoutChanges` 呼び出し以降にドキュメントのレイアウトに加えられたすべての変更を検出します。`AutomaticLayoutChangesDetectionEnabled` が true に設定されている場合、ドキュメントのエクスポート開始時に自動的に使用されます。
+
+### getAutomaticLayoutChangesDetectionEnabled() {#getAutomaticLayoutChangesDetectionEnabled--}
+```
+public boolean getAutomaticLayoutChangesDetectionEnabled()
+```
+
+
+Aspose.Note がレイアウト変更の検出を自動的に行うかどうかを示す値を取得します。デフォルト値は `true` です。
+
+**Returns:**
+boolean
+### getColor() {#getColor--}
+```
+public Color getColor()
+```
+
+
+色を取得します。
+
+**Returns:**
+java.awt.Color
+### getCreationTime() {#getCreationTime--}
+```
+public Date getCreationTime()
+```
+
+
+作成時刻を取得します。
+
+**Returns:**
+java.util.Date
+### getDisplayName() {#getDisplayName--}
+```
+public String getDisplayName()
+```
+
+
+表示名を取得します。
+
+**Returns:**
+java.lang.String
+### getFileFormat() {#getFileFormat--}
+```
+public int getFileFormat()
+```
+
+
+ファイル形式を取得します（OneNote 2010、OneNote Online）。
+
+**Returns:**
+int
+### getGuid() {#getGuid--}
+```
+public UUID getGuid()
+```
+
+
+オブジェクトのグローバルに一意な ID を取得します。
+
+**Returns:**
+java.util.UUID
+### getGuidInternal() {#getGuidInternal--}
+```
+public System.Guid getGuidInternal()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Guid
+### getPageHistory(Page page) {#getPageHistory-com.aspose.note.Page-}
+```
+public PageHistory getPageHistory(Page page)
+```
+
+
+ドキュメントに表示される各ページの完全な履歴を含む `PageHistory` を取得します（最も古いものがインデックス 0）。現在のページリビジョンは `PageHistory.current` としてアクセスでき、履歴バージョンのコレクションとは別に保持されます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.note/page) | ページの現在のリビジョンです。 |
+
+**Returns:**
+[PageHistory](../../com.aspose.note/pagehistory) - The `PageHistory`.
+### isEncrypted(InputStream stream, Document[] document) {#isEncrypted-java.io.InputStream-com.aspose.note.Document---}
+```
+public static boolean isEncrypted(InputStream stream, Document[] document)
+```
+
+
+ストリームからのドキュメントが暗号化されているかどうかをチェックします。チェックするにはドキュメントを完全にロードする必要があるため、このメソッドはパフォーマンスに影響を与える可能性があります。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | ストリームです。 |
+| document | [Document\[\]](../../com.aspose.note/document) | ロードされたドキュメントです。 |
+
+**Returns:**
+boolean - ドキュメントが暗号化されている場合は true、そうでない場合は false を返します。
+### isEncrypted(InputStream stream, LoadOptions options, Document[] document) {#isEncrypted-java.io.InputStream-com.aspose.note.LoadOptions-com.aspose.note.Document---}
+```
+public static boolean isEncrypted(InputStream stream, LoadOptions options, Document[] document)
+```
+
+
+ストリームからのドキュメントが暗号化されているかどうかをチェックします。チェックするにはドキュメントを完全にロードする必要があるため、このメソッドはパフォーマンスに影響を与える可能性があります。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | ストリームです。 |
+| options | [LoadOptions](../../com.aspose.note/loadoptions) | ロード オプションです。 |
+| document | [Document\[\]](../../com.aspose.note/document) | ロードされたドキュメントです。 |
+
+**Returns:**
+boolean - ドキュメントが暗号化されている場合は true、そうでない場合は false を返します。
+### isEncrypted(InputStream stream, String password, Document[] document) {#isEncrypted-java.io.InputStream-java.lang.String-com.aspose.note.Document---}
+```
+public static boolean isEncrypted(InputStream stream, String password, Document[] document)
+```
+
+
+ストリームからのドキュメントが暗号化されているかどうかをチェックします。チェックするにはドキュメントを完全にロードする必要があるため、このメソッドはパフォーマンスに影響を与える可能性があります。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | ストリームです。 |
+| password | java.lang.String | ドキュメントを復号化するためのパスワードです。 |
+| document | [Document\[\]](../../com.aspose.note/document) | ロードされたドキュメントです。 |
+
+**Returns:**
+boolean - ドキュメントが暗号化されている場合は true、そうでない場合は false を返します。
+### isEncrypted(String filePath, Document[] document) {#isEncrypted-java.lang.String-com.aspose.note.Document---}
+```
+public static boolean isEncrypted(String filePath, Document[] document)
+```
+
+
+ファイルからのドキュメントが暗号化されているかどうかをチェックします。チェックするにはドキュメントを完全にロードする必要があるため、このメソッドはパフォーマンスに影響を与える可能性があります。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| filePath | java.lang.String | ファイル パスです。 |
+| document | [Document\[\]](../../com.aspose.note/document) | ロードされたドキュメントです。 |
+
+**Returns:**
+boolean - ドキュメントが暗号化されている場合は true、そうでない場合は false を返します。
+### isEncrypted(String filePath, LoadOptions options, Document[] document) {#isEncrypted-java.lang.String-com.aspose.note.LoadOptions-com.aspose.note.Document---}
+```
+public static boolean isEncrypted(String filePath, LoadOptions options, Document[] document)
+```
+
+
+ファイルからのドキュメントが暗号化されているかどうかをチェックします。チェックするにはドキュメントを完全にロードする必要があるため、このメソッドはパフォーマンスに影響を与える可能性があります。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| filePath | java.lang.String | ファイル パスです。 |
+| options | [LoadOptions](../../com.aspose.note/loadoptions) | ロード オプションです。 |
+| document | [Document\[\]](../../com.aspose.note/document) | ロードされたドキュメントです。 |
+
+**Returns:**
+boolean - ドキュメントが暗号化されている場合は true、そうでない場合は false を返します。
+### isEncrypted(String filePath, String password, Document[] document) {#isEncrypted-java.lang.String-java.lang.String-com.aspose.note.Document---}
+```
+public static boolean isEncrypted(String filePath, String password, Document[] document)
+```
+
+
+ファイルからのドキュメントが暗号化されているかどうかをチェックします。チェックするにはドキュメントを完全にロードする必要があるため、このメソッドはパフォーマンスに影響を与える可能性があります。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| filePath | java.lang.String | ファイル パスです。 |
+| password | java.lang.String | ドキュメントを復号化するためのパスワードです。 |
+| document | [Document\[\]](../../com.aspose.note/document) | ロードされたドキュメントです。 |
+
+**Returns:**
+boolean - ドキュメントが暗号化されている場合は true、そうでない場合は false を返します。
+### print() {#print--}
+```
+public void print()
+```
+
+
+デフォルトのプリンターを使用してドキュメントを印刷します。
+
+### print(PrintOptions options) {#print-com.aspose.note.PrintOptions-}
+```
+public void print(PrintOptions options)
+```
+
+
+デフォルトのプリンターを使用してドキュメントを印刷します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| options | [PrintOptions](../../com.aspose.note/printoptions) | ドキュメントを印刷するために使用されるオプションです。null にすることができます。 |
+
+### print(String printerName) {#print-java.lang.String-}
+```
+public void print(String printerName)
+```
+
+
+デフォルトのプリンターを使用してドキュメントを印刷します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| printerName | java.lang.String |  |
+
+### print(AttributeSet printSettings) {#print-javax.print.attribute.AttributeSet-}
+```
+public void print(AttributeSet printSettings)
+```
+
+
+デフォルトのプリンターを使用してドキュメントを印刷します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| printSettings | javax.print.attribute.AttributeSet |  |
+
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+OneNote ドキュメントをストリームに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.OutputStream | ドキュメントが保存される System.iO.stream です。 |
+
+### save(OutputStream stream, SaveOptions options) {#save-java.io.OutputStream-com.aspose.note.SaveOptions-}
+```
+public void save(OutputStream stream, SaveOptions options)
+```
+
+
+指定された保存オプションを使用して OneNote ドキュメントをストリームに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.OutputStream | ドキュメントが保存される System.iO.stream です。 |
+| options | [SaveOptions](../../com.aspose.note/saveoptions) | ストリームにドキュメントが保存される方法のオプションを指定します。 |
+
+### save(OutputStream stream, int format) {#save-java.io.OutputStream-int-}
+```
+public void save(OutputStream stream, int format)
+```
+
+
+指定された形式で OneNote ドキュメントをストリームに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.OutputStream | ドキュメントが保存される System.iO.stream です。 |
+| format | int | ドキュメントを保存する形式です。 |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+OneNote ドキュメントをファイルに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ファイル名 | java.lang.String | ファイルのフルネーム。指定されたフルネームのファイルが既に存在する場合、既存のファイルが上書きされます。 |
+
+### save(String fileName, SaveOptions options) {#save-java.lang.String-com.aspose.note.SaveOptions-}
+```
+public void save(String fileName, SaveOptions options)
+```
+
+
+指定された保存オプションを使用して OneNote ドキュメントをファイルに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ファイル名 | java.lang.String | ファイルのフルネーム。指定されたフルネームのファイルが既に存在する場合、既存のファイルが上書きされます。 |
+| options | [SaveOptions](../../com.aspose.note/saveoptions) | ドキュメントがファイルに保存される方法のオプションを指定します。 |
+
+### save(String fileName, int format) {#save-java.lang.String-int-}
+```
+public void save(String fileName, int format)
+```
+
+
+指定された形式で OneNote ドキュメントをファイルに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ファイル名 | java.lang.String | ファイルのフルネーム。指定されたフルネームのファイルが既に存在する場合、既存のファイルが上書きされます。 |
+| format | int | ドキュメントを保存する形式です。 |
+
+### setAutomaticLayoutChangesDetectionEnabled(boolean value) {#setAutomaticLayoutChangesDetectionEnabled-boolean-}
+```
+public void setAutomaticLayoutChangesDetectionEnabled(boolean value)
+```
+
+
+Aspose.Note がレイアウト変更の検出を自動的に行うかどうかを示す値を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean | 新しい値です。null にすることができます。 |
+
+### setColor(Color value) {#setColor-java.awt.Color-}
+```
+public void setColor(Color value)
+```
+
+
+色を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.awt.Color | Color の値です。 |
+
+### setCreationTime(Date value) {#setCreationTime-java.util.Date-}
+```
+public void setCreationTime(Date value)
+```
+
+
+作成時刻を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Date | DateTime の値です。 |
+
+### setDisplayName(String value) {#setDisplayName-java.lang.String-}
+```
+public void setDisplayName(String value)
+```
+
+
+表示名を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | DateTime の値です。 |
+

--- a/japanese/java/com.aspose.note/documentprintattributeset/_index.md
+++ b/japanese/java/com.aspose.note/documentprintattributeset/_index.md
@@ -1,0 +1,223 @@
+---
+title: "DocumentPrintAttributeSet"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "AttributeSet 用のユーザーフレンドリーなインターフェイスを備えたヘルパークラスを表します。"
+type: docs
+weight: 21
+url: /ja/java/com.aspose.note/documentprintattributeset/
+---
+
+**Inheritance:**
+java.lang.Object, javax.print.attribute.HashAttributeSet
+```
+public final class DocumentPrintAttributeSet extends HashAttributeSet
+```
+
+AttributeSet 用のユーザーフレンドリーなインターフェイスを備えたヘルパークラスを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentPrintAttributeSet(int copies)](#DocumentPrintAttributeSet-int-) | `DocumentPrintAttributeSet` の新しいインスタンスを初期化します。 |
+| [DocumentPrintAttributeSet(String printerName, int copies)](#DocumentPrintAttributeSet-java.lang.String-int-) | `DocumentPrintAttributeSet` の新しいインスタンスを初期化します。 |
+| [DocumentPrintAttributeSet(String printerName)](#DocumentPrintAttributeSet-java.lang.String-) | `DocumentPrintAttributeSet` の新しいインスタンスを初期化します。 |
+| [DocumentPrintAttributeSet()](#DocumentPrintAttributeSet--) | `DocumentPrintAttributeSet` の新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getCopies()](#getCopies--) |  |
+| [getLandscape()](#getLandscape--) |  |
+| [getPrinterName()](#getPrinterName--) |  |
+| [setCollate(boolean value)](#setCollate-boolean-) | 文書が段組みされているかどうかを示す値を設定します。 |
+| [setCopies(int value)](#setCopies-int-) | 印刷する部数を設定します。 |
+| [setDuplex(boolean value)](#setDuplex-boolean-) | 両面印刷のプリンター設定を指定します。 |
+| [setLandscape(boolean value)](#setLandscape-boolean-) | ページの向きを設定します。 |
+| [setPrintRange(int page)](#setPrintRange-int-) | 印刷する単一ページを設定します。 |
+| [setPrintRange(int from, int to)](#setPrintRange-int-int-) | 印刷するページ範囲を設定します。 |
+| [setPrinterName(String printerName)](#setPrinterName-java.lang.String-) | 使用するプリンターの名前です。 |
+| [setPrinterName(String printerName, Locale locale)](#setPrinterName-java.lang.String-java.util.Locale-) | 使用するプリンターの名前です。 |
+### DocumentPrintAttributeSet(int copies) {#DocumentPrintAttributeSet-int-}
+```
+public DocumentPrintAttributeSet(int copies)
+```
+
+
+`DocumentPrintAttributeSet` の新しいインスタンスを初期化します。デフォルトでは文書のすべてのページが印刷されます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 部数 | int | 印刷する文書の部数です。 |
+
+### DocumentPrintAttributeSet(String printerName, int copies) {#DocumentPrintAttributeSet-java.lang.String-int-}
+```
+public DocumentPrintAttributeSet(String printerName, int copies)
+```
+
+
+`DocumentPrintAttributeSet` の新しいインスタンスを初期化します。デフォルトでは文書のすべてのページが印刷されます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| printerName | java.lang.String | プリンターの名前です。 |
+| 部数 | int | 印刷する文書の部数です。 |
+
+### DocumentPrintAttributeSet(String printerName) {#DocumentPrintAttributeSet-java.lang.String-}
+```
+public DocumentPrintAttributeSet(String printerName)
+```
+
+
+`DocumentPrintAttributeSet` の新しいインスタンスを初期化します。デフォルトでは各ページは1部のみです。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| printerName | java.lang.String | プリンターの名前です。 |
+
+### DocumentPrintAttributeSet() {#DocumentPrintAttributeSet--}
+```
+public DocumentPrintAttributeSet()
+```
+
+
+`DocumentPrintAttributeSet` の新しいインスタンスを初期化します。デフォルトでは各ページは1部のみです。
+
+### getCopies() {#getCopies--}
+```
+public int getCopies()
+```
+
+
+
+
+**Returns:**
+int
+### getLandscape() {#getLandscape--}
+```
+public boolean getLandscape()
+```
+
+
+
+
+**Returns:**
+boolean
+### getPrinterName() {#getPrinterName--}
+```
+public String getPrinterName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### setCollate(boolean value) {#setCollate-boolean-}
+```
+public void setCollate(boolean value)
+```
+
+
+文書が段組みされているかどうかを示す値を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean | true は SheetCollate.COLLATED の設定に相当し、false は SheetCollate.UNCOLLATED の設定に相当します。 |
+
+### setCopies(int value) {#setCopies-int-}
+```
+public void setCopies(int value)
+```
+
+
+印刷する部数を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int | 印刷する部数です。 |
+
+### setDuplex(boolean value) {#setDuplex-boolean-}
+```
+public void setDuplex(boolean value)
+```
+
+
+両面印刷のプリンター設定を指定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean | true は Sides.DUPLEX の設定に相当し、false は Sides.ONE\_SIDED の設定に相当します。 |
+
+### setLandscape(boolean value) {#setLandscape-boolean-}
+```
+public void setLandscape(boolean value)
+```
+
+
+ページの向きを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean | true は OrientationRequested.LANDSCAPE の設定に相当し、false は OrientationRequested.PORTRAIT の設定に相当します。 |
+
+### setPrintRange(int page) {#setPrintRange-int-}
+```
+public void setPrintRange(int page)
+```
+
+
+印刷する単一ページを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ページ | int | 印刷するページです。 |
+
+### setPrintRange(int from, int to) {#setPrintRange-int-int-}
+```
+public void setPrintRange(int from, int to)
+```
+
+
+印刷するページ範囲を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| から | int | 最初のページです。 |
+| まで | int | 最後のページ。 |
+
+### setPrinterName(String printerName) {#setPrinterName-java.lang.String-}
+```
+public void setPrinterName(String printerName)
+```
+
+
+使用するプリンターの名前です。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| printerName | java.lang.String | プリンターの名前です。 |
+
+### setPrinterName(String printerName, Locale locale) {#setPrinterName-java.lang.String-java.util.Locale-}
+```
+public void setPrinterName(String printerName, Locale locale)
+```
+
+
+使用するプリンターの名前です。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| printerName | java.lang.String | プリンターの名前です。 |
+| ロケール | java.util.Locale | printerName のロケール。 |
+

--- a/japanese/java/com.aspose.note/documentvisitor/_index.md
+++ b/japanese/java/com.aspose.note/documentvisitor/_index.md
@@ -1,0 +1,479 @@
+---
+title: "DocumentVisitor"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "指定されたノードをルートとするサブツリーを反復処理するための抽象クラスです。"
+type: docs
+weight: 22
+url: /ja/java/com.aspose.note/documentvisitor/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class DocumentVisitor
+```
+
+指定されたノードをルートとするサブツリーを反復処理するための抽象クラスです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentVisitor()](#DocumentVisitor--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [visitAttachedFileEnd(AttachedFile attachedFile)](#visitAttachedFileEnd-com.aspose.note.AttachedFile-) | `AttachedFile` ノードの訪問を終了します。 |
+| [visitAttachedFileStart(AttachedFile attachedFile)](#visitAttachedFileStart-com.aspose.note.AttachedFile-) | `AttachedFile` ノードの訪問を開始します。 |
+| [visitDocumentEnd(Document document)](#visitDocumentEnd-com.aspose.note.Document-) | `Document` ノードの訪問を終了します。 |
+| [visitDocumentStart(Document document)](#visitDocumentStart-com.aspose.note.Document-) | `Document` ノードの訪問を開始します。 |
+| [visitImageEnd(Image image)](#visitImageEnd-com.aspose.note.Image-) | `Image` ノードの訪問を終了します。 |
+| [visitImageStart(Image image)](#visitImageStart-com.aspose.note.Image-) | `Image` ノードの訪問を開始します。 |
+| [visitInkDrawingEnd(InkDrawing inkDrawing)](#visitInkDrawingEnd-com.aspose.note.InkDrawing-) | [InkDrawing](../../com.aspose.note/inkdrawing) ノードの訪問を終了します。 |
+| [visitInkDrawingStart(InkDrawing inkDrawing)](#visitInkDrawingStart-com.aspose.note.InkDrawing-) | [InkDrawing](../../com.aspose.note/inkdrawing) ノードの訪問を開始します。 |
+| [visitInkParagraphEnd(InkParagraph inkParagraph)](#visitInkParagraphEnd-com.aspose.note.InkParagraph-) | [InkParagraph](../../com.aspose.note/inkparagraph) ノードの訪問を終了します。 |
+| [visitInkParagraphStart(InkParagraph inkParagraph)](#visitInkParagraphStart-com.aspose.note.InkParagraph-) | [InkParagraph](../../com.aspose.note/inkparagraph) ノードの訪問を開始します。 |
+| [visitInkWordEnd(InkWord inkWord)](#visitInkWordEnd-com.aspose.note.InkWord-) | [InkWord](../../com.aspose.note/inkword) ノードの訪問を終了します。 |
+| [visitInkWordStart(InkWord inkWord)](#visitInkWordStart-com.aspose.note.InkWord-) | [InkWord](../../com.aspose.note/inkword) ノードの訪問を開始します。 |
+| [visitLoopEnd(Loop loop)](#visitLoopEnd-com.aspose.note.Loop-) | [Loop](../../com.aspose.note/loop) ノードの訪問を終了します。 |
+| [visitLoopStart(Loop loop)](#visitLoopStart-com.aspose.note.Loop-) | [Loop](../../com.aspose.note/loop) ノードの訪問を開始します。 |
+| [visitOutlineElementEnd(OutlineElement outlineElement)](#visitOutlineElementEnd-com.aspose.note.OutlineElement-) | `OutlineElement` ノードの訪問を終了します。 |
+| [visitOutlineElementStart(OutlineElement outlineElement)](#visitOutlineElementStart-com.aspose.note.OutlineElement-) | `OutlineElement` ノードの訪問を開始します。 |
+| [visitOutlineEnd(Outline outline)](#visitOutlineEnd-com.aspose.note.Outline-) | `Outline` ノードの訪問を終了します。 |
+| [visitOutlineGroupEnd(OutlineGroup outlineGroup)](#visitOutlineGroupEnd-com.aspose.note.OutlineGroup-) | `OutlineGroup` ノードの訪問を終了します。 |
+| [visitOutlineGroupStart(OutlineGroup outlineGroup)](#visitOutlineGroupStart-com.aspose.note.OutlineGroup-) | `OutlineGroup` ノードの訪問を開始します。 |
+| [visitOutlineStart(Outline outline)](#visitOutlineStart-com.aspose.note.Outline-) | `Outline` ノードの訪問を開始します。 |
+| [visitPageEnd(Page page)](#visitPageEnd-com.aspose.note.Page-) | `Page` ノードの訪問を終了します。 |
+| [visitPageStart(Page page)](#visitPageStart-com.aspose.note.Page-) | `Page` ノードの訪問を開始します。 |
+| [visitRichTextEnd(RichText richText)](#visitRichTextEnd-com.aspose.note.RichText-) | `RichText` ノードの訪問を終了します。 |
+| [visitRichTextStart(RichText richText)](#visitRichTextStart-com.aspose.note.RichText-) | `RichText` ノードの訪問を開始します。 |
+| [visitTableCellEnd(TableCell tableCell)](#visitTableCellEnd-com.aspose.note.TableCell-) | `TableCell` ノードの訪問を終了します。 |
+| [visitTableCellStart(TableCell tableCell)](#visitTableCellStart-com.aspose.note.TableCell-) | `TableCell` ノードの訪問を開始します。 |
+| [visitTableEnd(Table table)](#visitTableEnd-com.aspose.note.Table-) | `Table` ノードの訪問を終了します。 |
+| [visitTableRowEnd(TableRow tableRow)](#visitTableRowEnd-com.aspose.note.TableRow-) | `TableRow` ノードの訪問を終了します。 |
+| [visitTableRowStart(TableRow tableRow)](#visitTableRowStart-com.aspose.note.TableRow-) | `TableRow` ノードの訪問を開始します。 |
+| [visitTableStart(Table table)](#visitTableStart-com.aspose.note.Table-) | `Table` ノードの訪問を開始します。 |
+| [visitTitleEnd(Title title)](#visitTitleEnd-com.aspose.note.Title-) | `Title` ノードの訪問を終了します。 |
+| [visitTitleStart(Title title)](#visitTitleStart-com.aspose.note.Title-) | `Title` ノードの訪問を開始します。 |
+### DocumentVisitor() {#DocumentVisitor--}
+```
+public DocumentVisitor()
+```
+
+
+### visitAttachedFileEnd(AttachedFile attachedFile) {#visitAttachedFileEnd-com.aspose.note.AttachedFile-}
+```
+public void visitAttachedFileEnd(AttachedFile attachedFile)
+```
+
+
+`AttachedFile` ノードの訪問を終了します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| attachedFile | [AttachedFile](../../com.aspose.note/attachedfile) | `AttachedFile` ノードです。 |
+
+### visitAttachedFileStart(AttachedFile attachedFile) {#visitAttachedFileStart-com.aspose.note.AttachedFile-}
+```
+public void visitAttachedFileStart(AttachedFile attachedFile)
+```
+
+
+`AttachedFile` ノードの訪問を開始します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| attachedFile | [AttachedFile](../../com.aspose.note/attachedfile) | `AttachedFile` ノードです。 |
+
+### visitDocumentEnd(Document document) {#visitDocumentEnd-com.aspose.note.Document-}
+```
+public void visitDocumentEnd(Document document)
+```
+
+
+`Document` ノードの訪問を終了します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| document | [Document](../../com.aspose.note/document) | `Document` ノードです。 |
+
+### visitDocumentStart(Document document) {#visitDocumentStart-com.aspose.note.Document-}
+```
+public void visitDocumentStart(Document document)
+```
+
+
+`Document` ノードの訪問を開始します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| document | [Document](../../com.aspose.note/document) | `Document` ノードです。 |
+
+### visitImageEnd(Image image) {#visitImageEnd-com.aspose.note.Image-}
+```
+public void visitImageEnd(Image image)
+```
+
+
+`Image` ノードの訪問を終了します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| image | [Image](../../com.aspose.note/image) | `Image` ノードです。 |
+
+### visitImageStart(Image image) {#visitImageStart-com.aspose.note.Image-}
+```
+public void visitImageStart(Image image)
+```
+
+
+`Image` ノードの訪問を開始します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| image | [Image](../../com.aspose.note/image) | `Image` ノードです。 |
+
+### visitInkDrawingEnd(InkDrawing inkDrawing) {#visitInkDrawingEnd-com.aspose.note.InkDrawing-}
+```
+public void visitInkDrawingEnd(InkDrawing inkDrawing)
+```
+
+
+[InkDrawing](../../com.aspose.note/inkdrawing) ノードの訪問を終了します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| inkDrawing | [InkDrawing](../../com.aspose.note/inkdrawing) | この [InkDrawing](../../com.aspose.note/inkdrawing) ノードです。 |
+
+### visitInkDrawingStart(InkDrawing inkDrawing) {#visitInkDrawingStart-com.aspose.note.InkDrawing-}
+```
+public void visitInkDrawingStart(InkDrawing inkDrawing)
+```
+
+
+[InkDrawing](../../com.aspose.note/inkdrawing) ノードの訪問を開始します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| inkDrawing | [InkDrawing](../../com.aspose.note/inkdrawing) | この [InkDrawing](../../com.aspose.note/inkdrawing) ノードです。 |
+
+### visitInkParagraphEnd(InkParagraph inkParagraph) {#visitInkParagraphEnd-com.aspose.note.InkParagraph-}
+```
+public void visitInkParagraphEnd(InkParagraph inkParagraph)
+```
+
+
+[InkParagraph](../../com.aspose.note/inkparagraph) ノードの訪問を終了します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| inkParagraph | [InkParagraph](../../com.aspose.note/inkparagraph) | この [InkParagraph](../../com.aspose.note/inkparagraph) ノードです。 |
+
+### visitInkParagraphStart(InkParagraph inkParagraph) {#visitInkParagraphStart-com.aspose.note.InkParagraph-}
+```
+public void visitInkParagraphStart(InkParagraph inkParagraph)
+```
+
+
+[InkParagraph](../../com.aspose.note/inkparagraph) ノードの訪問を開始します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| inkParagraph | [InkParagraph](../../com.aspose.note/inkparagraph) | この [InkParagraph](../../com.aspose.note/inkparagraph) ノードです。 |
+
+### visitInkWordEnd(InkWord inkWord) {#visitInkWordEnd-com.aspose.note.InkWord-}
+```
+public void visitInkWordEnd(InkWord inkWord)
+```
+
+
+[InkWord](../../com.aspose.note/inkword) ノードの訪問を終了します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| inkWord | [InkWord](../../com.aspose.note/inkword) | この [InkWord](../../com.aspose.note/inkword) ノードです。 |
+
+### visitInkWordStart(InkWord inkWord) {#visitInkWordStart-com.aspose.note.InkWord-}
+```
+public void visitInkWordStart(InkWord inkWord)
+```
+
+
+[InkWord](../../com.aspose.note/inkword) ノードの訪問を開始します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| inkWord | [InkWord](../../com.aspose.note/inkword) | この [InkWord](../../com.aspose.note/inkword) ノードです。 |
+
+### visitLoopEnd(Loop loop) {#visitLoopEnd-com.aspose.note.Loop-}
+```
+public void visitLoopEnd(Loop loop)
+```
+
+
+[Loop](../../com.aspose.note/loop) ノードの訪問を終了します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| loop | [Loop](../../com.aspose.note/loop) | この [Loop](../../com.aspose.note/loop) ノードです。 |
+
+### visitLoopStart(Loop loop) {#visitLoopStart-com.aspose.note.Loop-}
+```
+public void visitLoopStart(Loop loop)
+```
+
+
+[Loop](../../com.aspose.note/loop) ノードの訪問を開始します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| loop | [Loop](../../com.aspose.note/loop) | この [Loop](../../com.aspose.note/loop) ノードです。 |
+
+### visitOutlineElementEnd(OutlineElement outlineElement) {#visitOutlineElementEnd-com.aspose.note.OutlineElement-}
+```
+public void visitOutlineElementEnd(OutlineElement outlineElement)
+```
+
+
+`OutlineElement` ノードの訪問を終了します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| outlineElement | [OutlineElement](../../com.aspose.note/outlineelement) | `OutlineElement` ノードです。 |
+
+### visitOutlineElementStart(OutlineElement outlineElement) {#visitOutlineElementStart-com.aspose.note.OutlineElement-}
+```
+public void visitOutlineElementStart(OutlineElement outlineElement)
+```
+
+
+`OutlineElement` ノードの訪問を開始します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| outlineElement | [OutlineElement](../../com.aspose.note/outlineelement) | `OutlineElement` ノードです。 |
+
+### visitOutlineEnd(Outline outline) {#visitOutlineEnd-com.aspose.note.Outline-}
+```
+public void visitOutlineEnd(Outline outline)
+```
+
+
+`Outline` ノードの訪問を終了します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| outline | [Outline](../../com.aspose.note/outline) | `Outline` ノードです。 |
+
+### visitOutlineGroupEnd(OutlineGroup outlineGroup) {#visitOutlineGroupEnd-com.aspose.note.OutlineGroup-}
+```
+public void visitOutlineGroupEnd(OutlineGroup outlineGroup)
+```
+
+
+`OutlineGroup` ノードの訪問を終了します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| outlineGroup | [OutlineGroup](../../com.aspose.note/outlinegroup) | `OutlineGroup` ノードです。 |
+
+### visitOutlineGroupStart(OutlineGroup outlineGroup) {#visitOutlineGroupStart-com.aspose.note.OutlineGroup-}
+```
+public void visitOutlineGroupStart(OutlineGroup outlineGroup)
+```
+
+
+`OutlineGroup` ノードの訪問を開始します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| outlineGroup | [OutlineGroup](../../com.aspose.note/outlinegroup) | `OutlineGroup` ノードです。 |
+
+### visitOutlineStart(Outline outline) {#visitOutlineStart-com.aspose.note.Outline-}
+```
+public void visitOutlineStart(Outline outline)
+```
+
+
+`Outline` ノードの訪問を開始します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| outline | [Outline](../../com.aspose.note/outline) | `Outline` ノードです。 |
+
+### visitPageEnd(Page page) {#visitPageEnd-com.aspose.note.Page-}
+```
+public void visitPageEnd(Page page)
+```
+
+
+`Page` ノードの訪問を終了します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.note/page) | `Page` ノードです。 |
+
+### visitPageStart(Page page) {#visitPageStart-com.aspose.note.Page-}
+```
+public void visitPageStart(Page page)
+```
+
+
+`Page` ノードの訪問を開始します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.note/page) | `Page` ノードです。 |
+
+### visitRichTextEnd(RichText richText) {#visitRichTextEnd-com.aspose.note.RichText-}
+```
+public void visitRichTextEnd(RichText richText)
+```
+
+
+`RichText` ノードの訪問を終了します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| richText | [RichText](../../com.aspose.note/richtext) | `RichText` ノードです。 |
+
+### visitRichTextStart(RichText richText) {#visitRichTextStart-com.aspose.note.RichText-}
+```
+public void visitRichTextStart(RichText richText)
+```
+
+
+`RichText` ノードの訪問を開始します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| richText | [RichText](../../com.aspose.note/richtext) | `RichText` ノードです。 |
+
+### visitTableCellEnd(TableCell tableCell) {#visitTableCellEnd-com.aspose.note.TableCell-}
+```
+public void visitTableCellEnd(TableCell tableCell)
+```
+
+
+`TableCell` ノードの訪問を終了します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| tableCell | [TableCell](../../com.aspose.note/tablecell) | `TableCell` ノードです。 |
+
+### visitTableCellStart(TableCell tableCell) {#visitTableCellStart-com.aspose.note.TableCell-}
+```
+public void visitTableCellStart(TableCell tableCell)
+```
+
+
+`TableCell` ノードの訪問を開始します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| tableCell | [TableCell](../../com.aspose.note/tablecell) | `TableCell` ノードです。 |
+
+### visitTableEnd(Table table) {#visitTableEnd-com.aspose.note.Table-}
+```
+public void visitTableEnd(Table table)
+```
+
+
+`Table` ノードの訪問を終了します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| table | [Table](../../com.aspose.note/table) | `Table` ノードです。 |
+
+### visitTableRowEnd(TableRow tableRow) {#visitTableRowEnd-com.aspose.note.TableRow-}
+```
+public void visitTableRowEnd(TableRow tableRow)
+```
+
+
+`TableRow` ノードの訪問を終了します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| tableRow | [TableRow](../../com.aspose.note/tablerow) | `TableRow` ノードです。 |
+
+### visitTableRowStart(TableRow tableRow) {#visitTableRowStart-com.aspose.note.TableRow-}
+```
+public void visitTableRowStart(TableRow tableRow)
+```
+
+
+`TableRow` ノードの訪問を開始します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| tableRow | [TableRow](../../com.aspose.note/tablerow) | `TableRow` ノードです。 |
+
+### visitTableStart(Table table) {#visitTableStart-com.aspose.note.Table-}
+```
+public void visitTableStart(Table table)
+```
+
+
+`Table` ノードの訪問を開始します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| table | [Table](../../com.aspose.note/table) | `Table` ノードです。 |
+
+### visitTitleEnd(Title title) {#visitTitleEnd-com.aspose.note.Title-}
+```
+public void visitTitleEnd(Title title)
+```
+
+
+`Title` ノードの訪問を終了します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| title | [Title](../../com.aspose.note/title) | `Title` ノードです。 |
+
+### visitTitleStart(Title title) {#visitTitleStart-com.aspose.note.Title-}
+```
+public void visitTitleStart(Title title)
+```
+
+
+`Title` ノードの訪問を開始します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| title | [Title](../../com.aspose.note/title) | `Title` ノードです。 |
+

--- a/japanese/java/com.aspose.note/extendedapsdocument/_index.md
+++ b/japanese/java/com.aspose.note/extendedapsdocument/_index.md
@@ -1,0 +1,97 @@
+---
+title: "ExtendedApsDocument"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ページから構成されページセットに変換された、完全なワンノートドキュメントを表します。"
+type: docs
+weight: 23
+url: /ja/java/com.aspose.note/extendedapsdocument/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.foundation.rendering.ApsNode
+
+**All Implemented Interfaces:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerable
+```
+public class ExtendedApsDocument extends ApsNode implements System.Collections.Generic.IGenericEnumerable<ApsPage>
+```
+
+ページをページセットに変換して構成された完全な OneNote ドキュメントを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ExtendedApsDocument()](#ExtendedApsDocument--) | 新しい `ExtendedApsDocument` クラスのインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [accept(ApsDocumentVisitor visitor)](#accept-com.aspose.foundation.rendering.ApsDocumentVisitor-) | この要素に ApsDocumentVisitor を受け入れます。 |
+| [addPage(ApsPage page)](#addPage-com.aspose.foundation.rendering.ApsPage-) | ドキュメントにページセットを追加します。 |
+| [getPageList()](#getPageList--) | ページセットのリストを取得します。 |
+| [iterator()](#iterator--) | 列挙子を返します。 |
+| [iterator_Rename_Namesake()](#iterator-Rename-Namesake--) |  |
+### ExtendedApsDocument() {#ExtendedApsDocument--}
+```
+public ExtendedApsDocument()
+```
+
+
+新しい `ExtendedApsDocument` クラスのインスタンスを初期化します。
+
+### accept(ApsDocumentVisitor visitor) {#accept-com.aspose.foundation.rendering.ApsDocumentVisitor-}
+```
+public void accept(ApsDocumentVisitor visitor)
+```
+
+
+この要素に ApsDocumentVisitor を受け入れます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ビジター | com.aspose.foundation.rendering.ApsDocumentVisitor | ビジターです。 |
+
+### addPage(ApsPage page) {#addPage-com.aspose.foundation.rendering.ApsPage-}
+```
+public void addPage(ApsPage page)
+```
+
+
+ドキュメントにページセットを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ページ | com.aspose.foundation.rendering.ApsPage | ページセットです。 |
+
+### getPageList() {#getPageList--}
+```
+public System.Collections.Generic.List<ApsPage> getPageList()
+```
+
+
+ページセットのリストを取得します。
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List&lt;com.aspose.foundation.rendering.ApsPage&gt;
+### iterator() {#iterator--}
+```
+public System.Collections.Generic.IGenericEnumerator<ApsPage> iterator()
+```
+
+
+列挙子を返します。
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;com.aspose.foundation.rendering.ApsPage&gt;
+### iterator_Rename_Namesake() {#iterator-Rename-Namesake--}
+```
+public System.Collections.IEnumerator iterator_Rename_Namesake()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Collections.IEnumerator

--- a/japanese/java/com.aspose.note/extendedapsglyphs/_index.md
+++ b/japanese/java/com.aspose.note/extendedapsglyphs/_index.md
@@ -1,0 +1,135 @@
+---
+title: "ExtendedApsGlyphs"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "標準の ApsGlyphs のラッパーを表し、描画動作のいくつかを拡張します。"
+type: docs
+weight: 24
+url: /ja/java/com.aspose.note/extendedapsglyphs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ExtendedApsNode](../../com.aspose.note/extendedapsnode)
+```
+public class ExtendedApsGlyphs extends ExtendedApsNode
+```
+
+標準 ApsGlyphs のラッパーを表し、描画動作の一部を拡張します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ExtendedApsGlyphs(ApsGlyphs internalGlyphs)](#ExtendedApsGlyphs-com.aspose.foundation.rendering.ApsGlyphs-) | `ExtendedApsGlyphs` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addToCompositeNode(ApsCompositeNode compositeNode)](#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-) | このノードを指定された `compositeNode` に追加します。 |
+| [applyPlaneTransform(System.Drawing.PointF transformVector)](#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-) | 平面変換を適用し、ノードを x および y 平面で移動させます。 |
+| [applyScaleTransform(float scaleTransform)](#applyScaleTransform-float-) | グリフにスケーリングを適用します。 |
+| [getBottom()](#getBottom--) | グリフの下端を取得します。 |
+| [getCopy()](#getCopy--) | グリフのコピーを取得します。 |
+| [getOrigin()](#getOrigin--) | 原点を取得します。 |
+| [getSize()](#getSize--) | サイズを取得します。 |
+| [getTop()](#getTop--) | 上端を取得します。 |
+### ExtendedApsGlyphs(ApsGlyphs internalGlyphs) {#ExtendedApsGlyphs-com.aspose.foundation.rendering.ApsGlyphs-}
+```
+public ExtendedApsGlyphs(ApsGlyphs internalGlyphs)
+```
+
+
+`ExtendedApsGlyphs` クラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| internalGlyphs | com.aspose.foundation.rendering.ApsGlyphs | 元の aps グリフ。 |
+
+### addToCompositeNode(ApsCompositeNode compositeNode) {#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-}
+```
+public void addToCompositeNode(ApsCompositeNode compositeNode)
+```
+
+
+このノードを指定された `compositeNode` に追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| compositeNode | com.aspose.foundation.rendering.ApsCompositeNode |  |
+
+### applyPlaneTransform(System.Drawing.PointF transformVector) {#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-}
+```
+public void applyPlaneTransform(System.Drawing.PointF transformVector)
+```
+
+
+平面変換を適用し、ノードを x および y 平面で移動させます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| transformVector | com.aspose.ms.System.Drawing.PointF |  |
+
+### applyScaleTransform(float scaleTransform) {#applyScaleTransform-float-}
+```
+public void applyScaleTransform(float scaleTransform)
+```
+
+
+グリフにスケーリングを適用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| scaleTransform | float | 変換のスケール係数です。 |
+
+### getBottom() {#getBottom--}
+```
+public float getBottom()
+```
+
+
+グリフの下端を取得します。
+
+**Returns:**
+float
+### getCopy() {#getCopy--}
+```
+public ExtendedApsNode getCopy()
+```
+
+
+グリフのコピーを取得します。
+
+**Returns:**
+[ExtendedApsNode](../../com.aspose.note/extendedapsnode) - The `IExtendedApsNode`.
+### getOrigin() {#getOrigin--}
+```
+public System.Drawing.PointF getOrigin()
+```
+
+
+原点を取得します。
+
+**Returns:**
+com.aspose.ms.System.Drawing.PointF
+### getSize() {#getSize--}
+```
+public System.Drawing.SizeF getSize()
+```
+
+
+サイズを取得します。
+
+**Returns:**
+com.aspose.ms.System.Drawing.SizeF
+### getTop() {#getTop--}
+```
+public float getTop()
+```
+
+
+上端を取得します。
+
+**Returns:**
+float

--- a/japanese/java/com.aspose.note/extendedapsimage/_index.md
+++ b/japanese/java/com.aspose.note/extendedapsimage/_index.md
@@ -1,0 +1,146 @@
+---
+title: "ExtendedApsImage"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "標準の ApsImage のラッパーを表し、描画動作の一部を拡張します。"
+type: docs
+weight: 25
+url: /ja/java/com.aspose.note/extendedapsimage/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ExtendedApsNode](../../com.aspose.note/extendedapsnode)
+```
+public class ExtendedApsImage extends ExtendedApsNode
+```
+
+標準 ApsImage のラッパーを表し、描画動作の一部を拡張します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ExtendedApsImage(ApsImage internalImage)](#ExtendedApsImage-com.aspose.foundation.rendering.ApsImage-) | `ExtendedApsImage` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addToCompositeNode(ApsCompositeNode compositeNode)](#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-) | このノードを指定された `compositeNode` に追加します。 |
+| [applyPlaneTransform(System.Drawing.PointF transformVector)](#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-) | 平面変換を適用し、ノードを x および y 平面で移動させます。 |
+| [applyScaleTransform(float scaleTransform)](#applyScaleTransform-float-) | 画像にスケーリングを適用します。 |
+| [getBottom()](#getBottom--) | 下端を取得します。 |
+| [getCopy()](#getCopy--) | このノードの完全なコピーを作成します。 |
+| [getOrigin()](#getOrigin--) | 原点を取得します。 |
+| [getSize()](#getSize--) | サイズを取得します。 |
+| [getTop()](#getTop--) | 上端を取得します。 |
+| [isBackground()](#isBackground--) | 画像が背景画像かどうかを取得します。 |
+### ExtendedApsImage(ApsImage internalImage) {#ExtendedApsImage-com.aspose.foundation.rendering.ApsImage-}
+```
+public ExtendedApsImage(ApsImage internalImage)
+```
+
+
+`ExtendedApsImage` クラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| internalImage | com.aspose.foundation.rendering.ApsImage | 画像。 |
+
+### addToCompositeNode(ApsCompositeNode compositeNode) {#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-}
+```
+public void addToCompositeNode(ApsCompositeNode compositeNode)
+```
+
+
+このノードを指定された `compositeNode` に追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| compositeNode | com.aspose.foundation.rendering.ApsCompositeNode |  |
+
+### applyPlaneTransform(System.Drawing.PointF transformVector) {#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-}
+```
+public void applyPlaneTransform(System.Drawing.PointF transformVector)
+```
+
+
+平面変換を適用し、ノードを x および y 平面で移動させます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| transformVector | com.aspose.ms.System.Drawing.PointF |  |
+
+### applyScaleTransform(float scaleTransform) {#applyScaleTransform-float-}
+```
+public void applyScaleTransform(float scaleTransform)
+```
+
+
+画像にスケーリングを適用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| scaleTransform | float | 変換のスケール係数です。 |
+
+### getBottom() {#getBottom--}
+```
+public float getBottom()
+```
+
+
+下端を取得します。
+
+**Returns:**
+float
+### getCopy() {#getCopy--}
+```
+public ExtendedApsNode getCopy()
+```
+
+
+このノードの完全なコピーを作成します。
+
+**Returns:**
+[ExtendedApsNode](../../com.aspose.note/extendedapsnode) - The `IExtendedApsNode`.
+### getOrigin() {#getOrigin--}
+```
+public System.Drawing.PointF getOrigin()
+```
+
+
+原点を取得します。
+
+**Returns:**
+com.aspose.ms.System.Drawing.PointF
+### getSize() {#getSize--}
+```
+public System.Drawing.SizeF getSize()
+```
+
+
+サイズを取得します。
+
+**Returns:**
+com.aspose.ms.System.Drawing.SizeF
+### getTop() {#getTop--}
+```
+public float getTop()
+```
+
+
+上端を取得します。
+
+**Returns:**
+float
+### isBackground() {#isBackground--}
+```
+public final boolean isBackground()
+```
+
+
+画像が背景画像かどうかを取得します。
+
+**Returns:**
+boolean

--- a/japanese/java/com.aspose.note/extendedapsnode/_index.md
+++ b/japanese/java/com.aspose.note/extendedapsnode/_index.md
@@ -1,0 +1,158 @@
+---
+title: "ExtendedApsNode"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "標準的な ApsNode のラッパーを表し、描画動作の一部を拡張します。"
+type: docs
+weight: 26
+url: /ja/java/com.aspose.note/extendedapsnode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class ExtendedApsNode
+```
+
+標準 ApsNode のラッパーを表し、描画動作の一部を拡張します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ExtendedApsNode()](#ExtendedApsNode--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addToCompositeNode(ApsCompositeNode compositeNode)](#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-) | このノードを指定された `compositeNode` に追加します。 |
+| [applyPlaneTransform(System.Drawing.PointF transformVector)](#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-) | 平面変換を適用し、ノードを x および y 平面で移動させます。 |
+| [applyScaleTransform(float scaleTransform)](#applyScaleTransform-float-) | ノードにスケーリングを適用します。 |
+| [copyAttributes(ApsNode src, ApsNode dst)](#copyAttributes-com.aspose.foundation.rendering.ApsNode-com.aspose.foundation.rendering.ApsNode-) |  |
+| [copyAttributes(ApsNodeAttributes src, ApsNodeAttributes dst)](#copyAttributes-com.aspose.foundation.rendering.ApsNodeAttributes-com.aspose.foundation.rendering.ApsNodeAttributes-) |  |
+| [getBottom()](#getBottom--) | ノードの底部の y 座標を取得または設定します。 |
+| [getCopy()](#getCopy--) | このノードの完全なコピーを作成します。 |
+| [getOrigin()](#getOrigin--) | ノードの原点を取得または設定します。 |
+| [getSize()](#getSize--) | ノードのサイズを取得または設定します。 |
+| [getTop()](#getTop--) | ノードの上部の y 座標を取得または設定します。 |
+### ExtendedApsNode() {#ExtendedApsNode--}
+```
+public ExtendedApsNode()
+```
+
+
+### addToCompositeNode(ApsCompositeNode compositeNode) {#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-}
+```
+public abstract void addToCompositeNode(ApsCompositeNode compositeNode)
+```
+
+
+このノードを指定された `compositeNode` に追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| compositeNode | com.aspose.foundation.rendering.ApsCompositeNode |  |
+
+### applyPlaneTransform(System.Drawing.PointF transformVector) {#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-}
+```
+public abstract void applyPlaneTransform(System.Drawing.PointF transformVector)
+```
+
+
+平面変換を適用し、ノードを x および y 平面で移動させます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| transformVector | com.aspose.ms.System.Drawing.PointF |  |
+
+### applyScaleTransform(float scaleTransform) {#applyScaleTransform-float-}
+```
+public abstract void applyScaleTransform(float scaleTransform)
+```
+
+
+ノードにスケーリングを適用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| scaleTransform | float | 変換のスケール係数です。 |
+
+### copyAttributes(ApsNode src, ApsNode dst) {#copyAttributes-com.aspose.foundation.rendering.ApsNode-com.aspose.foundation.rendering.ApsNode-}
+```
+public static void copyAttributes(ApsNode src, ApsNode dst)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| src | com.aspose.foundation.rendering.ApsNode |  |
+| dst | com.aspose.foundation.rendering.ApsNode |  |
+
+### copyAttributes(ApsNodeAttributes src, ApsNodeAttributes dst) {#copyAttributes-com.aspose.foundation.rendering.ApsNodeAttributes-com.aspose.foundation.rendering.ApsNodeAttributes-}
+```
+public static void copyAttributes(ApsNodeAttributes src, ApsNodeAttributes dst)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| src | com.aspose.foundation.rendering.ApsNodeAttributes |  |
+| dst | com.aspose.foundation.rendering.ApsNodeAttributes |  |
+
+### getBottom() {#getBottom--}
+```
+public float getBottom()
+```
+
+
+ノードの底部の y 座標を取得または設定します。
+
+**Returns:**
+float
+### getCopy() {#getCopy--}
+```
+public abstract ExtendedApsNode getCopy()
+```
+
+
+このノードの完全なコピーを作成します。
+
+**Returns:**
+[ExtendedApsNode](../../com.aspose.note/extendedapsnode) - The `!:ExtendedApsNode`.
+### getOrigin() {#getOrigin--}
+```
+public System.Drawing.PointF getOrigin()
+```
+
+
+ノードの原点を取得または設定します。
+
+**Returns:**
+com.aspose.ms.System.Drawing.PointF
+### getSize() {#getSize--}
+```
+public System.Drawing.SizeF getSize()
+```
+
+
+ノードのサイズを取得または設定します。
+
+**Returns:**
+com.aspose.ms.System.Drawing.SizeF
+### getTop() {#getTop--}
+```
+public float getTop()
+```
+
+
+ノードの上部の y 座標を取得または設定します。
+
+**Returns:**
+float

--- a/japanese/java/com.aspose.note/extendedapspage/_index.md
+++ b/japanese/java/com.aspose.note/extendedapspage/_index.md
@@ -1,0 +1,120 @@
+---
+title: "ExtendedApsPage"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "標準の ApsGlyphs のラッパーを表し、描画動作の一部を拡張します。"
+type: docs
+weight: 27
+url: /ja/java/com.aspose.note/extendedapspage/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.foundation.rendering.ApsNode, com.aspose.foundation.rendering.ApsCompositeNode, com.aspose.foundation.rendering.ApsPage
+
+**All Implemented Interfaces:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerable
+```
+public class ExtendedApsPage extends ApsPage implements System.Collections.Generic.IGenericEnumerable<ApsNode>
+```
+
+標準 ApsGlyphs のラッパーを表し、描画動作の一部を拡張します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ExtendedApsPage(System.Drawing.SizeF pageSize, float pageStartInNotePage, Margin margin)](#ExtendedApsPage-com.aspose.ms.System.Drawing.SizeF-float-com.aspose.foundation.layout.Margin-) | `ExtendedApsPage` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getContentSize()](#getContentSize--) | 余白を除いたページサイズを取得します。 |
+| [getMargin()](#getMargin--) | このページの余白を取得します。 |
+| [getPageEndInNotePage()](#getPageEndInNotePage--) | MS OneNote ページが複数の aps ページに分割される場合、MS OneNote ページ内でのページ末端の位置を取得します。 |
+| [getPageSize()](#getPageSize--) | 最終的なページサイズを取得します。 |
+| [getPageStartInNotePage()](#getPageStartInNotePage--) | MS OneNote ページが複数の aps ページに分割される場合、MS OneNote ページ内でのページ開始位置を取得します。 |
+| [iterator()](#iterator--) | このページのすべてのノードを反復処理する列挙子を返します。 |
+| [iterator_Rename_Namesake()](#iterator-Rename-Namesake--) | 取得列挙子です。 |
+### ExtendedApsPage(System.Drawing.SizeF pageSize, float pageStartInNotePage, Margin margin) {#ExtendedApsPage-com.aspose.ms.System.Drawing.SizeF-float-com.aspose.foundation.layout.Margin-}
+```
+public ExtendedApsPage(System.Drawing.SizeF pageSize, float pageStartInNotePage, Margin margin)
+```
+
+
+`ExtendedApsPage` クラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| pageSize | com.aspose.ms.System.Drawing.SizeF | ページサイズです。 |
+| pageStartInNotePage | float | 元の MS OneNote ページでのページ開始位置です。 |
+| margin | com.aspose.foundation.layout.Margin | 拡張されたページ余白。 |
+
+### getContentSize() {#getContentSize--}
+```
+public System.Drawing.SizeF getContentSize()
+```
+
+
+余白を除いたページサイズを取得します。
+
+**Returns:**
+com.aspose.ms.System.Drawing.SizeF
+### getMargin() {#getMargin--}
+```
+public Margin getMargin()
+```
+
+
+このページの余白を取得します。
+
+**Returns:**
+com.aspose.foundation.layout.Margin
+### getPageEndInNotePage() {#getPageEndInNotePage--}
+```
+public float getPageEndInNotePage()
+```
+
+
+MS OneNote ページが複数の aps ページに分割される場合、MS OneNote ページ内でのページ末端の位置を取得します。
+
+**Returns:**
+float
+### getPageSize() {#getPageSize--}
+```
+public System.Drawing.SizeF getPageSize()
+```
+
+
+最終的なページサイズを取得します。
+
+**Returns:**
+com.aspose.ms.System.Drawing.SizeF
+### getPageStartInNotePage() {#getPageStartInNotePage--}
+```
+public float getPageStartInNotePage()
+```
+
+
+MS OneNote ページが複数の aps ページに分割される場合、MS OneNote ページ内でのページ開始位置を取得します。
+
+**Returns:**
+float
+### iterator() {#iterator--}
+```
+public System.Collections.Generic.IGenericEnumerator<ApsNode> iterator()
+```
+
+
+このページのすべてのノードを反復処理する列挙子を返します。
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;com.aspose.foundation.rendering.ApsNode&gt; - この `IEnumerator`。
+### iterator_Rename_Namesake() {#iterator-Rename-Namesake--}
+```
+public System.Collections.IEnumerator iterator_Rename_Namesake()
+```
+
+
+取得列挙子です。
+
+**Returns:**
+com.aspose.ms.System.Collections.IEnumerator - この `IEnumerator`。

--- a/japanese/java/com.aspose.note/extendedapspath/_index.md
+++ b/japanese/java/com.aspose.note/extendedapspath/_index.md
@@ -1,0 +1,113 @@
+---
+title: "ExtendedApsPath"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "標準の ApsPath のラッパーを表し、描画動作の一部を拡張します。"
+type: docs
+weight: 28
+url: /ja/java/com.aspose.note/extendedapspath/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ExtendedApsNode](../../com.aspose.note/extendedapsnode)
+```
+public class ExtendedApsPath extends ExtendedApsNode
+```
+
+標準 ApsPath のラッパーを表し、描画動作の一部を拡張します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ExtendedApsPath(ApsPath internalApsPath)](#ExtendedApsPath-com.aspose.foundation.rendering.ApsPath-) | `ExtendedApsPath` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addToCompositeNode(ApsCompositeNode compositeNode)](#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-) | このノードを指定された `compositeNode` に追加します。 |
+| [applyPlaneTransform(System.Drawing.PointF transformVector)](#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-) | 平面変換を適用し、ノードを x および y 平面で移動させます。 |
+| [applyScaleTransform(float scaleTransform)](#applyScaleTransform-float-) | ノードにスケーリングを適用します。 |
+| [getBottom()](#getBottom--) | 下端を取得します。 |
+| [getCopy()](#getCopy--) | このノードの完全なコピーを作成します。 |
+| [getTop()](#getTop--) | 上端を取得します。 |
+### ExtendedApsPath(ApsPath internalApsPath) {#ExtendedApsPath-com.aspose.foundation.rendering.ApsPath-}
+```
+public ExtendedApsPath(ApsPath internalApsPath)
+```
+
+
+`ExtendedApsPath` クラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| internalApsPath | com.aspose.foundation.rendering.ApsPath | aps パスです。 |
+
+### addToCompositeNode(ApsCompositeNode compositeNode) {#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-}
+```
+public void addToCompositeNode(ApsCompositeNode compositeNode)
+```
+
+
+このノードを指定された `compositeNode` に追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| compositeNode | com.aspose.foundation.rendering.ApsCompositeNode |  |
+
+### applyPlaneTransform(System.Drawing.PointF transformVector) {#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-}
+```
+public void applyPlaneTransform(System.Drawing.PointF transformVector)
+```
+
+
+平面変換を適用し、ノードを x および y 平面で移動させます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| transformVector | com.aspose.ms.System.Drawing.PointF |  |
+
+### applyScaleTransform(float scaleTransform) {#applyScaleTransform-float-}
+```
+public void applyScaleTransform(float scaleTransform)
+```
+
+
+ノードにスケーリングを適用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| scaleTransform | float | 変換のスケール係数です。 |
+
+### getBottom() {#getBottom--}
+```
+public float getBottom()
+```
+
+
+下端を取得します。
+
+**Returns:**
+float
+### getCopy() {#getCopy--}
+```
+public ExtendedApsNode getCopy()
+```
+
+
+このノードの完全なコピーを作成します。
+
+**Returns:**
+[ExtendedApsNode](../../com.aspose.note/extendedapsnode) - The `IExtendedApsNode`.
+### getTop() {#getTop--}
+```
+public float getTop()
+```
+
+
+上端を取得します。
+
+**Returns:**
+float

--- a/japanese/java/com.aspose.note/extendedcompositenode/_index.md
+++ b/japanese/java/com.aspose.note/extendedcompositenode/_index.md
@@ -1,0 +1,111 @@
+---
+title: "ExtendedCompositeNode"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "複数の IExtendedApsNode インスタンスを結合します。"
+type: docs
+weight: 29
+url: /ja/java/com.aspose.note/extendedcompositenode/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ExtendedApsNode](../../com.aspose.note/extendedapsnode)
+```
+public class ExtendedCompositeNode extends ExtendedApsNode
+```
+
+`IExtendedApsNode` インスタンスをいくつか組み合わせます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ExtendedCompositeNode()](#ExtendedCompositeNode--) | `ExtendedCompositeNode` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(ExtendedApsNode extendedApsNode)](#add-com.aspose.note.ExtendedApsNode-) | `extendedApsNode` をノードの内部リストに追加します。 |
+| [addToCompositeNode(ApsCompositeNode compositeNode)](#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-) | このノードを指定された `compositeNode` に追加します。 |
+| [applyPlaneTransform(System.Drawing.PointF transformVector)](#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-) | 平面変換を適用し、ノードを x および y 平面で移動させます。 |
+| [applyScaleTransform(float scaleTransform)](#applyScaleTransform-float-) | ノードにスケーリングを適用します。 |
+| [getApsNodes()](#getApsNodes--) | この `ExtendedCompositeNode` に結合されたすべての `IExtendedApsNode` インスタンスを取得します。 |
+| [getCopy()](#getCopy--) | このノードの完全なコピーを作成します。 |
+### ExtendedCompositeNode() {#ExtendedCompositeNode--}
+```
+public ExtendedCompositeNode()
+```
+
+
+`ExtendedCompositeNode` クラスの新しいインスタンスを初期化します。
+
+### add(ExtendedApsNode extendedApsNode) {#add-com.aspose.note.ExtendedApsNode-}
+```
+public final void add(ExtendedApsNode extendedApsNode)
+```
+
+
+`extendedApsNode` をノードの内部リストに追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| extendedApsNode | [ExtendedApsNode](../../com.aspose.note/extendedapsnode) |  |
+
+### addToCompositeNode(ApsCompositeNode compositeNode) {#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-}
+```
+public void addToCompositeNode(ApsCompositeNode compositeNode)
+```
+
+
+このノードを指定された `compositeNode` に追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| compositeNode | com.aspose.foundation.rendering.ApsCompositeNode |  |
+
+### applyPlaneTransform(System.Drawing.PointF transformVector) {#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-}
+```
+public void applyPlaneTransform(System.Drawing.PointF transformVector)
+```
+
+
+平面変換を適用し、ノードを x および y 平面で移動させます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| transformVector | com.aspose.ms.System.Drawing.PointF |  |
+
+### applyScaleTransform(float scaleTransform) {#applyScaleTransform-float-}
+```
+public void applyScaleTransform(float scaleTransform)
+```
+
+
+ノードにスケーリングを適用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| scaleTransform | float | 変換のスケール係数です。 |
+
+### getApsNodes() {#getApsNodes--}
+```
+public final System.Collections.Generic.IGenericCollection<ExtendedApsNode> getApsNodes()
+```
+
+
+この `ExtendedCompositeNode` に結合されたすべての `IExtendedApsNode` インスタンスを取得します。
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericCollection&lt;com.aspose.note.ExtendedApsNode&gt;
+### getCopy() {#getCopy--}
+```
+public ExtendedApsNode getCopy()
+```
+
+
+このノードの完全なコピーを作成します。
+
+**Returns:**
+[ExtendedApsNode](../../com.aspose.note/extendedapsnode) - The `IExtendedApsNode`.

--- a/japanese/java/com.aspose.note/fileformat/_index.md
+++ b/japanese/java/com.aspose.note/fileformat/_index.md
@@ -1,0 +1,56 @@
+---
+title: "FileFormat"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "OneNote ファイル形式を表します。"
+type: docs
+weight: 30
+url: /ja/java/com.aspose.note/fileformat/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class FileFormat extends System.Enum
+```
+
+OneNote ファイル形式を表します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [OneNote2007](#OneNote2007) | OneNote 2010。 |
+| [OneNote2010](#OneNote2010) | OneNote 2010。 |
+| [OneNoteOnline](#OneNoteOnline) | OneNote Online。 |
+| [Unknown](#Unknown) | 不明なファイル形式。 |
+### OneNote2007 {#OneNote2007}
+```
+public static final int OneNote2007
+```
+
+
+OneNote 2010。
+
+### OneNote2010 {#OneNote2010}
+```
+public static final int OneNote2010
+```
+
+
+OneNote 2010。
+
+### OneNoteOnline {#OneNoteOnline}
+```
+public static final int OneNoteOnline
+```
+
+
+OneNote Online。
+
+### Unknown {#Unknown}
+```
+public static final int Unknown
+```
+
+
+不明なファイル形式。
+

--- a/japanese/java/com.aspose.note/fontsavingargs/_index.md
+++ b/japanese/java/com.aspose.note/fontsavingargs/_index.md
@@ -1,0 +1,53 @@
+---
+title: "FontSavingArgs"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "FontSaving イベントのデータを提供します。"
+type: docs
+weight: 31
+url: /ja/java/com.aspose.note/fontsavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ResourceSavingArgs](../../com.aspose.note/resourcesavingargs)
+```
+public class FontSavingArgs extends ResourceSavingArgs
+```
+
+FontSaving イベントのデータを提供します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getFontFamilyName()](#getFontFamilyName--) | 保存されるフォントのファミリ名を取得します。 |
+| [isBold()](#isBold--) | 保存中のフォントが太字かどうかを示す値を取得します。 |
+| [isItalic()](#isItalic--) | 保存中のフォントが斜体かどうかを示す値を取得します。 |
+### getFontFamilyName() {#getFontFamilyName--}
+```
+public final String getFontFamilyName()
+```
+
+
+保存されるフォントのファミリ名を取得します。
+
+**Returns:**
+java.lang.String
+### isBold() {#isBold--}
+```
+public final boolean isBold()
+```
+
+
+保存中のフォントが太字かどうかを示す値を取得します。
+
+**Returns:**
+boolean
+### isItalic() {#isItalic--}
+```
+public final boolean isItalic()
+```
+
+
+保存中のフォントが斜体かどうかを示す値を取得します。
+
+**Returns:**
+boolean

--- a/japanese/java/com.aspose.note/htmlsaveoptions/_index.md
+++ b/japanese/java/com.aspose.note/htmlsaveoptions/_index.md
@@ -1,0 +1,287 @@
+---
+title: "HtmlSaveOptions"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ドキュメントを HTML 形式で保存する際に追加オプションを指定できます。"
+type: docs
+weight: 32
+url: /ja/java/com.aspose.note/htmlsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.SaveOptions](../../com.aspose.note/saveoptions)
+```
+public class HtmlSaveOptions extends SaveOptions
+```
+
+ドキュメントを HTML 形式で保存する際に追加オプションを指定できます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [HtmlSaveOptions()](#HtmlSaveOptions--) | 新しい [HtmlSaveOptions](../../com.aspose.note/htmlsaveoptions) クラスのインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getCssPerPageGeneration()](#getCssPerPageGeneration--) | 新しいページごとに StyleSheet ファイルが個別に生成されるかどうかを取得または設定します。 |
+| [getCssSavingCallback()](#getCssSavingCallback--) | CSS を格納するリソースを作成するために呼び出されるコールバックを取得または設定します。 |
+| [getDocumentPerPageGeneration()](#getDocumentPerPageGeneration--) | ページごとのドキュメント生成が有効かどうかを示す値を取得または設定します。 |
+| [getExportCss()](#getExportCss--) | CSS のエクスポート方法を取得または設定します。 |
+| [getExportFonts()](#getExportFonts--) | フォントのエクスポート方法を取得または設定します。 |
+| [getExportImages()](#getExportImages--) | 画像のエクスポート方法を取得または設定します。 |
+| [getFontFaceTypes()](#getFontFaceTypes--) | フォントフェイスの種類を取得または設定します。 |
+| [getFontSavingCallback()](#getFontSavingCallback--) | フォントを格納するリソースを作成するために呼び出されるコールバックを取得または設定します。 |
+| [getImageSavingCallback()](#getImageSavingCallback--) | 画像を格納するリソースを作成するために呼び出されるコールバックを取得または設定します。 |
+| [getPageSavingCallback()](#getPageSavingCallback--) | ページを格納するリソースを作成するために呼び出されるコールバックを取得または設定します。 |
+| [setCssPerPageGeneration(boolean value)](#setCssPerPageGeneration-boolean-) | 新しいページごとに StyleSheet ファイルが個別に生成されるかどうかを取得または設定します。 |
+| [setCssSavingCallback(ICssSavingCallback value)](#setCssSavingCallback-com.aspose.note.ICssSavingCallback-) | CSS を格納するリソースを作成するために呼び出されるコールバックを取得または設定します。 |
+| [setDocumentPerPageGeneration(boolean value)](#setDocumentPerPageGeneration-boolean-) | ページごとのドキュメント生成が有効かどうかを示す値を取得または設定します。 |
+| [setExportCss(int value)](#setExportCss-int-) | CSS のエクスポート方法を取得または設定します。 |
+| [setExportFonts(int value)](#setExportFonts-int-) | フォントのエクスポート方法を取得または設定します。 |
+| [setExportImages(int value)](#setExportImages-int-) | 画像のエクスポート方法を取得または設定します。 |
+| [setFontFaceTypes(int value)](#setFontFaceTypes-int-) | フォントフェイスの種類を取得または設定します。 |
+| [setFontSavingCallback(IFontSavingCallback value)](#setFontSavingCallback-com.aspose.note.IFontSavingCallback-) | フォントを格納するリソースを作成するために呼び出されるコールバックを取得または設定します。 |
+| [setImageSavingCallback(IImageSavingCallback value)](#setImageSavingCallback-com.aspose.note.IImageSavingCallback-) | 画像を格納するリソースを作成するために呼び出されるコールバックを取得または設定します。 |
+| [setPageSavingCallback(IPageSavingCallback value)](#setPageSavingCallback-com.aspose.note.IPageSavingCallback-) | ページを格納するリソースを作成するために呼び出されるコールバックを取得または設定します。 |
+### HtmlSaveOptions() {#HtmlSaveOptions--}
+```
+public HtmlSaveOptions()
+```
+
+
+新しい [HtmlSaveOptions](../../com.aspose.note/htmlsaveoptions) クラスのインスタンスを初期化します。
+
+### getCssPerPageGeneration() {#getCssPerPageGeneration--}
+```
+public final boolean getCssPerPageGeneration()
+```
+
+
+新しいページごとに StyleSheet ファイルが個別に生成されるかどうかを取得または設定します。
+
+**Returns:**
+boolean
+### getCssSavingCallback() {#getCssSavingCallback--}
+```
+public final ICssSavingCallback getCssSavingCallback()
+```
+
+
+CSS を格納するリソースを作成するために呼び出されるコールバックを取得または設定します。
+
+**Returns:**
+[ICssSavingCallback](../../com.aspose.note/icsssavingcallback)
+### getDocumentPerPageGeneration() {#getDocumentPerPageGeneration--}
+```
+public final boolean getDocumentPerPageGeneration()
+```
+
+
+ページごとのドキュメント生成が有効かどうかを示す値を取得または設定します。
+
+**Returns:**
+boolean
+### getExportCss() {#getExportCss--}
+```
+public final int getExportCss()
+```
+
+
+CSS のエクスポート方法を取得または設定します。
+
+**Returns:**
+int
+### getExportFonts() {#getExportFonts--}
+```
+public final int getExportFonts()
+```
+
+
+フォントのエクスポート方法を取得または設定します。
+
+**Returns:**
+int
+### getExportImages() {#getExportImages--}
+```
+public final int getExportImages()
+```
+
+
+画像のエクスポート方法を取得または設定します。
+
+**Returns:**
+int
+### getFontFaceTypes() {#getFontFaceTypes--}
+```
+public final int getFontFaceTypes()
+```
+
+
+フォントフェイスの種類を取得または設定します。
+
+値: フォントフェイスの種類。
+
+**Returns:**
+int
+### getFontSavingCallback() {#getFontSavingCallback--}
+```
+public final IFontSavingCallback getFontSavingCallback()
+```
+
+
+フォントを格納するリソースを作成するために呼び出されるコールバックを取得または設定します。
+
+**Returns:**
+[IFontSavingCallback](../../com.aspose.note/ifontsavingcallback)
+### getImageSavingCallback() {#getImageSavingCallback--}
+```
+public final IImageSavingCallback getImageSavingCallback()
+```
+
+
+画像を格納するリソースを作成するために呼び出されるコールバックを取得または設定します。
+
+**Returns:**
+[IImageSavingCallback](../../com.aspose.note/iimagesavingcallback)
+### getPageSavingCallback() {#getPageSavingCallback--}
+```
+public final IPageSavingCallback getPageSavingCallback()
+```
+
+
+ページを格納するリソースを作成するために呼び出されるコールバックを取得または設定します。
+
+**Returns:**
+[IPageSavingCallback](../../com.aspose.note/ipagesavingcallback)
+### setCssPerPageGeneration(boolean value) {#setCssPerPageGeneration-boolean-}
+```
+public final void setCssPerPageGeneration(boolean value)
+```
+
+
+新しいページごとに StyleSheet ファイルが個別に生成されるかどうかを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setCssSavingCallback(ICssSavingCallback value) {#setCssSavingCallback-com.aspose.note.ICssSavingCallback-}
+```
+public final void setCssSavingCallback(ICssSavingCallback value)
+```
+
+
+CSS を格納するリソースを作成するために呼び出されるコールバックを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ICssSavingCallback](../../com.aspose.note/icsssavingcallback) |  |
+
+### setDocumentPerPageGeneration(boolean value) {#setDocumentPerPageGeneration-boolean-}
+```
+public final void setDocumentPerPageGeneration(boolean value)
+```
+
+
+ページごとのドキュメント生成が有効かどうかを示す値を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setExportCss(int value) {#setExportCss-int-}
+```
+public final void setExportCss(int value)
+```
+
+
+CSS のエクスポート方法を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setExportFonts(int value) {#setExportFonts-int-}
+```
+public final void setExportFonts(int value)
+```
+
+
+フォントのエクスポート方法を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setExportImages(int value) {#setExportImages-int-}
+```
+public final void setExportImages(int value)
+```
+
+
+画像のエクスポート方法を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setFontFaceTypes(int value) {#setFontFaceTypes-int-}
+```
+public final void setFontFaceTypes(int value)
+```
+
+
+フォントフェイスの種類を取得または設定します。
+
+値: フォントフェイスの種類。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setFontSavingCallback(IFontSavingCallback value) {#setFontSavingCallback-com.aspose.note.IFontSavingCallback-}
+```
+public final void setFontSavingCallback(IFontSavingCallback value)
+```
+
+
+フォントを格納するリソースを作成するために呼び出されるコールバックを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IFontSavingCallback](../../com.aspose.note/ifontsavingcallback) |  |
+
+### setImageSavingCallback(IImageSavingCallback value) {#setImageSavingCallback-com.aspose.note.IImageSavingCallback-}
+```
+public final void setImageSavingCallback(IImageSavingCallback value)
+```
+
+
+画像を格納するリソースを作成するために呼び出されるコールバックを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IImageSavingCallback](../../com.aspose.note/iimagesavingcallback) |  |
+
+### setPageSavingCallback(IPageSavingCallback value) {#setPageSavingCallback-com.aspose.note.IPageSavingCallback-}
+```
+public final void setPageSavingCallback(IPageSavingCallback value)
+```
+
+
+ページを格納するリソースを作成するために呼び出されるコールバックを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IPageSavingCallback](../../com.aspose.note/ipagesavingcallback) |  |
+

--- a/japanese/java/com.aspose.note/icompositenode/_index.md
+++ b/japanese/java/com.aspose.note/icompositenode/_index.md
@@ -1,0 +1,33 @@
+---
+title: "ICompositeNode"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "他のノードを含むことができるノードのインターフェイスです。"
+type: docs
+weight: 96
+url: /ja/java/com.aspose.note/icompositenode/
+---
+```
+public interface ICompositeNode
+```
+
+他のノードを含むことができるノードのインターフェイスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [&lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass)](#-T1-getChildNodes-java.lang.Class-T1--) |  |
+### &lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass) {#-T1-getChildNodes-java.lang.Class-T1--}
+```
+public abstract List<T1> <T1>getChildNodes(Class<T1> typeParameterClass)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| typeParameterClass | java.lang.Class&lt;T1&gt; |  |
+
+**Returns:**
+java.util.List&lt;T1&gt;

--- a/japanese/java/com.aspose.note/icompositenodet/_index.md
+++ b/japanese/java/com.aspose.note/icompositenodet/_index.md
@@ -1,0 +1,20 @@
+---
+title: "ICompositeNodeT"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "他のノードを含むことができるノードのインターフェイスです。"
+type: docs
+weight: 97
+url: /ja/java/com.aspose.note/icompositenodet/
+---
+
+**All Implemented Interfaces:**
+[com.aspose.note.ICompositeNode](../../com.aspose.note/icompositenode), com.aspose.ms.System.Collections.Generic.IGenericEnumerable
+```
+public interface ICompositeNodeT<T> extends ICompositeNode, System.Collections.Generic.IGenericEnumerable<T>
+```
+
+他のノードを含むことができるノードのインターフェイスです。
+
+`T`: 子ノードの型
+
+T :

--- a/japanese/java/com.aspose.note/icsssavingcallback/_index.md
+++ b/japanese/java/com.aspose.note/icsssavingcallback/_index.md
@@ -1,0 +1,31 @@
+---
+title: "ICssSavingCallback"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "HTML にドキュメントを保存する際に、Aspose.Note が CSS カスケーディングスタイルシートを保存する方法を制御したい場合は、このインターフェイスを実装してください。"
+type: docs
+weight: 98
+url: /ja/java/com.aspose.note/icsssavingcallback/
+---
+```
+public interface ICssSavingCallback
+```
+
+HTML にドキュメントを保存する際に Aspose.Note が CSS（カスケーディングスタイルシート）を保存する方法を制御したい場合は、このインターフェイスを実装してください。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [cssSaving(CssSavingArgs args)](#cssSaving-com.aspose.note.CssSavingArgs-) | Aspose.Note が CSS（カスケーディングスタイルシート）を保存するときに呼び出されます。 |
+### cssSaving(CssSavingArgs args) {#cssSaving-com.aspose.note.CssSavingArgs-}
+```
+public abstract void cssSaving(CssSavingArgs args)
+```
+
+
+Aspose.Note が CSS（カスケーディングスタイルシート）を保存するときに呼び出されます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| args | [CssSavingArgs](../../com.aspose.note/csssavingargs) | 保存パラメータです。 |
+

--- a/japanese/java/com.aspose.note/ifontsavingcallback/_index.md
+++ b/japanese/java/com.aspose.note/ifontsavingcallback/_index.md
@@ -1,0 +1,31 @@
+---
+title: "IFontSavingCallback"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "HTML にドキュメントを保存する際に Aspose.Note がフォントを保存する方法を制御したい場合は、このインターフェイスを実装してください。"
+type: docs
+weight: 99
+url: /ja/java/com.aspose.note/ifontsavingcallback/
+---
+```
+public interface IFontSavingCallback
+```
+
+HTML にドキュメントを保存する際に Aspose.Note がフォントを保存する方法を制御したい場合は、このインターフェイスを実装してください。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [fontSaving(FontSavingArgs args)](#fontSaving-com.aspose.note.FontSavingArgs-) | Aspose.Note がフォントを保存するときに呼び出されます。 |
+### fontSaving(FontSavingArgs args) {#fontSaving-com.aspose.note.FontSavingArgs-}
+```
+public abstract void fontSaving(FontSavingArgs args)
+```
+
+
+Aspose.Note がフォントを保存するときに呼び出されます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| args | [FontSavingArgs](../../com.aspose.note/fontsavingargs) | 保存パラメータです。 |
+

--- a/japanese/java/com.aspose.note/iimagesavingcallback/_index.md
+++ b/japanese/java/com.aspose.note/iimagesavingcallback/_index.md
@@ -1,0 +1,31 @@
+---
+title: "IImageSavingCallback"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "HTML にドキュメントを保存する際に Aspose.Note が画像を保存する方法を制御したい場合は、このインターフェイスを実装してください。"
+type: docs
+weight: 100
+url: /ja/java/com.aspose.note/iimagesavingcallback/
+---
+```
+public interface IImageSavingCallback
+```
+
+HTML にドキュメントを保存する際に Aspose.Note が画像を保存する方法を制御したい場合は、このインターフェイスを実装してください。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [imageSaving(ImageSavingArgs args)](#imageSaving-com.aspose.note.ImageSavingArgs-) | Aspose.Note が画像を保存するときに呼び出されます。 |
+### imageSaving(ImageSavingArgs args) {#imageSaving-com.aspose.note.ImageSavingArgs-}
+```
+public abstract void imageSaving(ImageSavingArgs args)
+```
+
+
+Aspose.Note が画像を保存するときに呼び出されます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| args | [ImageSavingArgs](../../com.aspose.note/imagesavingargs) | 保存パラメータです。 |
+

--- a/japanese/java/com.aspose.note/iindentatednode/_index.md
+++ b/japanese/java/com.aspose.note/iindentatednode/_index.md
@@ -1,0 +1,60 @@
+---
+title: "IIndentatedNode"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "子ノードに対して相対インデントを持つノードのインターフェイスです。"
+type: docs
+weight: 101
+url: /ja/java/com.aspose.note/iindentatednode/
+---
+```
+public interface IIndentatedNode
+```
+
+子ノードに対して相対インデントを持つノードのインターフェイスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [&lt;T&gt;setIndentPosition(byte value)](#-T-setIndentPosition-byte-) | インデント位置を取得または設定します。 |
+| [&lt;T&gt;setIndentPosition(int value)](#-T-setIndentPosition-int-) | インデント位置を取得または設定します。 |
+| [getIndentPosition()](#getIndentPosition--) | インデント位置を取得または設定します。 |
+### &lt;T&gt;setIndentPosition(byte value) {#-T-setIndentPosition-byte-}
+```
+public abstract T <T>setIndentPosition(byte value)
+```
+
+
+インデント位置を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte |  |
+
+**Returns:**
+T
+### &lt;T&gt;setIndentPosition(int value) {#-T-setIndentPosition-int-}
+```
+public abstract T <T>setIndentPosition(int value)
+```
+
+
+インデント位置を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+**Returns:**
+T
+### getIndentPosition() {#getIndentPosition--}
+```
+public abstract byte getIndentPosition()
+```
+
+
+インデント位置を取得または設定します。
+
+**Returns:**
+byte

--- a/japanese/java/com.aspose.note/image/_index.md
+++ b/japanese/java/com.aspose.note/image/_index.md
@@ -1,0 +1,420 @@
+---
+title: "画像"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "画像を表します。"
+type: docs
+weight: 33
+url: /ja/java/com.aspose.note/image/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode
+
+**All Implemented Interfaces:**
+[com.aspose.note.IPageChildNode](../../com.aspose.note/ipagechildnode), [com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode), [com.aspose.note.ITaggable](../../com.aspose.note/itaggable)
+```
+public final class Image extends CompositeNode<Loop> implements IPageChildNode, IOutlineElementChildNode, ITaggable
+```
+
+画像を表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Image(String path)](#Image-java.lang.String-) | `Image` クラスの新しいインスタンスを初期化します。 |
+| [Image(String fileName, InputStream imageStream)](#Image-java.lang.String-java.io.InputStream-) | `Image` クラスの新しいインスタンスを初期化します。 |
+| [Image()](#Image--) | `Image` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | ノードのビジターを受け入れます。 |
+| [getAlignment()](#getAlignment--) | 配置を取得します。 |
+| [getAlternativeTextDescription()](#getAlternativeTextDescription--) | 画像の代替テキストの本文を取得します。 |
+| [getAlternativeTextTitle()](#getAlternativeTextTitle--) | 画像の代替テキストのタイトルを取得します。 |
+| [getBytes()](#getBytes--) | 画像データストアを取得します。 |
+| [getFileName()](#getFileName--) | ファイル名を取得します。 |
+| [getFilePath()](#getFilePath--) | 画像ファイルへのパスを取得します。 |
+| [getFormat()](#getFormat--) | 画像の形式を取得します。 |
+| [getHeight()](#getHeight--) | 高さを取得します。 |
+| [getHorizontalOffset()](#getHorizontalOffset--) | 水平オフセットを取得します。 |
+| [getHyperlinkUrl()](#getHyperlinkUrl--) | 画像に関連付けられたハイパーリンクを取得します。 |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 最終更新時刻を取得します。 |
+| [getOriginalHeight()](#getOriginalHeight--) | 元の高さを取得します。 |
+| [getOriginalWidth()](#getOriginalWidth--) | 元の幅を取得します。 |
+| [getTags()](#getTags--) | 画像のすべてのタグのリストを取得します。 |
+| [getVerticalOffset()](#getVerticalOffset--) | 垂直オフセットを取得します。 |
+| [getWidth()](#getWidth--) | 幅を取得します。 |
+| [isBackground()](#isBackground--) | 画像が背景画像かどうかを取得します。 |
+| [replace(Image newImage)](#replace-com.aspose.note.Image-) | 提供された Image オブジェクトのデータで現在の画像データを置き換えます。 |
+| [setAlignment(int value)](#setAlignment-int-) | 配置を設定します。 |
+| [setAlternativeTextDescription(String value)](#setAlternativeTextDescription-java.lang.String-) | 画像の代替テキストの本文を設定します。 |
+| [setAlternativeTextTitle(String value)](#setAlternativeTextTitle-java.lang.String-) | 画像の代替テキストのタイトルを設定します。 |
+| [setBackground(boolean value)](#setBackground-boolean-) | 画像が背景画像かどうかを取得します。 |
+| [setHeight(float value)](#setHeight-float-) | 高さを設定します。 |
+| [setHorizontalOffset(float value)](#setHorizontalOffset-float-) | 水平オフセットを設定します。 |
+| [setHyperlinkUrl(String value)](#setHyperlinkUrl-java.lang.String-) | 画像に関連付けられたハイパーリンクを設定します。 |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 最終更新時刻を設定します。 |
+| [setVerticalOffset(float value)](#setVerticalOffset-float-) | 垂直オフセットを設定します。 |
+| [setWidth(float value)](#setWidth-float-) | 幅を設定します。 |
+### Image(String path) {#Image-java.lang.String-}
+```
+public Image(String path)
+```
+
+
+`Image` クラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| パス | java.lang.String | `Image` を作成するためのファイルへのパスを含む文字列です。 |
+
+### Image(String fileName, InputStream imageStream) {#Image-java.lang.String-java.io.InputStream-}
+```
+public Image(String fileName, InputStream imageStream)
+```
+
+
+`Image` クラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ファイル名 | java.lang.String | 画像の名前です。 |
+| imageStream | java.io.InputStream | 画像を含むストリームです。 |
+
+### Image() {#Image--}
+```
+public Image()
+```
+
+
+`Image` クラスの新しいインスタンスを初期化します。
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+ノードのビジターを受け入れます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor` から派生したクラスのオブジェクト。 |
+
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+配置を取得します。
+
+**Returns:**
+int
+### getAlternativeTextDescription() {#getAlternativeTextDescription--}
+```
+public final String getAlternativeTextDescription()
+```
+
+
+画像の代替テキストの本文を取得します。
+
+**Returns:**
+java.lang.String
+### getAlternativeTextTitle() {#getAlternativeTextTitle--}
+```
+public final String getAlternativeTextTitle()
+```
+
+
+画像の代替テキストのタイトルを取得します。
+
+**Returns:**
+java.lang.String
+### getBytes() {#getBytes--}
+```
+public byte[] getBytes()
+```
+
+
+画像データストアを取得します。
+
+**Returns:**
+byte[]
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+ファイル名を取得します。
+
+**Returns:**
+java.lang.String
+### getFilePath() {#getFilePath--}
+```
+public String getFilePath()
+```
+
+
+画像ファイルへのパスを取得します。
+
+**Returns:**
+java.lang.String
+### getFormat() {#getFormat--}
+```
+public final System.Drawing.Imaging.ImageFormat getFormat()
+```
+
+
+画像の形式を取得します。
+
+**Returns:**
+com.aspose.ms.System.Drawing.Imaging.ImageFormat
+### getHeight() {#getHeight--}
+```
+public final float getHeight()
+```
+
+
+高さを取得します。これは MS OneNote ドキュメント内の画像の実際の高さです。
+
+**Returns:**
+float
+### getHorizontalOffset() {#getHorizontalOffset--}
+```
+public float getHorizontalOffset()
+```
+
+
+水平オフセットを取得します。
+
+**Returns:**
+float
+### getHyperlinkUrl() {#getHyperlinkUrl--}
+```
+public String getHyperlinkUrl()
+```
+
+
+画像に関連付けられたハイパーリンクを取得します。
+
+**Returns:**
+java.lang.String
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+最終更新時刻を取得します。
+
+**Returns:**
+java.util.Date
+### getOriginalHeight() {#getOriginalHeight--}
+```
+public float getOriginalHeight()
+```
+
+
+元の高さを取得します。これはリサイズ前の画像の元の幅です。
+
+**Returns:**
+float
+### getOriginalWidth() {#getOriginalWidth--}
+```
+public float getOriginalWidth()
+```
+
+
+元の幅を取得します。これはリサイズ前の画像の元の幅です。
+
+**Returns:**
+float
+### getTags() {#getTags--}
+```
+public final System.Collections.Generic.List<ITag> getTags()
+```
+
+
+画像のすべてのタグのリストを取得します。
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List&lt;com.aspose.note.ITag&gt;
+### getVerticalOffset() {#getVerticalOffset--}
+```
+public float getVerticalOffset()
+```
+
+
+垂直オフセットを取得します。
+
+**Returns:**
+float
+### getWidth() {#getWidth--}
+```
+public final float getWidth()
+```
+
+
+幅を取得します。これは MS OneNote ドキュメント内の画像の実際の幅です。
+
+**Returns:**
+float
+### isBackground() {#isBackground--}
+```
+public final boolean isBackground()
+```
+
+
+画像が背景画像かどうかを取得します。
+
+**Returns:**
+boolean
+### replace(Image newImage) {#replace-com.aspose.note.Image-}
+```
+public void replace(Image newImage)
+```
+
+
+提供された Image オブジェクトのデータで現在の画像データを置き換えます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| newImage | [Image](../../com.aspose.note/image) |  |
+
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+配置を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setAlternativeTextDescription(String value) {#setAlternativeTextDescription-java.lang.String-}
+```
+public final void setAlternativeTextDescription(String value)
+```
+
+
+画像の代替テキストの本文を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setAlternativeTextTitle(String value) {#setAlternativeTextTitle-java.lang.String-}
+```
+public final void setAlternativeTextTitle(String value)
+```
+
+
+画像の代替テキストのタイトルを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setBackground(boolean value) {#setBackground-boolean-}
+```
+public final void setBackground(boolean value)
+```
+
+
+画像が背景画像かどうかを取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setHeight(float value) {#setHeight-float-}
+```
+public final void setHeight(float value)
+```
+
+
+高さを設定します。これは MS OneNote ドキュメント内の画像の実際の高さです。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setHorizontalOffset(float value) {#setHorizontalOffset-float-}
+```
+public void setHorizontalOffset(float value)
+```
+
+
+水平オフセットを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setHyperlinkUrl(String value) {#setHyperlinkUrl-java.lang.String-}
+```
+public void setHyperlinkUrl(String value)
+```
+
+
+画像に関連付けられたハイパーリンクを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+最終更新時刻を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Date |  |
+
+### setVerticalOffset(float value) {#setVerticalOffset-float-}
+```
+public void setVerticalOffset(float value)
+```
+
+
+垂直オフセットを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setWidth(float value) {#setWidth-float-}
+```
+public final void setWidth(float value)
+```
+
+
+幅を設定します。これは MS OneNote ドキュメント内の画像の実際の幅です。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+

--- a/japanese/java/com.aspose.note/imagebinarizationoptions/_index.md
+++ b/japanese/java/com.aspose.note/imagebinarizationoptions/_index.md
@@ -1,0 +1,83 @@
+---
+title: "ImageBinarizationOptions"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "画像の二値化オプション。"
+type: docs
+weight: 34
+url: /ja/java/com.aspose.note/imagebinarizationoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ImageBinarizationOptions
+```
+
+画像の二値化オプションです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ImageBinarizationOptions()](#ImageBinarizationOptions--) | 新しい [ImageBinarizationOptions](../../com.aspose.note/imagebinarizationoptions) クラスのインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getBinarizationMethod()](#getBinarizationMethod--) | 二値化方法を取得または設定します。 |
+| [getBinarizationThreshold()](#getBinarizationThreshold--) | 固定閾値二値化方法の閾値を取得または設定します。 |
+| [setBinarizationMethod(int value)](#setBinarizationMethod-int-) | 二値化方法を取得または設定します。 |
+| [setBinarizationThreshold(int value)](#setBinarizationThreshold-int-) | 固定閾値二値化方法の閾値を取得または設定します。 |
+### ImageBinarizationOptions() {#ImageBinarizationOptions--}
+```
+public ImageBinarizationOptions()
+```
+
+
+新しい [ImageBinarizationOptions](../../com.aspose.note/imagebinarizationoptions) クラスのインスタンスを初期化します。
+
+### getBinarizationMethod() {#getBinarizationMethod--}
+```
+public final int getBinarizationMethod()
+```
+
+
+二値化方法を取得または設定します。デフォルト値は [BinarizationMethod.FixedThreshold](../../com.aspose.note/binarizationmethod\#FixedThreshold) です。
+
+**Returns:**
+int
+### getBinarizationThreshold() {#getBinarizationThreshold--}
+```
+public final int getBinarizationThreshold()
+```
+
+
+固定閾値二値化方法の閾値を取得または設定します。デフォルト値は 128 です。
+
+**Returns:**
+int
+### setBinarizationMethod(int value) {#setBinarizationMethod-int-}
+```
+public final void setBinarizationMethod(int value)
+```
+
+
+二値化方法を取得または設定します。デフォルト値は [BinarizationMethod.FixedThreshold](../../com.aspose.note/binarizationmethod\#FixedThreshold) です。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setBinarizationThreshold(int value) {#setBinarizationThreshold-int-}
+```
+public final void setBinarizationThreshold(int value)
+```
+
+
+固定閾値二値化方法の閾値を取得または設定します。デフォルト値は 128 です。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+

--- a/japanese/java/com.aspose.note/imagesaveoptions/_index.md
+++ b/japanese/java/com.aspose.note/imagesaveoptions/_index.md
@@ -1,0 +1,179 @@
+---
+title: "ImageSaveOptions"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ドキュメントページを画像にレンダリングする際に追加オプションを指定できます。"
+type: docs
+weight: 35
+url: /ja/java/com.aspose.note/imagesaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.SaveOptions](../../com.aspose.note/saveoptions)
+```
+public class ImageSaveOptions extends SaveOptions
+```
+
+ドキュメントページを画像にレンダリングする際に追加オプションを指定できます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ImageSaveOptions(int format)](#ImageSaveOptions-int-) | `ImageSaveOptions` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getBinarizationOptions()](#getBinarizationOptions--) | 画像の二値化オプションを取得または設定します。 |
+| [getColorMode()](#getColorMode--) | 出力画像の `ColorMode`([getColorMode](../../com.aspose.note/imagesaveoptions\#getColorMode--)/[setColorMode(int)](../../com.aspose.note/imagesaveoptions\#setColorMode-int-)) を取得または設定します。 |
+| [getQuality()](#getQuality--) | 保存された画像の品質を決定する値を取得します。 |
+| [getResolution()](#getResolution--) | 生成された画像の解像度（ドット毎インチ）を取得します。 |
+| [getTiffCompression()](#getTiffCompression--) | 生成された画像を TIFF 形式で保存する際に使用する圧縮タイプを取得または設定します。 |
+| [setBinarizationOptions(ImageBinarizationOptions value)](#setBinarizationOptions-com.aspose.note.ImageBinarizationOptions-) | 画像の二値化オプションを取得または設定します。 |
+| [setColorMode(int value)](#setColorMode-int-) | 出力画像の `ColorMode`([getColorMode](../../com.aspose.note/imagesaveoptions\#getColorMode--)/[setColorMode(int)](../../com.aspose.note/imagesaveoptions\#setColorMode-int-)) を取得または設定します。 |
+| [setQuality(int value)](#setQuality-int-) | 保存された画像の品質を決定する値を設定します。 |
+| [setResolution(float value)](#setResolution-float-) | 生成された画像の解像度（dpi）を設定します。 |
+| [setTiffCompression(int value)](#setTiffCompression-int-) | 生成された画像を TIFF 形式で保存する際に使用する圧縮タイプを取得または設定します。 |
+### ImageSaveOptions(int format) {#ImageSaveOptions-int-}
+```
+public ImageSaveOptions(int format)
+```
+
+
+`ImageSaveOptions` クラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| format | int | ドキュメントが保存される形式です。 |
+
+### getBinarizationOptions() {#getBinarizationOptions--}
+```
+public final ImageBinarizationOptions getBinarizationOptions()
+```
+
+
+画像の二値化オプションを取得または設定します。
+
+**Returns:**
+[ImageBinarizationOptions](../../com.aspose.note/imagebinarizationoptions)
+### getColorMode() {#getColorMode--}
+```
+public final int getColorMode()
+```
+
+
+出力画像の `ColorMode`([getColorMode](../../com.aspose.note/imagesaveoptions\#getColorMode--)/[setColorMode(int)](../../com.aspose.note/imagesaveoptions\#setColorMode-int-)) を取得または設定します。
+
+**Returns:**
+int
+### getQuality() {#getQuality--}
+```
+public final int getQuality()
+```
+
+
+保存された画像の品質を決定する値を取得します。この値は System.Drawing.Imaging.Encoder.Quality パラメータとしてコーデックに渡されます。
+
+--------------------
+
+品質カテゴリの有用な値の範囲は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 は最低品質の画像、100 は最高品質の画像を表します。デフォルト値は 90 です。
+
+**Returns:**
+int
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+生成された画像の解像度（ドット毎インチ）を取得します。
+
+--------------------
+
+デフォルト値は 96 です。
+
+**Returns:**
+float
+### getTiffCompression() {#getTiffCompression--}
+```
+public final int getTiffCompression()
+```
+
+
+生成された画像を TIFF 形式で保存する際に使用する圧縮タイプを取得または設定します。
+
+**Returns:**
+int
+### setBinarizationOptions(ImageBinarizationOptions value) {#setBinarizationOptions-com.aspose.note.ImageBinarizationOptions-}
+```
+public final void setBinarizationOptions(ImageBinarizationOptions value)
+```
+
+
+画像の二値化オプションを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ImageBinarizationOptions](../../com.aspose.note/imagebinarizationoptions) |  |
+
+### setColorMode(int value) {#setColorMode-int-}
+```
+public final void setColorMode(int value)
+```
+
+
+出力画像の `ColorMode`([getColorMode](../../com.aspose.note/imagesaveoptions\#getColorMode--)/[setColorMode(int)](../../com.aspose.note/imagesaveoptions\#setColorMode-int-)) を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setQuality(int value) {#setQuality-int-}
+```
+public final void setQuality(int value)
+```
+
+
+保存された画像の品質を決定する値を設定します。この値は System.Drawing.Imaging.Encoder.Quality パラメータとしてコーデックに渡されます。
+
+--------------------
+
+品質カテゴリの有用な値の範囲は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 は最低品質の画像、100 は最高品質の画像を表します。デフォルト値は 90 です。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+生成された画像の解像度（dpi）を設定します。
+
+--------------------
+
+デフォルト値は 90 です。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setTiffCompression(int value) {#setTiffCompression-int-}
+```
+public final void setTiffCompression(int value)
+```
+
+
+生成された画像を TIFF 形式で保存する際に使用する圧縮タイプを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+

--- a/japanese/java/com.aspose.note/imagesavingargs/_index.md
+++ b/japanese/java/com.aspose.note/imagesavingargs/_index.md
@@ -1,0 +1,31 @@
+---
+title: "ImageSavingArgs"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ImageSaving イベントのデータを提供します。"
+type: docs
+weight: 36
+url: /ja/java/com.aspose.note/imagesavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ResourceSavingArgs](../../com.aspose.note/resourcesavingargs)
+```
+public class ImageSavingArgs extends ResourceSavingArgs
+```
+
+ImageSaving イベントのデータを提供します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getImageType()](#getImageType--) | 保存される画像のタイプを取得します。 |
+### getImageType() {#getImageType--}
+```
+public final int getImageType()
+```
+
+
+保存される画像のタイプを取得します。
+
+**Returns:**
+int

--- a/japanese/java/com.aspose.note/indentatednode/_index.md
+++ b/japanese/java/com.aspose.note/indentatednode/_index.md
@@ -1,0 +1,82 @@
+---
+title: "IndentatedNode"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "子ノードの相対インデントを持つノードの基本クラスです。"
+type: docs
+weight: 37
+url: /ja/java/com.aspose.note/indentatednode/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode
+
+**All Implemented Interfaces:**
+com.aspose.note.IIndentatedNodeExtended
+```
+public class IndentatedNode<T,Self> extends CompositeNode<T> implements IIndentatedNodeExtended
+```
+
+子ノードの相対インデントを持つノードの基本クラスです。
+
+`T`: 複合ノード内の要素の型です。
+
+T :
+Self :
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getIndentPosition()](#getIndentPosition--) | インデント位置を取得または設定します。 |
+| [getInternalIndentPosition()](#getInternalIndentPosition--) | インデントサイズを取得するために RgOutlineIndentDistance 配列で合計する項目数を取得します。 |
+| [setIndentPosition(byte value)](#setIndentPosition-byte-) | インデント位置を取得または設定します。 |
+| [setIndentPosition(int value)](#setIndentPosition-int-) |  |
+### getIndentPosition() {#getIndentPosition--}
+```
+public final byte getIndentPosition()
+```
+
+
+インデント位置を取得または設定します。
+
+**Returns:**
+byte
+### getInternalIndentPosition() {#getInternalIndentPosition--}
+```
+public int getInternalIndentPosition()
+```
+
+
+インデントサイズを取得するために RgOutlineIndentDistance 配列で合計する項目数を取得します。
+
+**Returns:**
+int
+### setIndentPosition(byte value) {#setIndentPosition-byte-}
+```
+public final Self setIndentPosition(byte value)
+```
+
+
+インデント位置を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte |  |
+
+**Returns:**
+Self
+### setIndentPosition(int value) {#setIndentPosition-int-}
+```
+public final Self setIndentPosition(int value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+**Returns:**
+Self

--- a/japanese/java/com.aspose.note/inkdrawing/_index.md
+++ b/japanese/java/com.aspose.note/inkdrawing/_index.md
@@ -1,0 +1,87 @@
+---
+title: "InkDrawing"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "任意の描画コンテンツを含むインクノードを表します。"
+type: docs
+weight: 38
+url: /ja/java/com.aspose.note/inkdrawing/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.InkNode](../../com.aspose.note/inknode)
+
+**All Implemented Interfaces:**
+[com.aspose.note.IPageChildNode](../../com.aspose.note/ipagechildnode)
+```
+public final class InkDrawing extends InkNode implements IPageChildNode
+```
+
+任意の描画コンテンツを含むインクノードを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | ノードのビジターを受け入れます。 |
+| [getHorizontalOffset()](#getHorizontalOffset--) | 水平オフセットを取得します。 |
+| [getVerticalOffset()](#getVerticalOffset--) | 垂直オフセットを取得します。 |
+| [setHorizontalOffset(float value)](#setHorizontalOffset-float-) | 水平オフセットを設定します。 |
+| [setVerticalOffset(float value)](#setVerticalOffset-float-) | 垂直オフセットを設定します。 |
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+ノードのビジターを受け入れます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | [DocumentVisitor](../../com.aspose.note/documentvisitor) から派生したクラスのオブジェクトです。 |
+
+### getHorizontalOffset() {#getHorizontalOffset--}
+```
+public final float getHorizontalOffset()
+```
+
+
+水平オフセットを取得します。
+
+**Returns:**
+float
+### getVerticalOffset() {#getVerticalOffset--}
+```
+public final float getVerticalOffset()
+```
+
+
+垂直オフセットを取得します。
+
+**Returns:**
+float
+### setHorizontalOffset(float value) {#setHorizontalOffset-float-}
+```
+public final void setHorizontalOffset(float value)
+```
+
+
+水平オフセットを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setVerticalOffset(float value) {#setVerticalOffset-float-}
+```
+public final void setVerticalOffset(float value)
+```
+
+
+垂直オフセットを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+

--- a/japanese/java/com.aspose.note/inknode/_index.md
+++ b/japanese/java/com.aspose.note/inknode/_index.md
@@ -1,0 +1,16 @@
+---
+title: "InkNode"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "すべてのインクノードの共通インターフェイスを表します。"
+type: docs
+weight: 39
+url: /ja/java/com.aspose.note/inknode/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node)
+```
+public abstract class InkNode extends Node
+```
+
+すべてのインクノードの共通インターフェイスを表します。

--- a/japanese/java/com.aspose.note/inkparagraph/_index.md
+++ b/japanese/java/com.aspose.note/inkparagraph/_index.md
@@ -1,0 +1,37 @@
+---
+title: "InkParagraph"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "斜体のような追加プロパティを持つ手書きテキストを含むインクノードを表します。"
+type: docs
+weight: 40
+url: /ja/java/com.aspose.note/inkparagraph/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.InkNode](../../com.aspose.note/inknode)
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode)
+```
+public final class InkParagraph extends InkNode implements IOutlineElementChildNode
+```
+
+斜体のような追加プロパティを持つ手書きテキストを含むインクノードを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | ノードのビジターを受け入れます。 |
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+ノードのビジターを受け入れます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | [DocumentVisitor](../../com.aspose.note/documentvisitor) から派生したクラスのオブジェクトです。 |
+

--- a/japanese/java/com.aspose.note/inkword/_index.md
+++ b/japanese/java/com.aspose.note/inkword/_index.md
@@ -1,0 +1,37 @@
+---
+title: "InkWord"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "手書きテキストを含むインクノードを表します。"
+type: docs
+weight: 41
+url: /ja/java/com.aspose.note/inkword/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.InkNode](../../com.aspose.note/inknode)
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode)
+```
+public final class InkWord extends InkNode implements IOutlineElementChildNode
+```
+
+手書きテキストを含むインクノードを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | ノードのビジターを受け入れます。 |
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+ノードのビジターを受け入れます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | [DocumentVisitor](../../com.aspose.note/documentvisitor) から派生したクラスのオブジェクトです。 |
+

--- a/japanese/java/com.aspose.note/inode/_index.md
+++ b/japanese/java/com.aspose.note/inode/_index.md
@@ -1,0 +1,53 @@
+---
+title: "INode"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "Aspose.Note ドキュメントのすべてのノードのインターフェイスです。"
+type: docs
+weight: 102
+url: /ja/java/com.aspose.note/inode/
+---
+```
+public interface INode
+```
+
+Aspose.Note ドキュメントのすべてのノードのインターフェイスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) |  |
+| [getNextSibling()](#getNextSibling--) |  |
+| [getPreviousSibling()](#getPreviousSibling--) |  |
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public abstract void accept(DocumentVisitor visitor)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) |  |
+
+### getNextSibling() {#getNextSibling--}
+```
+public abstract INode getNextSibling()
+```
+
+
+
+
+**Returns:**
+[INode](../../com.aspose.note/inode)
+### getPreviousSibling() {#getPreviousSibling--}
+```
+public abstract INode getPreviousSibling()
+```
+
+
+
+
+**Returns:**
+[INode](../../com.aspose.note/inode)

--- a/japanese/java/com.aspose.note/inotebookchildnode/_index.md
+++ b/japanese/java/com.aspose.note/inotebookchildnode/_index.md
@@ -1,0 +1,61 @@
+---
+title: "INotebookChildNode"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "Aspose.Note ノートブックの子を表します。"
+type: docs
+weight: 104
+url: /ja/java/com.aspose.note/inotebookchildnode/
+---
+```
+public interface INotebookChildNode
+```
+
+Aspose.Note ノートブックの子要素を表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getColor()](#getColor--) |  |
+| [getDisplayName()](#getDisplayName--) |  |
+| [getGuid()](#getGuid--) |  |
+| [getGuidInternal()](#getGuidInternal--) |  |
+### getColor() {#getColor--}
+```
+public abstract Color getColor()
+```
+
+
+
+
+**Returns:**
+java.awt.Color
+### getDisplayName() {#getDisplayName--}
+```
+public abstract String getDisplayName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getGuid() {#getGuid--}
+```
+public abstract UUID getGuid()
+```
+
+
+
+
+**Returns:**
+java.util.UUID
+### getGuidInternal() {#getGuidInternal--}
+```
+public abstract System.Guid getGuidInternal()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Guid

--- a/japanese/java/com.aspose.note/inotetag/_index.md
+++ b/japanese/java/com.aspose.note/inotetag/_index.md
@@ -1,0 +1,84 @@
+---
+title: "INoteTag"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ノートタグのインターフェイスです（すなわち）。"
+type: docs
+weight: 103
+url: /ja/java/com.aspose.note/inotetag/
+---
+
+**All Implemented Interfaces:**
+[com.aspose.note.ITag](../../com.aspose.note/itag)
+```
+public interface INoteTag extends ITag
+```
+
+ノートタグのインターフェイスです（すなわち、Outlook タスクに関連付けられていないタグ）。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getFontColor()](#getFontColor--) | フォントの色を取得します。 |
+| [getHighlight()](#getHighlight--) | ハイライトの色を取得します。 |
+| [setFontColor(Color value)](#setFontColor-java.awt.Color-) | フォントの色を設定します。 |
+| [setHighlight(Color value)](#setHighlight-java.awt.Color-) | ハイライトの色を設定します。 |
+| [setLabel(String value)](#setLabel-java.lang.String-) | ラベルテキストを設定します。 |
+### getFontColor() {#getFontColor--}
+```
+public abstract Color getFontColor()
+```
+
+
+フォントの色を取得します。
+
+**Returns:**
+java.awt.Color
+### getHighlight() {#getHighlight--}
+```
+public abstract Color getHighlight()
+```
+
+
+ハイライトの色を取得します。
+
+**Returns:**
+java.awt.Color
+### setFontColor(Color value) {#setFontColor-java.awt.Color-}
+```
+public abstract void setFontColor(Color value)
+```
+
+
+フォントの色を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.awt.Color |  |
+
+### setHighlight(Color value) {#setHighlight-java.awt.Color-}
+```
+public abstract void setHighlight(Color value)
+```
+
+
+ハイライトの色を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.awt.Color |  |
+
+### setLabel(String value) {#setLabel-java.lang.String-}
+```
+public abstract void setLabel(String value)
+```
+
+
+ラベルテキストを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+

--- a/japanese/java/com.aspose.note/ioutlinechildnode/_index.md
+++ b/japanese/java/com.aspose.note/ioutlinechildnode/_index.md
@@ -1,0 +1,16 @@
+---
+title: "IOutlineChildNode"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "アウトラインノードのすべての子ノードのインターフェイスです。"
+type: docs
+weight: 105
+url: /ja/java/com.aspose.note/ioutlinechildnode/
+---
+
+**All Implemented Interfaces:**
+[com.aspose.note.INode](../../com.aspose.note/inode)
+```
+public interface IOutlineChildNode extends INode
+```
+
+アウトラインノードのすべての子ノードのインターフェイスです。

--- a/japanese/java/com.aspose.note/ioutlineelementchildnode/_index.md
+++ b/japanese/java/com.aspose.note/ioutlineelementchildnode/_index.md
@@ -1,0 +1,16 @@
+---
+title: "IOutlineElementChildNode"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "アウトライン要素ノードのすべての子ノードのインターフェイスです。"
+type: docs
+weight: 106
+url: /ja/java/com.aspose.note/ioutlineelementchildnode/
+---
+
+**All Implemented Interfaces:**
+[com.aspose.note.INode](../../com.aspose.note/inode)
+```
+public interface IOutlineElementChildNode extends INode
+```
+
+アウトライン要素ノードのすべての子ノードのインターフェイスです。

--- a/japanese/java/com.aspose.note/ipagechildnode/_index.md
+++ b/japanese/java/com.aspose.note/ipagechildnode/_index.md
@@ -1,0 +1,70 @@
+---
+title: "IPageChildNode"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ページノードのすべての子ノードのインターフェイスです。"
+type: docs
+weight: 107
+url: /ja/java/com.aspose.note/ipagechildnode/
+---
+
+**All Implemented Interfaces:**
+[com.aspose.note.INode](../../com.aspose.note/inode)
+```
+public interface IPageChildNode extends INode
+```
+
+ページノードのすべての子ノードのインターフェイスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getHorizontalOffset()](#getHorizontalOffset--) | 水平オフセットを取得または設定します。 |
+| [getVerticalOffset()](#getVerticalOffset--) | 垂直オフセットを取得または設定します。 |
+| [setHorizontalOffset(float value)](#setHorizontalOffset-float-) | 水平オフセットを取得または設定します。 |
+| [setVerticalOffset(float value)](#setVerticalOffset-float-) | 垂直オフセットを取得または設定します。 |
+### getHorizontalOffset() {#getHorizontalOffset--}
+```
+public abstract float getHorizontalOffset()
+```
+
+
+水平オフセットを取得または設定します。
+
+**Returns:**
+float
+### getVerticalOffset() {#getVerticalOffset--}
+```
+public abstract float getVerticalOffset()
+```
+
+
+垂直オフセットを取得または設定します。
+
+**Returns:**
+float
+### setHorizontalOffset(float value) {#setHorizontalOffset-float-}
+```
+public abstract void setHorizontalOffset(float value)
+```
+
+
+水平オフセットを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setVerticalOffset(float value) {#setVerticalOffset-float-}
+```
+public abstract void setVerticalOffset(float value)
+```
+
+
+垂直オフセットを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+

--- a/japanese/java/com.aspose.note/ipagesavingcallback/_index.md
+++ b/japanese/java/com.aspose.note/ipagesavingcallback/_index.md
@@ -1,0 +1,31 @@
+---
+title: "IPageSavingCallback"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "Aspose.Note が個別のページを保存する方法を制御したい場合は、このインターフェイスを実装してください。"
+type: docs
+weight: 108
+url: /ja/java/com.aspose.note/ipagesavingcallback/
+---
+```
+public interface IPageSavingCallback
+```
+
+Aspose.Note が個別のページを保存する方法を制御したい場合は、このインターフェイスを実装してください。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [pageSaving(PageSavingArgs args)](#pageSaving-com.aspose.note.PageSavingArgs-) | Aspose.Note が別々のページを保存するときに呼び出されます。 |
+### pageSaving(PageSavingArgs args) {#pageSaving-com.aspose.note.PageSavingArgs-}
+```
+public abstract void pageSaving(PageSavingArgs args)
+```
+
+
+Aspose.Note が別々のページを保存するときに呼び出されます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| args | [PageSavingArgs](../../com.aspose.note/pagesavingargs) | 保存パラメータです。 |
+

--- a/japanese/java/com.aspose.note/itag/_index.md
+++ b/japanese/java/com.aspose.note/itag/_index.md
@@ -1,0 +1,96 @@
+---
+title: "ITag"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "あらゆる種類のタグのインターフェイスです。"
+type: docs
+weight: 109
+url: /ja/java/com.aspose.note/itag/
+---
+```
+public interface ITag
+```
+
+あらゆる種類のタグのインターフェイスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getCompletedTime()](#getCompletedTime--) | 完了時刻を取得します。 |
+| [getCreationTime()](#getCreationTime--) | 作成時刻を取得します。 |
+| [getIcon()](#getIcon--) | アイコンを取得します。 |
+| [getLabel()](#getLabel--) | ラベルテキストを取得します。 |
+| [getStatus()](#getStatus--) | ステータスを取得します。 |
+| [setCreationTime(Date value)](#setCreationTime-java.util.Date-) | 作成時刻を設定します。 |
+### getCompletedTime() {#getCompletedTime--}
+```
+public abstract Date getCompletedTime()
+```
+
+
+完了時刻を取得します。
+
+値: `Nullable\{DateTime\}`です。
+
+**Returns:**
+java.util.Date
+### getCreationTime() {#getCreationTime--}
+```
+public abstract Date getCreationTime()
+```
+
+
+作成時刻を取得します。
+
+値: java.util.Dateです。
+
+**Returns:**
+java.util.Date
+### getIcon() {#getIcon--}
+```
+public abstract int getIcon()
+```
+
+
+アイコンを取得します。
+
+値: [TagIcon](../../com.aspose.note.infrastructure/tagicon)です。
+
+**Returns:**
+int
+### getLabel() {#getLabel--}
+```
+public abstract String getLabel()
+```
+
+
+ラベルテキストを取得します。
+
+**Returns:**
+java.lang.String
+### getStatus() {#getStatus--}
+```
+public abstract int getStatus()
+```
+
+
+ステータスを取得します。
+
+値: [TagStatus](../../com.aspose.note/tagstatus)です。
+
+**Returns:**
+int
+### setCreationTime(Date value) {#setCreationTime-java.util.Date-}
+```
+public abstract void setCreationTime(Date value)
+```
+
+
+作成時刻を設定します。
+
+値: java.util.Dateです。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Date |  |
+

--- a/japanese/java/com.aspose.note/itaggable/_index.md
+++ b/japanese/java/com.aspose.note/itaggable/_index.md
@@ -1,0 +1,31 @@
+---
+title: "ITaggable"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "タグでマークできるノードのインターフェイスです。"
+type: docs
+weight: 110
+url: /ja/java/com.aspose.note/itaggable/
+---
+
+**All Implemented Interfaces:**
+[com.aspose.note.INode](../../com.aspose.note/inode)
+```
+public interface ITaggable extends INode
+```
+
+タグでマークできるノードのインターフェイスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getTags()](#getTags--) | すべてのタグのリストを取得します。 |
+### getTags() {#getTags--}
+```
+public abstract System.Collections.Generic.List<ITag> getTags()
+```
+
+
+すべてのタグのリストを取得します。
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List&lt;com.aspose.note.ITag&gt;

--- a/japanese/java/com.aspose.note/keeppartandclonesolidobjecttonextpagealgorithm/_index.md
+++ b/japanese/java/com.aspose.note/keeppartandclonesolidobjecttonextpagealgorithm/_index.md
@@ -1,0 +1,71 @@
+---
+title: "KeepPartAndCloneSolidObjectToNextPageAlgorithm"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "オブジェクトの上部をページの下部に追加し、元のページに収まらない場合はオブジェクト全体を次のページにクローンします。"
+type: docs
+weight: 42
+url: /ja/java/com.aspose.note/keeppartandclonesolidobjecttonextpagealgorithm/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm)
+```
+public class KeepPartAndCloneSolidObjectToNextPageAlgorithm extends PageSplittingAlgorithm
+```
+
+オブジェクトの上部をページの下部に追加し、元のページに収まらない場合はオブジェクト全体を次のページにクローンします。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [KeepPartAndCloneSolidObjectToNextPageAlgorithm()](#KeepPartAndCloneSolidObjectToNextPageAlgorithm--) | `KeepPartAndCloneSolidObjectToNextPageAlgorithm` クラスの新しいインスタンスを初期化し、クローン部分のデフォルトの高さ制限を使用します。 |
+| [KeepPartAndCloneSolidObjectToNextPageAlgorithm(float heightLimitOfClonedPart)](#KeepPartAndCloneSolidObjectToNextPageAlgorithm-float-) | `KeepPartAndCloneSolidObjectToNextPageAlgorithm` クラスの新しいインスタンスを初期化し、クローン部分の特定の高さ制限を使用します。 |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [DEFAULT_HEIGHT_LIMIT_OF_CLONED_PART](#DEFAULT-HEIGHT-LIMIT-OF-CLONED-PART) | クローン部分のデフォルトの最大サイズです。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getHeightLimitOfClonedPart()](#getHeightLimitOfClonedPart--) | クローン部分の高さ制限を取得します。 |
+### KeepPartAndCloneSolidObjectToNextPageAlgorithm() {#KeepPartAndCloneSolidObjectToNextPageAlgorithm--}
+```
+public KeepPartAndCloneSolidObjectToNextPageAlgorithm()
+```
+
+
+`KeepPartAndCloneSolidObjectToNextPageAlgorithm` クラスの新しいインスタンスを初期化し、クローン部分のデフォルトの高さ制限を使用します。
+
+### KeepPartAndCloneSolidObjectToNextPageAlgorithm(float heightLimitOfClonedPart) {#KeepPartAndCloneSolidObjectToNextPageAlgorithm-float-}
+```
+public KeepPartAndCloneSolidObjectToNextPageAlgorithm(float heightLimitOfClonedPart)
+```
+
+
+`KeepPartAndCloneSolidObjectToNextPageAlgorithm` クラスの新しいインスタンスを初期化し、クローン部分の特定の高さ制限を使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| heightLimitOfClonedPart | float | クローンされた部分の最大高さ。 |
+
+### DEFAULT_HEIGHT_LIMIT_OF_CLONED_PART {#DEFAULT-HEIGHT-LIMIT-OF-CLONED-PART}
+```
+public static final float DEFAULT_HEIGHT_LIMIT_OF_CLONED_PART
+```
+
+
+クローン部分のデフォルトの最大サイズです。
+
+### getHeightLimitOfClonedPart() {#getHeightLimitOfClonedPart--}
+```
+public float getHeightLimitOfClonedPart()
+```
+
+
+クローン部分の高さ制限を取得します。
+
+**Returns:**
+float

--- a/japanese/java/com.aspose.note/keepsolidobjectsalgorithm/_index.md
+++ b/japanese/java/com.aspose.note/keepsolidobjectsalgorithm/_index.md
@@ -1,0 +1,71 @@
+---
+title: "KeepSolidObjectsAlgorithm"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "オブジェクト全体が元のページに収まらない場合、次のページへシフトします。"
+type: docs
+weight: 43
+url: /ja/java/com.aspose.note/keepsolidobjectsalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm)
+```
+public class KeepSolidObjectsAlgorithm extends PageSplittingAlgorithm
+```
+
+元のページに収まらない場合、オブジェクト全体を次のページへ移動します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [KeepSolidObjectsAlgorithm()](#KeepSolidObjectsAlgorithm--) | `KeepSolidObjectsAlgorithm` クラスの新しいインスタンスを、クローンされた部分のデフォルト高さ制限を使用して初期化します。 |
+| [KeepSolidObjectsAlgorithm(float heightLimitOfClonedPart)](#KeepSolidObjectsAlgorithm-float-) | `KeepSolidObjectsAlgorithm` クラスの新しいインスタンスを、クローンされた部分の特定の高さ制限を使用して初期化します。 |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [DEFAULT_HEIGHT_LIMIT_OF_CLONED_PART](#DEFAULT-HEIGHT-LIMIT-OF-CLONED-PART) | クローン部分のデフォルトの最大サイズです。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getHeightLimitOfClonedPart()](#getHeightLimitOfClonedPart--) | クローン部分の高さ制限を取得します。 |
+### KeepSolidObjectsAlgorithm() {#KeepSolidObjectsAlgorithm--}
+```
+public KeepSolidObjectsAlgorithm()
+```
+
+
+`KeepSolidObjectsAlgorithm` クラスの新しいインスタンスを、クローンされた部分のデフォルト高さ制限を使用して初期化します。
+
+### KeepSolidObjectsAlgorithm(float heightLimitOfClonedPart) {#KeepSolidObjectsAlgorithm-float-}
+```
+public KeepSolidObjectsAlgorithm(float heightLimitOfClonedPart)
+```
+
+
+`KeepSolidObjectsAlgorithm` クラスの新しいインスタンスを、クローンされた部分の特定の高さ制限を使用して初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| heightLimitOfClonedPart | float | クローンされた部分の最大高さ。 |
+
+### DEFAULT_HEIGHT_LIMIT_OF_CLONED_PART {#DEFAULT-HEIGHT-LIMIT-OF-CLONED-PART}
+```
+public static final float DEFAULT_HEIGHT_LIMIT_OF_CLONED_PART
+```
+
+
+クローン部分のデフォルトの最大サイズです。
+
+### getHeightLimitOfClonedPart() {#getHeightLimitOfClonedPart--}
+```
+public float getHeightLimitOfClonedPart()
+```
+
+
+クローン部分の高さ制限を取得します。
+
+**Returns:**
+float

--- a/japanese/java/com.aspose.note/license/_index.md
+++ b/japanese/java/com.aspose.note/license/_index.md
@@ -1,0 +1,142 @@
+---
+title: "License"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "コンポーネントをライセンスするためのメソッドを提供します。"
+type: docs
+weight: 44
+url: /ja/java/com.aspose.note/license/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class License
+```
+
+コンポーネントをライセンスするためのメソッドを提供します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [License()](#License--) | このクラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [resetThreadContext()](#resetThreadContext--) | 現在のスレッドのライセンス コンテキストをリセットします。 |
+| [setLicense(File licenseFile)](#setLicense-java.io.File-) | コンポーネントにライセンスを付与します。 |
+| [setLicense(InputStream stream)](#setLicense-java.io.InputStream-) | コンポーネントにライセンスを付与します。 |
+| [setLicense(String licenseName)](#setLicense-java.lang.String-) | コンポーネントにライセンスを付与します。 |
+| [setThreadContext(InputStream stream)](#setThreadContext-java.io.InputStream-) | 現在のスレッドのライセンス コンテキストを設定します。 |
+### License() {#License--}
+```
+public License()
+```
+
+
+このクラスの新しいインスタンスを初期化します。
+
+### resetThreadContext() {#resetThreadContext--}
+```
+public static void resetThreadContext()
+```
+
+
+現在のスレッドのライセンス コンテキストをリセットします。
+
+### setLicense(File licenseFile) {#setLicense-java.io.File-}
+```
+public void setLicense(File licenseFile)
+```
+
+
+コンポーネントにライセンスを付与します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| licenseFile | java.io.File | ライセンスのファイル`System.IO.FileInfo`。 |
+
+### setLicense(InputStream stream) {#setLicense-java.io.InputStream-}
+```
+public final void setLicense(InputStream stream)
+```
+
+
+コンポーネントにライセンスを付与します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+|  | ストリーム | java.io.InputStream | ライセンスを含むストリームです。 |
+
+--------------------
+
+`
+
+このメソッドを使用して、ストリームからライセンスをロードします。
+
+`
+
+`void setLicense(java.io.InputStream stream)` |
+
+### setLicense(String licenseName) {#setLicense-java.lang.String-}
+```
+public final void setLicense(String licenseName)
+```
+
+
+コンポーネントにライセンスを付与します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+|  | licenseName | java.lang.String | 完全または短いファイル名`または埋め込みリソースの名前`にすることができます。空文字列を使用すると評価モードに切り替わります。 |
+
+--------------------
+
+`
+
+次の場所でライセンスを検索します:
+
+` `
+
+1. 明示的なパス。
+
+` `
+
+2. Aspose コンポーネント アセンブリを含むフォルダー。
+
+3. クライアントの呼び出しアセンブリを含むフォルダー。
+
+4. エントリ（スタートアップ）アセンブリを含むフォルダー。
+
+5. クライアントの呼び出しアセンブリ内の埋め込みリソース。
+
+**Note:**On the .NET Compact Framework, tries to find the license only in these locations:
+
+1. 明示的なパス。
+
+2. クライアントの呼び出しアセンブリ内の埋め込みリソース。
+
+` `
+
+2. Aspose コンポーネント JAR ファイルを含むフォルダー。
+
+3. クライアントの呼び出し JAR ファイルを含むフォルダー。
+
+` |
+
+### setThreadContext(InputStream stream) {#setThreadContext-java.io.InputStream-}
+```
+public static void setThreadContext(InputStream stream)
+```
+
+
+現在のスレッドのライセンス コンテキストを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | ライセンスを含むストリームです。 |
+

--- a/japanese/java/com.aspose.note/licenseexceptions/_index.md
+++ b/japanese/java/com.aspose.note/licenseexceptions/_index.md
@@ -1,0 +1,145 @@
+---
+title: "LicenseExceptions"
+second_title: "Aspose.Note for Java API リファレンス"
+description: 
+type: docs
+weight: 45
+url: /ja/java/com.aspose.note/licenseexceptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LicenseExceptions
+```
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [LicenseExceptions()](#LicenseExceptions--) |  |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [BlackListedLicense_ExceptionMessage](#BlackListedLicense-ExceptionMessage) |  |
+| [ExpiredLicense_ExceptionMessage](#ExpiredLicense-ExceptionMessage) |  |
+| [InvalidBlackListResourceName_ExceptionMessage](#InvalidBlackListResourceName-ExceptionMessage) |  |
+| [InvalidEditionType_ExceptionMessage](#InvalidEditionType-ExceptionMessage) |  |
+| [InvalidLicenseSignature_ExceptionMessage](#InvalidLicenseSignature-ExceptionMessage) |  |
+| [InvalidProduct_ExceptionMessage](#InvalidProduct-ExceptionMessage) |  |
+| [InvalidSignatureBlackList_ExceptionMessage](#InvalidSignatureBlackList-ExceptionMessage) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [throwBlackListedLicense()](#throwBlackListedLicense--) |  |
+| [throwExpiredLicense()](#throwExpiredLicense--) |  |
+| [throwInvalidBlackListResourceName()](#throwInvalidBlackListResourceName--) |  |
+| [throwInvalidEditionType()](#throwInvalidEditionType--) |  |
+| [throwInvalidLicense()](#throwInvalidLicense--) |  |
+| [throwInvalidProduct()](#throwInvalidProduct--) |  |
+| [throwInvalidSignatureBlackList()](#throwInvalidSignatureBlackList--) |  |
+### LicenseExceptions() {#LicenseExceptions--}
+```
+public LicenseExceptions()
+```
+
+
+### BlackListedLicense_ExceptionMessage {#BlackListedLicense-ExceptionMessage}
+```
+public static final String BlackListedLicense_ExceptionMessage
+```
+
+
+### ExpiredLicense_ExceptionMessage {#ExpiredLicense-ExceptionMessage}
+```
+public static final String ExpiredLicense_ExceptionMessage
+```
+
+
+### InvalidBlackListResourceName_ExceptionMessage {#InvalidBlackListResourceName-ExceptionMessage}
+```
+public static final String InvalidBlackListResourceName_ExceptionMessage
+```
+
+
+### InvalidEditionType_ExceptionMessage {#InvalidEditionType-ExceptionMessage}
+```
+public static final String InvalidEditionType_ExceptionMessage
+```
+
+
+### InvalidLicenseSignature_ExceptionMessage {#InvalidLicenseSignature-ExceptionMessage}
+```
+public static final String InvalidLicenseSignature_ExceptionMessage
+```
+
+
+### InvalidProduct_ExceptionMessage {#InvalidProduct-ExceptionMessage}
+```
+public static final String InvalidProduct_ExceptionMessage
+```
+
+
+### InvalidSignatureBlackList_ExceptionMessage {#InvalidSignatureBlackList-ExceptionMessage}
+```
+public static final String InvalidSignatureBlackList_ExceptionMessage
+```
+
+
+### throwBlackListedLicense() {#throwBlackListedLicense--}
+```
+public static void throwBlackListedLicense()
+```
+
+
+
+
+### throwExpiredLicense() {#throwExpiredLicense--}
+```
+public static void throwExpiredLicense()
+```
+
+
+
+
+### throwInvalidBlackListResourceName() {#throwInvalidBlackListResourceName--}
+```
+public static void throwInvalidBlackListResourceName()
+```
+
+
+
+
+### throwInvalidEditionType() {#throwInvalidEditionType--}
+```
+public static void throwInvalidEditionType()
+```
+
+
+
+
+### throwInvalidLicense() {#throwInvalidLicense--}
+```
+public static void throwInvalidLicense()
+```
+
+
+
+
+### throwInvalidProduct() {#throwInvalidProduct--}
+```
+public static void throwInvalidProduct()
+```
+
+
+
+
+### throwInvalidSignatureBlackList() {#throwInvalidSignatureBlackList--}
+```
+public static void throwInvalidSignatureBlackList()
+```
+
+
+
+

--- a/japanese/java/com.aspose.note/loadoptions/_index.md
+++ b/japanese/java/com.aspose.note/loadoptions/_index.md
@@ -1,0 +1,83 @@
+---
+title: "LoadOptions"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ドキュメントの読み込みに使用されるオプションです。"
+type: docs
+weight: 46
+url: /ja/java/com.aspose.note/loadoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LoadOptions
+```
+
+ドキュメントの読み込みに使用されるオプションです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [LoadOptions()](#LoadOptions--) | `LoadOptions` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getDocumentPassword()](#getDocumentPassword--) | 暗号化されたドキュメントコンテンツのパスワードを取得または設定します。 |
+| [getLoadHistory()](#getLoadHistory--) | ドキュメントローダーが履歴を無視すべきかどうかを示す値を取得または設定します。 |
+| [setDocumentPassword(String value)](#setDocumentPassword-java.lang.String-) | 暗号化されたドキュメントコンテンツのパスワードを取得または設定します。 |
+| [setLoadHistory(boolean value)](#setLoadHistory-boolean-) | ドキュメントローダーが履歴を無視すべきかどうかを示す値を取得または設定します。 |
+### LoadOptions() {#LoadOptions--}
+```
+public LoadOptions()
+```
+
+
+`LoadOptions` クラスの新しいインスタンスを初期化します。
+
+### getDocumentPassword() {#getDocumentPassword--}
+```
+public String getDocumentPassword()
+```
+
+
+暗号化されたドキュメントコンテンツのパスワードを取得または設定します。ドキュメントがパスワードで保護されていない場合、この値は無視されます。
+
+**Returns:**
+java.lang.String
+### getLoadHistory() {#getLoadHistory--}
+```
+public boolean getLoadHistory()
+```
+
+
+ドキュメントローダーが履歴を無視すべきかどうかを示す値を取得または設定します。このオプションを使用するとメモリと CPU の使用量を減らすことができます。デフォルト値は `true` です。
+
+**Returns:**
+boolean
+### setDocumentPassword(String value) {#setDocumentPassword-java.lang.String-}
+```
+public void setDocumentPassword(String value)
+```
+
+
+暗号化されたドキュメントコンテンツのパスワードを取得または設定します。ドキュメントがパスワードで保護されていない場合、この値は無視されます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setLoadHistory(boolean value) {#setLoadHistory-boolean-}
+```
+public void setLoadHistory(boolean value)
+```
+
+
+ドキュメントローダーが履歴を無視すべきかどうかを示す値を取得または設定します。このオプションを使用するとメモリと CPU の使用量を減らすことができます。デフォルト値は `true` です。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+

--- a/japanese/java/com.aspose.note/localeoptions/_index.md
+++ b/japanese/java/com.aspose.note/localeoptions/_index.md
@@ -1,0 +1,65 @@
+---
+title: "LocaleOptions"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "LocaleOptions 型は Aspose.Note のロケール構成を指定します。"
+type: docs
+weight: 47
+url: /ja/java/com.aspose.note/localeoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LocaleOptions
+```
+
+LocaleOptions 型は Aspose.Note のロケール構成を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [LocaleOptions()](#LocaleOptions--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clear()](#clear--) | Aspose.Note の既定ロケールをクリアします。 |
+| [getLocale()](#getLocale--) | Aspose.Note の現在の実際の既定ロケールを取得します |
+| [setLocale(Locale local)](#setLocale-java.util.Locale-) | Aspose.Note に関連する既定ロケールを設定します。 |
+### LocaleOptions() {#LocaleOptions--}
+```
+public LocaleOptions()
+```
+
+
+### clear() {#clear--}
+```
+public static void clear()
+```
+
+
+Aspose.Note の既定ロケールをクリアします。Java の既定ロケールが使用されます。
+
+### getLocale() {#getLocale--}
+```
+public static Locale getLocale()
+```
+
+
+Aspose.Note の現在の実際の既定ロケールを取得します
+
+**Returns:**
+java.util.Locale - ロケールインスタンス
+### setLocale(Locale local) {#setLocale-java.util.Locale-}
+```
+public static void setLocale(Locale local)
+```
+
+
+Aspose.Note に関連する既定ロケールを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ローカル | java.util.Locale | ロケールインスタンス |
+

--- a/japanese/java/com.aspose.note/loop/_index.md
+++ b/japanese/java/com.aspose.note/loop/_index.md
@@ -1,0 +1,100 @@
+---
+title: "Loop"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ループを表します。"
+type: docs
+weight: 48
+url: /ja/java/com.aspose.note/loop/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node)
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode)
+```
+public class Loop extends Node implements IOutlineElementChildNode
+```
+
+ループを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Loop()](#Loop--) | `Loop` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | ノードのビジターを受け入れます。 |
+| [getHyperlinkUrl()](#getHyperlinkUrl--) | ハイパーリンクを取得します。 |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 最終更新時刻を取得します。 |
+| [setHyperlinkUrl(String value)](#setHyperlinkUrl-java.lang.String-) | ハイパーリンクを設定します。 |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 最終更新時刻を設定します。 |
+### Loop() {#Loop--}
+```
+public Loop()
+```
+
+
+`Loop` クラスの新しいインスタンスを初期化します。
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+ノードのビジターを受け入れます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor` から派生したクラスのオブジェクト。 |
+
+### getHyperlinkUrl() {#getHyperlinkUrl--}
+```
+public String getHyperlinkUrl()
+```
+
+
+ハイパーリンクを取得します。
+
+**Returns:**
+java.lang.String
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+最終更新時刻を取得します。
+
+**Returns:**
+java.util.Date
+### setHyperlinkUrl(String value) {#setHyperlinkUrl-java.lang.String-}
+```
+public void setHyperlinkUrl(String value)
+```
+
+
+ハイパーリンクを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+最終更新時刻を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Date |  |
+

--- a/japanese/java/com.aspose.note/margins/_index.md
+++ b/japanese/java/com.aspose.note/margins/_index.md
@@ -1,0 +1,283 @@
+---
+title: "Margins"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ノードの余白の寸法を指定します。"
+type: docs
+weight: 49
+url: /ja/java/com.aspose.note/margins/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.lang.Struct
+
+**All Implemented Interfaces:**
+com.aspose.ms.System.IEquatable
+```
+public class Margins extends Struct<Margins> implements System.IEquatable<Margins>
+```
+
+ノードの余白の寸法を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Margins()](#Margins--) |  |
+| [Margins(float left, float right, float top, float bottom)](#Margins-float-float-float-float-) | `Margins` 構造体の新しいインスタンスを、指定された左、右、上、下の余白で初期化します。 |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Empty](#Empty) | 空の余白です。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [Clone()](#Clone--) |  |
+| [CloneTo(Margins that)](#CloneTo-com.aspose.note.Margins-) |  |
+| [clone()](#clone--) |  |
+| [equals(Margins other)](#equals-com.aspose.note.Margins-) |  |
+| [equals(Margins obj1, Margins obj2)](#equals-com.aspose.note.Margins-com.aspose.note.Margins-) |  |
+| [equals(Object obj)](#equals-java.lang.Object-) | 2つの `T:Margins` 構造体が等しいかテストします。 |
+| [getBottom()](#getBottom--) | 下余白の幅を取得または設定します。 |
+| [getLeft()](#getLeft--) | 左余白の幅を取得または設定します。 |
+| [getRight()](#getRight--) | 右余白の幅を取得または設定します。 |
+| [getTop()](#getTop--) | 上余白の幅を取得または設定します。 |
+| [op_Equality(Margins lhs, Margins rhs)](#op-Equality-com.aspose.note.Margins-com.aspose.note.Margins-) | 2つの `T:Margins` 構造体が等しいかテストします。 |
+| [op_Inequality(Margins lhs, Margins rhs)](#op-Inequality-com.aspose.note.Margins-com.aspose.note.Margins-) | 2つの `T:Margins` 構造体が等しくないかテストします。 |
+| [setBottom(float value)](#setBottom-float-) | 下余白の幅を取得または設定します。 |
+| [setLeft(float value)](#setLeft-float-) | 左余白の幅を取得または設定します。 |
+| [setRight(float value)](#setRight-float-) | 右余白の幅を取得または設定します。 |
+| [setTop(float value)](#setTop-float-) | 上余白の幅を取得または設定します。 |
+### Margins() {#Margins--}
+```
+public Margins()
+```
+
+
+### Margins(float left, float right, float top, float bottom) {#Margins-float-float-float-float-}
+```
+public Margins(float left, float right, float top, float bottom)
+```
+
+
+`Margins` 構造体の新しいインスタンスを、指定された左、右、上、下の余白で初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 左 | float | 左余白の幅です。 |
+| 右 | float | 右余白の幅です。 |
+| 上 | float | 上余白の幅です。 |
+| 下 | float | 下余白の幅です。 |
+
+### Empty {#Empty}
+```
+public static final Margins Empty
+```
+
+
+空の余白です。
+
+### Clone() {#Clone--}
+```
+public Margins Clone()
+```
+
+
+
+
+**Returns:**
+[Margins](../../com.aspose.note/margins)
+### CloneTo(Margins that) {#CloneTo-com.aspose.note.Margins-}
+```
+public void CloneTo(Margins that)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| that | [Margins](../../com.aspose.note/margins) |  |
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### equals(Margins other) {#equals-com.aspose.note.Margins-}
+```
+public boolean equals(Margins other)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| other | [Margins](../../com.aspose.note/margins) |  |
+
+**Returns:**
+boolean
+### equals(Margins obj1, Margins obj2) {#equals-com.aspose.note.Margins-com.aspose.note.Margins-}
+```
+public static boolean equals(Margins obj1, Margins obj2)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| obj1 | [Margins](../../com.aspose.note/margins) |  |
+| obj2 | [Margins](../../com.aspose.note/margins) |  |
+
+**Returns:**
+boolean
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+2つの `T:Margins` 構造体が等しいかテストします。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| obj | java.lang.Object | 任意のオブジェクト。 |
+
+**Returns:**
+boolean - `bool`です。
+### getBottom() {#getBottom--}
+```
+public float getBottom()
+```
+
+
+下余白の幅を取得または設定します。
+
+**Returns:**
+float
+### getLeft() {#getLeft--}
+```
+public float getLeft()
+```
+
+
+左余白の幅を取得または設定します。
+
+**Returns:**
+float
+### getRight() {#getRight--}
+```
+public float getRight()
+```
+
+
+右余白の幅を取得または設定します。
+
+**Returns:**
+float
+### getTop() {#getTop--}
+```
+public float getTop()
+```
+
+
+上余白の幅を取得または設定します。
+
+**Returns:**
+float
+### op_Equality(Margins lhs, Margins rhs) {#op-Equality-com.aspose.note.Margins-com.aspose.note.Margins-}
+```
+public static boolean op_Equality(Margins lhs, Margins rhs)
+```
+
+
+2つの `T:Margins` 構造体が等しいかテストします。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| lhs | [Margins](../../com.aspose.note/margins) | `T:Margins` 構造体です。 |
+| rhs | [Margins](../../com.aspose.note/margins) | 比較対象となる `T:Margins` 構造体です。 |
+
+**Returns:**
+boolean - `bool`です。
+### op_Inequality(Margins lhs, Margins rhs) {#op-Inequality-com.aspose.note.Margins-com.aspose.note.Margins-}
+```
+public static boolean op_Inequality(Margins lhs, Margins rhs)
+```
+
+
+2つの `T:Margins` 構造体が等しくないかテストします。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| lhs | [Margins](../../com.aspose.note/margins) | `T:Margins` 構造体です。 |
+| rhs | [Margins](../../com.aspose.note/margins) | 比較対象となる `T:Margins` 構造体です。 |
+
+**Returns:**
+boolean - `bool`です。
+### setBottom(float value) {#setBottom-float-}
+```
+public void setBottom(float value)
+```
+
+
+下余白の幅を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setLeft(float value) {#setLeft-float-}
+```
+public void setLeft(float value)
+```
+
+
+左余白の幅を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setRight(float value) {#setRight-float-}
+```
+public void setRight(float value)
+```
+
+
+右余白の幅を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setTop(float value) {#setTop-float-}
+```
+public void setTop(float value)
+```
+
+
+上余白の幅を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+

--- a/japanese/java/com.aspose.note/metered/_index.md
+++ b/japanese/java/com.aspose.note/metered/_index.md
@@ -1,0 +1,108 @@
+---
+title: "Metered"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "メーターキーを設定するためのメソッドを提供します。"
+type: docs
+weight: 50
+url: /ja/java/com.aspose.note/metered/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Metered
+```
+
+メーターキーを設定するためのメソッドを提供します。
+
+--------------------
+
+&gt; ```
+&gt; この例では、metered の公開キーと秘密キーを設定しようとします
+&gt; ``````
+
+  [C#]
+
+Metered metered = new Metered();
+metered.SetMeteredKey("PublicKey", "PrivateKey");
+  [Visual Basic]
+Dim metered As Metered = New Metered
+metered.SetMeteredKey("PublicKey", "PrivateKey")
+  
+```
+
+the component jar file:
+
+```
+
+Metered metered = new Metered();
+metered.setMeteredKey("PublicKey", "PrivateKey");
+  
+```
+
+
+## Constructors
+
+| Constructor | Description |
+| --- | --- |
+| [Metered()](#Metered--) |  |
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getConsumptionCredit()](#getConsumptionCredit--) | Gets consumption credit. |
+| [getConsumptionQuantity()](#getConsumptionQuantity--) | Gets consumption file size. |
+| [resetMeteredKey()](#resetMeteredKey--) | Removes previously setup license. |
+| [setMeteredKey(String publicKey, String privateKey)](#setMeteredKey-java.lang.String-java.lang.String-) | Sets metered public and private keys. |
+### Metered() {#Metered--}
+```
+public Metered()
+```
+
+
+### getConsumptionCredit() {#getConsumptionCredit--}
+```
+public static BigDecimal getConsumptionCredit()
+```
+
+
+Gets consumption credit.
+
+**Returns:**
+java.math.BigDecimal - Returns the number of consumed credit points.
+### getConsumptionQuantity() {#getConsumptionQuantity--}
+```
+public static BigDecimal getConsumptionQuantity()
+```
+
+
+Gets consumption file size.
+
+**Returns:**
+java.math.BigDecimal - Returns the number of consumed bytes.
+### resetMeteredKey() {#resetMeteredKey--}
+```
+public final void resetMeteredKey()
+```
+
+
+Removes previously setup license.
+
+### setMeteredKey(String publicKey, String privateKey) {#setMeteredKey-java.lang.String-java.lang.String-}
+```
+public final void setMeteredKey(String publicKey, String privateKey)
+```
+
+
+Sets metered public and private keys.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| publicKey | java.lang.String | The public key. |
+| privateKey | java.lang.String | The private key.
+
+--------------------
+
+If you purchase metered license, this API should be called on application startup, normally, this is enough. However, if metered fails to upload consumption data during 24 hours period, the license will be set to evaluation status. To avoid such case, you should regularly check the license status If it is evaluation status, call this API again. |
+

--- a/japanese/java/com.aspose.note/node/_index.md
+++ b/japanese/java/com.aspose.note/node/_index.md
@@ -1,0 +1,120 @@
+---
+title: "ノード"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "Aspose.Note ドキュメントのすべてのノードの基底クラスです。"
+type: docs
+weight: 51
+url: /ja/java/com.aspose.note/node/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.note.INode](../../com.aspose.note/inode)
+```
+public abstract class Node implements INode
+```
+
+Aspose.Note ドキュメントのすべてのノードの基底クラスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | ノードのビジターを受け入れます。 |
+| [getDocument()](#getDocument--) | ノードのドキュメントを取得します。 |
+| [getNextSibling()](#getNextSibling--) | 同じノードツリー階層の次のノードを取得します。 |
+| [getNodeId()](#getNodeId--) | ノードの ID を取得します。 |
+| [getNodeType()](#getNodeType--) | ノードのタイプを取得します。 |
+| [getParentNode()](#getParentNode--) | 親ノードを取得します。 |
+| [getPreviousSibling()](#getPreviousSibling--) | 同じノードツリー階層の前のノードを取得します。 |
+| [isComposite()](#isComposite--) | このノードが複合ノードかどうかを示す値を取得します。 |
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public abstract void accept(DocumentVisitor visitor)
+```
+
+
+ノードのビジターを受け入れます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor` から派生したクラスのオブジェクト。 |
+
+### getDocument() {#getDocument--}
+```
+public Document getDocument()
+```
+
+
+ノードのドキュメントを取得します。
+
+値: ドキュメント。
+
+**Returns:**
+[Document](../../com.aspose.note/document)
+### getNextSibling() {#getNextSibling--}
+```
+public INode getNextSibling()
+```
+
+
+同じノードツリー階層の次のノードを取得します。
+
+値: 次の兄弟要素。
+
+**Returns:**
+[INode](../../com.aspose.note/inode)
+### getNodeId() {#getNodeId--}
+```
+public ExtendedGuid getNodeId()
+```
+
+
+ノードの ID を取得します。
+
+**Returns:**
+[ExtendedGuid](../../com.aspose.note.revision.types/extendedguid)
+### getNodeType() {#getNodeType--}
+```
+public int getNodeType()
+```
+
+
+ノードのタイプを取得します。
+
+**Returns:**
+int
+### getParentNode() {#getParentNode--}
+```
+public ICompositeNode getParentNode()
+```
+
+
+親ノードを取得します。
+
+**Returns:**
+[ICompositeNode](../../com.aspose.note/icompositenode)
+### getPreviousSibling() {#getPreviousSibling--}
+```
+public INode getPreviousSibling()
+```
+
+
+同じノードツリー階層の前のノードを取得します。
+
+値: 前の兄弟要素。
+
+**Returns:**
+[INode](../../com.aspose.note/inode)
+### isComposite() {#isComposite--}
+```
+public boolean isComposite()
+```
+
+
+このノードが複合ノードかどうかを示す値を取得します。true の場合、ノードは子ノードを持つことができます。
+
+**Returns:**
+boolean

--- a/japanese/java/com.aspose.note/nodetype/_index.md
+++ b/japanese/java/com.aspose.note/nodetype/_index.md
@@ -1,0 +1,182 @@
+---
+title: "NodeType"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ノードのタイプを指定します。"
+type: docs
+weight: 52
+url: /ja/java/com.aspose.note/nodetype/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class NodeType extends System.Enum
+```
+
+ノードのタイプを指定します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [AttachedFile](#AttachedFile) | ノードが `AttachedFile` であることを指定します。 |
+| [Document](#Document) | ノードが `Document` であることを指定します。 |
+| [Image](#Image) | ノードが `Image` であることを指定します。 |
+| [InkDrawing](#InkDrawing) | ノードが [InkDrawing](../../com.aspose.note/nodetype\#InkDrawing) であることを指定します。 |
+| [InkParagraph](#InkParagraph) | ノードが [InkParagraph](../../com.aspose.note/nodetype\#InkParagraph) であることを指定します。 |
+| [InkWord](#InkWord) | ノードが [InkWord](../../com.aspose.note/nodetype\#InkWord) であることを指定します。 |
+| [Loop](#Loop) | ノードが [Loop](../../com.aspose.note/nodetype\#Loop) であることを指定します。 |
+| [Outline](#Outline) | ノードが `Outline` であることを指定します。 |
+| [OutlineElement](#OutlineElement) | ノードが `OutlineElement` であることを指定します。 |
+| [OutlineGroup](#OutlineGroup) | ノードが `OutlineGroup` であることを指定します。 |
+| [Page](#Page) | ノードが `Page` であることを指定します。 |
+| [PageSeries](#PageSeries) | ノードが `PageSeries` であることを指定します。 |
+| [RichText](#RichText) | ノードが `RichText` であることを指定します。 |
+| [Section](#Section) | ノードが `Section` であることを指定します。 |
+| [Table](#Table) | ノードが `Table` であることを指定します。 |
+| [TableCell](#TableCell) | ノードが `TableCell` であることを指定します。 |
+| [TableRow](#TableRow) | ノードが `TableRow` であることを指定します。 |
+| [Title](#Title) | ノードが `Title` であることを指定します。 |
+### AttachedFile {#AttachedFile}
+```
+public static final int AttachedFile
+```
+
+
+ノードが `AttachedFile` であることを指定します。
+
+### Document {#Document}
+```
+public static final int Document
+```
+
+
+ノードが `Document` であることを指定します。
+
+### Image {#Image}
+```
+public static final int Image
+```
+
+
+ノードが `Image` であることを指定します。
+
+### InkDrawing {#InkDrawing}
+```
+public static final int InkDrawing
+```
+
+
+ノードが [InkDrawing](../../com.aspose.note/nodetype\#InkDrawing) であることを指定します。
+
+### InkParagraph {#InkParagraph}
+```
+public static final int InkParagraph
+```
+
+
+ノードが [InkParagraph](../../com.aspose.note/nodetype\#InkParagraph) であることを指定します。
+
+### InkWord {#InkWord}
+```
+public static final int InkWord
+```
+
+
+ノードが [InkWord](../../com.aspose.note/nodetype\#InkWord) であることを指定します。
+
+### Loop {#Loop}
+```
+public static final int Loop
+```
+
+
+ノードが [Loop](../../com.aspose.note/nodetype\#Loop) であることを指定します。
+
+### Outline {#Outline}
+```
+public static final int Outline
+```
+
+
+ノードが `Outline` であることを指定します。
+
+### OutlineElement {#OutlineElement}
+```
+public static final int OutlineElement
+```
+
+
+ノードが `OutlineElement` であることを指定します。
+
+### OutlineGroup {#OutlineGroup}
+```
+public static final int OutlineGroup
+```
+
+
+ノードが `OutlineGroup` であることを指定します。
+
+### Page {#Page}
+```
+public static final int Page
+```
+
+
+ノードが `Page` であることを指定します。
+
+### PageSeries {#PageSeries}
+```
+public static final int PageSeries
+```
+
+
+ノードが `PageSeries` であることを指定します。
+
+### RichText {#RichText}
+```
+public static final int RichText
+```
+
+
+ノードが `RichText` であることを指定します。
+
+### Section {#Section}
+```
+public static final int Section
+```
+
+
+ノードが `Section` であることを指定します。
+
+### Table {#Table}
+```
+public static final int Table
+```
+
+
+ノードが `Table` であることを指定します。
+
+### TableCell {#TableCell}
+```
+public static final int TableCell
+```
+
+
+ノードが `TableCell` であることを指定します。
+
+### TableRow {#TableRow}
+```
+public static final int TableRow
+```
+
+
+ノードが `TableRow` であることを指定します。
+
+### Title {#Title}
+```
+public static final int Title
+```
+
+
+ノードが `Title` であることを指定します。
+

--- a/japanese/java/com.aspose.note/notebook/_index.md
+++ b/japanese/java/com.aspose.note/notebook/_index.md
@@ -1,0 +1,438 @@
+---
+title: "ノートブック"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "Aspose.Note ノートブックを表します。"
+type: docs
+weight: 56
+url: /ja/java/com.aspose.note/notebook/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.note.INotebookChildNode](../../com.aspose.note/inotebookchildnode), com.aspose.ms.System.Collections.Generic.IGenericEnumerable
+```
+public class Notebook implements INotebookChildNode, System.Collections.Generic.IGenericEnumerable<INotebookChildNode>
+```
+
+Aspose.Note ノートブックを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Notebook()](#Notebook--) | `Notebook` クラスの新しいインスタンスを初期化します。 |
+| [Notebook(String filePath)](#Notebook-java.lang.String-) | `Notebook` クラスの新しいインスタンスを初期化します。 |
+| [Notebook(String filePath, NotebookLoadOptions loadOptions)](#Notebook-java.lang.String-com.aspose.note.NotebookLoadOptions-) | `Notebook` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [&lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass)](#-T1-getChildNodes-java.lang.Class-T1--) | ノードのタイプで子ノードをすべて取得します。 |
+| [appendChild(INotebookChildNode newChild)](#appendChild-com.aspose.note.INotebookChildNode-) | ノードをリストの末尾に追加します。 |
+| [getColor()](#getColor--) | 色を取得または設定します。 |
+| [getCount()](#getCount--) | `Notebook` に含まれる要素数を取得します。 |
+| [getDisplayName()](#getDisplayName--) | 表示名を取得または設定します。 |
+| [getFileFormat()](#getFileFormat--) | ファイル形式を取得します（OneNote 2010、OneNote Online）。 |
+| [getGuid()](#getGuid--) | オブジェクトのグローバルに一意な ID を取得します。 |
+| [getGuidInternal()](#getGuidInternal--) |  |
+| [get_Item(int index)](#get-Item-int-) | 指定されたインデックスでノートブックの子ノードを取得します。 |
+| [isHistoryEnabled()](#isHistoryEnabled--) | 履歴が有効かどうかを示す値を取得または設定します。 |
+| [iterator()](#iterator--) | `Notebook` の子ノードを列挙する列挙子を返します。 |
+| [loadChildDocument(InputStream stream)](#loadChildDocument-java.io.InputStream-) | 子ドキュメントノードを追加します。 |
+| [loadChildDocument(InputStream stream, LoadOptions loadOptions)](#loadChildDocument-java.io.InputStream-com.aspose.note.LoadOptions-) | 子ドキュメントノードを追加します。 |
+| [loadChildDocument(String filePath)](#loadChildDocument-java.lang.String-) | 子ドキュメントノードを追加します。 |
+| [loadChildDocument(String filePath, LoadOptions loadOptions)](#loadChildDocument-java.lang.String-com.aspose.note.LoadOptions-) | 子ドキュメントノードを追加します。 |
+| [loadChildNotebook(String filePath)](#loadChildNotebook-java.lang.String-) | 子ノートブックノードを追加します。 |
+| [loadChildNotebook(String filePath, NotebookLoadOptions loadOptions)](#loadChildNotebook-java.lang.String-com.aspose.note.NotebookLoadOptions-) | 子ノートブックノードを追加します。 |
+| [removeChild(INotebookChildNode oldChild)](#removeChild-com.aspose.note.INotebookChildNode-) | 子ノードを削除します。 |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | OneNote ドキュメントをストリームに保存します。 |
+| [save(OutputStream stream, NotebookSaveOptions options)](#save-java.io.OutputStream-com.aspose.note.NotebookSaveOptions-) | 指定された保存オプションを使用して OneNote ドキュメントをストリームに保存します。 |
+| [save(OutputStream stream, int format)](#save-java.io.OutputStream-int-) | 指定された形式で OneNote ドキュメントをストリームに保存します。 |
+| [save(String fileName)](#save-java.lang.String-) | OneNote ドキュメントをファイルに保存します。 |
+| [save(String fileName, NotebookSaveOptions options)](#save-java.lang.String-com.aspose.note.NotebookSaveOptions-) | 指定された保存オプションを使用して OneNote ドキュメントをファイルに保存します。 |
+| [save(String fileName, int format)](#save-java.lang.String-int-) | 指定された形式で OneNote ドキュメントをファイルに保存します。 |
+| [setColor(Color value)](#setColor-java.awt.Color-) | 色を取得または設定します。 |
+| [setDisplayName(String value)](#setDisplayName-java.lang.String-) | 表示名を取得または設定します。 |
+| [setHistoryEnabled(boolean value)](#setHistoryEnabled-boolean-) | 履歴が有効かどうかを示す値を取得または設定します。 |
+### Notebook() {#Notebook--}
+```
+public Notebook()
+```
+
+
+`Notebook` クラスの新しいインスタンスを初期化します。
+
+### Notebook(String filePath) {#Notebook-java.lang.String-}
+```
+public Notebook(String filePath)
+```
+
+
+`Notebook` クラスの新しいインスタンスを初期化します。ファイルから既存の OneNote ノートブックを開きます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| filePath | java.lang.String | ファイル パスです。 |
+
+### Notebook(String filePath, NotebookLoadOptions loadOptions) {#Notebook-java.lang.String-com.aspose.note.NotebookLoadOptions-}
+```
+public Notebook(String filePath, NotebookLoadOptions loadOptions)
+```
+
+
+新しい `Notebook` クラスのインスタンスを初期化します。ファイルから既存の OneNote ノートブックを開きます。子ノードの読み込み戦略（"lazy"/instant）などの追加オプションを指定できます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| filePath | java.lang.String | ファイル パスです。 |
+| loadOptions | [NotebookLoadOptions](../../com.aspose.note/notebookloadoptions) | ロード オプションです。 |
+
+### &lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass) {#-T1-getChildNodes-java.lang.Class-T1--}
+```
+public List<T1> <T1>getChildNodes(Class<T1> typeParameterClass)
+```
+
+
+ノードのタイプで子ノードをすべて取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| typeParameterClass | java.lang.Class&lt;T1&gt; |  |
+
+**Returns:**
+java.util.List&lt;T1&gt; - 子ノードのリスト。
+
+`T1`: 返されたリスト内の要素の型です。
+### appendChild(INotebookChildNode newChild) {#appendChild-com.aspose.note.INotebookChildNode-}
+```
+public INotebookChildNode appendChild(INotebookChildNode newChild)
+```
+
+
+ノードをリストの末尾に追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| newChild | [INotebookChildNode](../../com.aspose.note/inotebookchildnode) | 追加するノードです。 |
+
+**Returns:**
+[INotebookChildNode](../../com.aspose.note/inotebookchildnode) - The added node.
+### getColor() {#getColor--}
+```
+public Color getColor()
+```
+
+
+色を取得または設定します。
+
+**Returns:**
+java.awt.Color
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+`Notebook` に含まれる要素数を取得します。
+
+**Returns:**
+int
+### getDisplayName() {#getDisplayName--}
+```
+public String getDisplayName()
+```
+
+
+表示名を取得または設定します。
+
+**Returns:**
+java.lang.String
+### getFileFormat() {#getFileFormat--}
+```
+public int getFileFormat()
+```
+
+
+ファイル形式を取得します（OneNote 2010、OneNote Online）。
+
+**Returns:**
+int
+### getGuid() {#getGuid--}
+```
+public UUID getGuid()
+```
+
+
+オブジェクトのグローバルに一意な ID を取得します。
+
+値: GUIDです。
+
+**Returns:**
+java.util.UUID
+### getGuidInternal() {#getGuidInternal--}
+```
+public System.Guid getGuidInternal()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Guid
+### get_Item(int index) {#get-Item-int-}
+```
+public INotebookChildNode get_Item(int index)
+```
+
+
+指定されたインデックスでノートブックの子ノードを取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| index | int | 子ノードへのインデックスです。 |
+
+**Returns:**
+[INotebookChildNode](../../com.aspose.note/inotebookchildnode) - The child node on the `index` position.
+### isHistoryEnabled() {#isHistoryEnabled--}
+```
+public boolean isHistoryEnabled()
+```
+
+
+履歴が有効かどうかを示す値を取得または設定します。
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public System.Collections.Generic.IGenericEnumerator<INotebookChildNode> iterator()
+```
+
+
+`Notebook` の子ノードを列挙する列挙子を返します。
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;com.aspose.note.INotebookChildNode&gt; - `IEnumerator`。
+### loadChildDocument(InputStream stream) {#loadChildDocument-java.io.InputStream-}
+```
+public void loadChildDocument(InputStream stream)
+```
+
+
+子ドキュメントノードを追加します。ストリームから既存の OneNote ドキュメントを開きます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | ストリームです。 |
+
+### loadChildDocument(InputStream stream, LoadOptions loadOptions) {#loadChildDocument-java.io.InputStream-com.aspose.note.LoadOptions-}
+```
+public void loadChildDocument(InputStream stream, LoadOptions loadOptions)
+```
+
+
+子ドキュメントノードを追加します。ストリームから既存の OneNote ドキュメントを開きます。追加のロード オプションを指定できます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | ストリームです。 |
+| loadOptions | [LoadOptions](../../com.aspose.note/loadoptions) | ロード オプションです。 |
+
+### loadChildDocument(String filePath) {#loadChildDocument-java.lang.String-}
+```
+public void loadChildDocument(String filePath)
+```
+
+
+子ドキュメントノードを追加します。ファイルから既存の OneNote ドキュメントを開きます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| filePath | java.lang.String | ファイル パスです。 |
+
+### loadChildDocument(String filePath, LoadOptions loadOptions) {#loadChildDocument-java.lang.String-com.aspose.note.LoadOptions-}
+```
+public void loadChildDocument(String filePath, LoadOptions loadOptions)
+```
+
+
+子ドキュメントノードを追加します。ファイルから既存の OneNote ドキュメントを開きます。追加のロード オプションを指定できます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| filePath | java.lang.String | ファイル パスです。 |
+| loadOptions | [LoadOptions](../../com.aspose.note/loadoptions) | ロード オプションです。 |
+
+### loadChildNotebook(String filePath) {#loadChildNotebook-java.lang.String-}
+```
+public void loadChildNotebook(String filePath)
+```
+
+
+子ノートブックノードを追加します。ファイルから既存の OneNote ノートブックを開きます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| filePath | java.lang.String | ファイル パスです。 |
+
+### loadChildNotebook(String filePath, NotebookLoadOptions loadOptions) {#loadChildNotebook-java.lang.String-com.aspose.note.NotebookLoadOptions-}
+```
+public void loadChildNotebook(String filePath, NotebookLoadOptions loadOptions)
+```
+
+
+子ノートブックノードを追加します。ファイルから既存の OneNote ノートブックを開きます。追加のロード オプションを指定できます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| filePath | java.lang.String | ファイル パスです。 |
+| loadOptions | [NotebookLoadOptions](../../com.aspose.note/notebookloadoptions) | ロード オプションです。 |
+
+### removeChild(INotebookChildNode oldChild) {#removeChild-com.aspose.note.INotebookChildNode-}
+```
+public INotebookChildNode removeChild(INotebookChildNode oldChild)
+```
+
+
+子ノードを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| oldChild | [INotebookChildNode](../../com.aspose.note/inotebookchildnode) | 削除するノードです。 |
+
+**Returns:**
+[INotebookChildNode](../../com.aspose.note/inotebookchildnode) - The removed node.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+OneNote ドキュメントをストリームに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.OutputStream | ストリームです。 |
+
+### save(OutputStream stream, NotebookSaveOptions options) {#save-java.io.OutputStream-com.aspose.note.NotebookSaveOptions-}
+```
+public void save(OutputStream stream, NotebookSaveOptions options)
+```
+
+
+指定された保存オプションを使用して OneNote ドキュメントをストリームに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.OutputStream | ストリームです。 |
+| options | [NotebookSaveOptions](../../com.aspose.note/notebooksaveoptions) | ドキュメントの保存方法に関するオプションを指定します。 |
+
+### save(OutputStream stream, int format) {#save-java.io.OutputStream-int-}
+```
+public void save(OutputStream stream, int format)
+```
+
+
+指定された形式で OneNote ドキュメントをストリームに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.OutputStream | ストリームです。 |
+| format | int | ドキュメントを保存する形式です。 |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+OneNote ドキュメントをファイルに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ファイル名 | java.lang.String | ファイルのフルネーム。指定されたフルネームのファイルが既に存在する場合、既存のファイルが上書きされます。 |
+
+### save(String fileName, NotebookSaveOptions options) {#save-java.lang.String-com.aspose.note.NotebookSaveOptions-}
+```
+public void save(String fileName, NotebookSaveOptions options)
+```
+
+
+指定された保存オプションを使用して OneNote ドキュメントをファイルに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ファイル名 | java.lang.String | ファイルのフルネーム。指定されたフルネームのファイルが既に存在する場合、既存のファイルが上書きされます。 |
+| options | [NotebookSaveOptions](../../com.aspose.note/notebooksaveoptions) | ドキュメントがファイルに保存される方法のオプションを指定します。 |
+
+### save(String fileName, int format) {#save-java.lang.String-int-}
+```
+public void save(String fileName, int format)
+```
+
+
+指定された形式で OneNote ドキュメントをファイルに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ファイル名 | java.lang.String | ファイルのフルネーム。指定されたフルネームのファイルが既に存在する場合、既存のファイルが上書きされます。 |
+| format | int | ドキュメントを保存する形式です。 |
+
+### setColor(Color value) {#setColor-java.awt.Color-}
+```
+public void setColor(Color value)
+```
+
+
+色を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.awt.Color |  |
+
+### setDisplayName(String value) {#setDisplayName-java.lang.String-}
+```
+public void setDisplayName(String value)
+```
+
+
+表示名を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setHistoryEnabled(boolean value) {#setHistoryEnabled-boolean-}
+```
+public void setHistoryEnabled(boolean value)
+```
+
+
+履歴が有効かどうかを示す値を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+

--- a/japanese/java/com.aspose.note/notebookimagesaveoptions/_index.md
+++ b/japanese/java/com.aspose.note/notebookimagesaveoptions/_index.md
@@ -1,0 +1,34 @@
+---
+title: "NotebookImageSaveOptions"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ノートブックページを画像にレンダリングする際に追加オプションを指定できます。"
+type: docs
+weight: 57
+url: /ja/java/com.aspose.note/notebookimagesaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.NotebookSaveOptions](../../com.aspose.note/notebooksaveoptions), com.aspose.note.NotebookSaveOptionsGeneric
+```
+public class NotebookImageSaveOptions extends NotebookSaveOptionsGeneric<ImageSaveOptions>
+```
+
+ノートブックページを画像にレンダリングする際に追加オプションを指定できます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [NotebookImageSaveOptions(int format)](#NotebookImageSaveOptions-int-) | 新しい `NotebookImageSaveOptions` クラスのインスタンスを初期化します。 |
+### NotebookImageSaveOptions(int format) {#NotebookImageSaveOptions-int-}
+```
+public NotebookImageSaveOptions(int format)
+```
+
+
+新しい `NotebookImageSaveOptions` クラスのインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| format | int | ノートブックが保存される形式。 |
+

--- a/japanese/java/com.aspose.note/notebookloadoptions/_index.md
+++ b/japanese/java/com.aspose.note/notebookloadoptions/_index.md
@@ -1,0 +1,99 @@
+---
+title: "NotebookLoadOptions"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ノートブックの読み込みに使用されるオプションです。"
+type: docs
+weight: 58
+url: /ja/java/com.aspose.note/notebookloadoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class NotebookLoadOptions
+```
+
+ノートブックの読み込みに使用されるオプションです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [NotebookLoadOptions()](#NotebookLoadOptions--) | 新しい `NotebookLoadOptions` クラスのインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getDeferredLoading()](#getDeferredLoading--) | 子ドキュメントを後で明示的にロードするかどうかを示す値を取得または設定します。 |
+| [getInstantLoading()](#getInstantLoading--) | 親ドキュメントのロード中に子ドキュメントをロードするかどうかを示す値を取得または設定します。 |
+| [setDeferredLoading(boolean value)](#setDeferredLoading-boolean-) | 子ドキュメントを後で明示的にロードするかどうかを示す値を取得または設定します。 |
+| [setInstantLoading(boolean value)](#setInstantLoading-boolean-) | 親ドキュメントのロード中に子ドキュメントをロードするかどうかを示す値を取得または設定します。 |
+### NotebookLoadOptions() {#NotebookLoadOptions--}
+```
+public NotebookLoadOptions()
+```
+
+
+新しい `NotebookLoadOptions` クラスのインスタンスを初期化します。
+
+### getDeferredLoading() {#getDeferredLoading--}
+```
+public final boolean getDeferredLoading()
+```
+
+
+子ドキュメントを後で明示的にロードするかどうかを示す値を取得または設定します。
+
+--------------------
+
+デフォルト値は `false` です。そのため子ドキュメントは暗黙的にロードされます。値が `true` の場合、ユーザーは `Notebook.loadChildDocument` を呼び出すか、ノートブック自体がロードされた後に各ノートブックの子ノードを呼び出す必要があります。値が `true` の場合、`NotebookLoadOptions.instantLoading` オプションは無視されます。ノートブックがストリームからロードされる場合、ユーザーが `false` に明示的に設定していても、値は常に `true` です。
+
+**Returns:**
+boolean
+### getInstantLoading() {#getInstantLoading--}
+```
+public boolean getInstantLoading()
+```
+
+
+親ドキュメントのロード中に子ドキュメントをロードするかどうかを示す値を取得または設定します。
+
+--------------------
+
+デフォルト値は `false` です。そのため子ドキュメントは「遅延」ロードされ、つまり特定の子への直接アクセスが行われるまでロードが延期されます。値が `true` の場合、ロードは即座に実行されることを示します。
+
+**Returns:**
+boolean
+### setDeferredLoading(boolean value) {#setDeferredLoading-boolean-}
+```
+public final void setDeferredLoading(boolean value)
+```
+
+
+子ドキュメントを後で明示的にロードするかどうかを示す値を取得または設定します。
+
+--------------------
+
+デフォルト値は `false` です。そのため子ドキュメントは暗黙的にロードされます。値が `true` の場合、ユーザーは `Notebook.loadChildDocument` を呼び出すか、ノートブック自体がロードされた後に各ノートブックの子ノードを呼び出す必要があります。値が `true` の場合、`NotebookLoadOptions.instantLoading` オプションは無視されます。ノートブックがストリームからロードされる場合、ユーザーが `false` に明示的に設定していても、値は常に `true` です。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setInstantLoading(boolean value) {#setInstantLoading-boolean-}
+```
+public void setInstantLoading(boolean value)
+```
+
+
+親ドキュメントのロード中に子ドキュメントをロードするかどうかを示す値を取得または設定します。
+
+--------------------
+
+デフォルト値は `false` です。そのため子ドキュメントは「遅延」ロードされ、つまり特定の子への直接アクセスが行われるまでロードが延期されます。値が `true` の場合、ロードは即座に実行されることを示します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+

--- a/japanese/java/com.aspose.note/notebookonesaveoptions/_index.md
+++ b/japanese/java/com.aspose.note/notebookonesaveoptions/_index.md
@@ -1,0 +1,29 @@
+---
+title: "NotebookOneSaveOptions"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ノートブックを OneNote 形式で保存する際に追加オプションを指定できます。"
+type: docs
+weight: 59
+url: /ja/java/com.aspose.note/notebookonesaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.NotebookSaveOptions](../../com.aspose.note/notebooksaveoptions), com.aspose.note.NotebookSaveOptionsGeneric
+```
+public class NotebookOneSaveOptions extends NotebookSaveOptionsGeneric<OneSaveOptions>
+```
+
+ノートブックを OneNote 形式で保存する際に追加オプションを指定できます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [NotebookOneSaveOptions()](#NotebookOneSaveOptions--) | `NotebookOneSaveOptions` クラスの新しいインスタンスを初期化します。 |
+### NotebookOneSaveOptions() {#NotebookOneSaveOptions--}
+```
+public NotebookOneSaveOptions()
+```
+
+
+`NotebookOneSaveOptions` クラスの新しいインスタンスを初期化します。
+

--- a/japanese/java/com.aspose.note/notebookpdfsaveoptions/_index.md
+++ b/japanese/java/com.aspose.note/notebookpdfsaveoptions/_index.md
@@ -1,0 +1,29 @@
+---
+title: "NotebookPdfSaveOptions"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ノートブックページを PDF にレンダリングする際に追加オプションを指定できます。"
+type: docs
+weight: 60
+url: /ja/java/com.aspose.note/notebookpdfsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.NotebookSaveOptions](../../com.aspose.note/notebooksaveoptions), com.aspose.note.NotebookSaveOptionsGeneric
+```
+public class NotebookPdfSaveOptions extends NotebookSaveOptionsGeneric<PdfSaveOptions>
+```
+
+ノートブックページを PDF にレンダリングする際に追加オプションを指定できます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [NotebookPdfSaveOptions()](#NotebookPdfSaveOptions--) | `NotebookPdfSaveOptions` クラスの新しいインスタンスを初期化します。 |
+### NotebookPdfSaveOptions() {#NotebookPdfSaveOptions--}
+```
+public NotebookPdfSaveOptions()
+```
+
+
+`NotebookPdfSaveOptions` クラスの新しいインスタンスを初期化します。
+

--- a/japanese/java/com.aspose.note/notebooksaveoptions/_index.md
+++ b/japanese/java/com.aspose.note/notebooksaveoptions/_index.md
@@ -1,0 +1,100 @@
+---
+title: "NotebookSaveOptions"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "特定の形式向けのノートブック保存オプションを表す抽象基底クラスです。"
+type: docs
+weight: 61
+url: /ja/java/com.aspose.note/notebooksaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class NotebookSaveOptions
+```
+
+特定の形式向けのノートブック保存オプションを表す抽象基底クラスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getDeferredSaving()](#getDeferredSaving--) | 子ドキュメントを明示的に保存すべきかどうかを示す値を取得または設定します。 |
+| [getDocumentSaveOptionsInternal()](#getDocumentSaveOptionsInternal--) | ノートブックのすべての子ドキュメントの保存オプションを取得します。 |
+| [getFlatten()](#getFlatten--) | ノートブックの子階層がフラットに保存されるかどうかを示す値を取得または設定します。 |
+| [getSaveFormat()](#getSaveFormat--) | ノートブックが保存される形式を取得します。 |
+| [setDeferredSaving(boolean value)](#setDeferredSaving-boolean-) | 子ドキュメントを明示的に保存すべきかどうかを示す値を取得または設定します。 |
+| [setFlatten(boolean value)](#setFlatten-boolean-) | ノートブックの子階層がフラットに保存されるかどうかを示す値を取得または設定します。 |
+### getDeferredSaving() {#getDeferredSaving--}
+```
+public boolean getDeferredSaving()
+```
+
+
+子ドキュメントを明示的に保存すべきかどうかを示す値を取得または設定します。
+
+--------------------
+
+デフォルト値は `false` です。そのため子ドキュメントは暗黙的に保存されます。値が `true` の場合、ユーザーは各ノートブックの子ノードを明示的に保存すべきことを示します。ノートブックがストリームに保存される場合、ユーザーが `false` に明示的に設定したかどうかに関わらず、値は常に `true` になります。
+
+**Returns:**
+boolean
+### getDocumentSaveOptionsInternal() {#getDocumentSaveOptionsInternal--}
+```
+public abstract SaveOptions getDocumentSaveOptionsInternal()
+```
+
+
+ノートブックのすべての子ドキュメントの保存オプションを取得します。
+
+**Returns:**
+[SaveOptions](../../com.aspose.note/saveoptions) - The `SaveOptions`.
+### getFlatten() {#getFlatten--}
+```
+public boolean getFlatten()
+```
+
+
+ノートブックの子階層がフラットに保存されるかどうかを示す値を取得または設定します。
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public abstract int getSaveFormat()
+```
+
+
+ノートブックが保存される形式を取得します。
+
+**Returns:**
+int
+### setDeferredSaving(boolean value) {#setDeferredSaving-boolean-}
+```
+public void setDeferredSaving(boolean value)
+```
+
+
+子ドキュメントを明示的に保存すべきかどうかを示す値を取得または設定します。
+
+--------------------
+
+デフォルト値は `false` です。そのため子ドキュメントは暗黙的に保存されます。値が `true` の場合、ユーザーは各ノートブックの子ノードを明示的に保存すべきことを示します。ノートブックがストリームに保存される場合、ユーザーが `false` に明示的に設定したかどうかに関わらず、値は常に `true` になります。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setFlatten(boolean value) {#setFlatten-boolean-}
+```
+public void setFlatten(boolean value)
+```
+
+
+ノートブックの子階層がフラットに保存されるかどうかを示す値を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+

--- a/japanese/java/com.aspose.note/notebooksaveoptionsgeneric/_index.md
+++ b/japanese/java/com.aspose.note/notebooksaveoptionsgeneric/_index.md
@@ -1,0 +1,68 @@
+---
+title: "NotebookSaveOptionsGeneric"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "特定の形式向けのノートブック保存オプションを表し、すべてのドキュメント子ノードに共通の保存オプションを提供する抽象基底クラスです。"
+type: docs
+weight: 62
+url: /ja/java/com.aspose.note/notebooksaveoptionsgeneric/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.NotebookSaveOptions](../../com.aspose.note/notebooksaveoptions)
+```
+public abstract class NotebookSaveOptionsGeneric<TDocumentSaveOptions> extends NotebookSaveOptions
+```
+
+特定の形式向けのノートブック保存オプションを表し、すべてのドキュメント子ノードに共通の保存オプションを提供する抽象基底クラスです。
+
+`TDocumentSaveOptions`: すべてのノートブックの子ドキュメントの保存オプションです。
+
+TDocumentSaveOptions :
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [NotebookSaveOptionsGeneric()](#NotebookSaveOptionsGeneric--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getDocumentSaveOptions()](#getDocumentSaveOptions--) | すべてのノートブックの子ドキュメントの保存オプションを取得または設定します。 |
+| [getDocumentSaveOptionsInternal()](#getDocumentSaveOptionsInternal--) | ノートブックのすべての子ドキュメントの保存オプションを取得します。 |
+| [getSaveFormat()](#getSaveFormat--) | ノートブックが保存される形式を取得します。 |
+### NotebookSaveOptionsGeneric() {#NotebookSaveOptionsGeneric--}
+```
+public NotebookSaveOptionsGeneric()
+```
+
+
+### getDocumentSaveOptions() {#getDocumentSaveOptions--}
+```
+public TDocumentSaveOptions getDocumentSaveOptions()
+```
+
+
+すべてのノートブックの子ドキュメントの保存オプションを取得または設定します。
+
+**Returns:**
+TDocumentSaveOptions
+### getDocumentSaveOptionsInternal() {#getDocumentSaveOptionsInternal--}
+```
+public SaveOptions getDocumentSaveOptionsInternal()
+```
+
+
+ノートブックのすべての子ドキュメントの保存オプションを取得します。
+
+**Returns:**
+[SaveOptions](../../com.aspose.note/saveoptions) - The `SaveOptions`.
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+ノートブックが保存される形式を取得します。
+
+**Returns:**
+int

--- a/japanese/java/com.aspose.note/notecheckbox/_index.md
+++ b/japanese/java/com.aspose.note/notecheckbox/_index.md
@@ -1,0 +1,883 @@
+---
+title: "NoteCheckBox"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "完了と未完了の状態を切り替えることができるノートタグを表します。"
+type: docs
+weight: 53
+url: /ja/java/com.aspose.note/notecheckbox/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.note.TagExtended, [com.aspose.note.CheckBox](../../com.aspose.note/checkbox)
+
+**All Implemented Interfaces:**
+[com.aspose.note.INoteTag](../../com.aspose.note/inotetag), com.aspose.ms.System.IEquatable
+```
+public class NoteCheckBox extends CheckBox implements INoteTag, System.IEquatable<NoteCheckBox>
+```
+
+完了と未完了の状態を切り替えることができるノートタグを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [createBlueCheckBox()](#createBlueCheckBox--) | \* 新しいノートタグを作成します（BlueCheckBoxEmpty アイコン、デフォルトラベル）。 |
+| [createBlueCheckBox(String label)](#createBlueCheckBox-java.lang.String-) | \* 新しいノートチェックボックスを作成します（BlueCheckBoxEmpty アイコン、指定されたラベル）。 |
+| [createBlueCheckBox1()](#createBlueCheckBox1--) | \* 新しいノートタグを作成します（BlueCheckBox1Empty アイコン、デフォルトラベル）。 |
+| [createBlueCheckBox1(String label)](#createBlueCheckBox1-java.lang.String-) | \* 新しいノートチェックボックスを作成します（BlueCheckBox1Empty アイコン、指定されたラベル）。 |
+| [createBlueCheckBox2()](#createBlueCheckBox2--) | \* 新しいノートタグを作成します（BlueCheckBox2Empty アイコン、デフォルトラベル）。 |
+| [createBlueCheckBox2(String label)](#createBlueCheckBox2-java.lang.String-) | \* 新しいノートチェックボックスを作成します（BlueCheckBox2Empty アイコン、指定されたラベル）。 |
+| [createBlueCheckBox3()](#createBlueCheckBox3--) | \* 新しいノートタグを作成します（BlueCheckBox3Empty アイコン、デフォルトラベル）。 |
+| [createBlueCheckBox3(String label)](#createBlueCheckBox3-java.lang.String-) | \* 新しいノートチェックボックスを作成します（BlueCheckBox3Empty アイコン、指定されたラベル）。 |
+| [createBlueExclamationCheckBox()](#createBlueExclamationCheckBox--) | \* 新しいノートタグを作成します（BlueExclamationCheckBoxEmpty アイコン、デフォルトラベル）。 |
+| [createBlueExclamationCheckBox(String label)](#createBlueExclamationCheckBox-java.lang.String-) | \* 新しいノートチェックボックスを作成します（BlueExclamationCheckBoxEmpty アイコン、指定されたラベル）。 |
+| [createBlueFlagCheckBox()](#createBlueFlagCheckBox--) | \* 新しいノートタグを作成します（BlueFlagCheckBoxEmpty アイコン、デフォルトラベル）。 |
+| [createBlueFlagCheckBox(String label)](#createBlueFlagCheckBox-java.lang.String-) | \* 新しいノートチェックボックスを作成します（BlueFlagCheckBoxEmpty アイコン、指定されたラベル）。 |
+| [createBluePersonCheckBox()](#createBluePersonCheckBox--) | * 新しいノートタグを作成し、BluePersonCheckBoxEmpty アイコンとデフォルトラベルを使用します。 |
+| [createBluePersonCheckBox(String label)](#createBluePersonCheckBox-java.lang.String-) | * 新しいノートチェックボックスを作成し、BluePersonCheckBoxEmpty アイコンと指定ラベルを使用します。 |
+| [createBlueRightArrowCheckBox()](#createBlueRightArrowCheckBox--) | * 新しいノートタグを作成し、BlueRightArrowCheckBoxEmpty アイコンとデフォルトラベルを使用します。 |
+| [createBlueRightArrowCheckBox(String label)](#createBlueRightArrowCheckBox-java.lang.String-) | * 新しいノートチェックボックスを作成し、BlueRightArrowCheckBoxEmpty アイコンと指定ラベルを使用します。 |
+| [createBlueStarCheckBox()](#createBlueStarCheckBox--) | * 新しいノートタグを作成し、BlueStarCheckBoxEmpty アイコンとデフォルトラベルを使用します。 |
+| [createBlueStarCheckBox(String label)](#createBlueStarCheckBox-java.lang.String-) | * 新しいノートチェックボックスを作成し、BlueStarCheckBoxEmpty アイコンと指定ラベルを使用します。 |
+| [createGreenCheckBox()](#createGreenCheckBox--) | * 新しいノートタグを作成し、GreenCheckBoxEmpty アイコンとデフォルトラベルを使用します。 |
+| [createGreenCheckBox(String label)](#createGreenCheckBox-java.lang.String-) | * 新しいノートチェックボックスを作成し、GreenCheckBoxEmpty アイコンと指定ラベルを使用します。 |
+| [createGreenCheckBox1()](#createGreenCheckBox1--) | * 新しいノートタグを作成し、GreenCheckBox1Empty アイコンとデフォルトラベルを使用します。 |
+| [createGreenCheckBox1(String label)](#createGreenCheckBox1-java.lang.String-) | * 新しいノートチェックボックスを作成し、GreenCheckBox1Empty アイコンと指定ラベルを使用します。 |
+| [createGreenCheckBox2()](#createGreenCheckBox2--) | * 新しいノートタグを作成し、GreenCheckBox2Empty アイコンとデフォルトラベルを使用します。 |
+| [createGreenCheckBox2(String label)](#createGreenCheckBox2-java.lang.String-) | * 新しいノートチェックボックスを作成し、GreenCheckBox2Empty アイコンと指定ラベルを使用します。 |
+| [createGreenCheckBox3()](#createGreenCheckBox3--) | * 新しいノートタグを作成し、GreenCheckBox3Empty アイコンとデフォルトラベルを使用します。 |
+| [createGreenCheckBox3(String label)](#createGreenCheckBox3-java.lang.String-) | * 新しいノートチェックボックスを作成し、GreenCheckBox3Empty アイコンと指定ラベルを使用します。 |
+| [createGreenExclamationCheckBox()](#createGreenExclamationCheckBox--) | * 新しいノートタグを作成し、GreenExclamationCheckBoxEmpty アイコンとデフォルトラベルを使用します。 |
+| [createGreenExclamationCheckBox(String label)](#createGreenExclamationCheckBox-java.lang.String-) | * 新しいノートチェックボックスを作成し、GreenExclamationCheckBoxEmpty アイコンと指定ラベルを使用します。 |
+| [createGreenFlagCheckBox()](#createGreenFlagCheckBox--) | * 新しいノートタグを作成し、GreenFlagCheckBoxEmpty アイコンとデフォルトラベルを使用します。 |
+| [createGreenFlagCheckBox(String label)](#createGreenFlagCheckBox-java.lang.String-) | * 新しいノートチェックボックスを作成し、GreenFlagCheckBoxEmpty アイコンと指定ラベルを使用します。 |
+| [createGreenPersonCheckBox()](#createGreenPersonCheckBox--) | * 新しいノートタグを作成し、GreenPersonCheckBoxEmpty アイコンとデフォルトラベルを使用します。 |
+| [createGreenPersonCheckBox(String label)](#createGreenPersonCheckBox-java.lang.String-) | * 新しいノートチェックボックスを作成し、GreenPersonCheckBoxEmpty アイコンと指定ラベルを使用します。 |
+| [createGreenRightArrowCheckBox()](#createGreenRightArrowCheckBox--) | * 新しいノートタグを作成し、GreenRightArrowCheckBoxEmpty アイコンとデフォルトラベルを使用します。 |
+| [createGreenRightArrowCheckBox(String label)](#createGreenRightArrowCheckBox-java.lang.String-) | * 新しいノートチェックボックスを作成し、GreenRightArrowCheckBoxEmpty アイコンと指定ラベルを使用します。 |
+| [createGreenStarCheckBox()](#createGreenStarCheckBox--) | * 新しいノートタグを作成し、GreenStarCheckBoxEmpty アイコンとデフォルトラベルを使用します。 |
+| [createGreenStarCheckBox(String label)](#createGreenStarCheckBox-java.lang.String-) | * 新しいノートチェックボックスを作成し、GreenStarCheckBoxEmpty アイコンと指定ラベルを使用します。 |
+| [createRedFlagCheckBox()](#createRedFlagCheckBox--) | * 新しいノートタグを作成し、RedFlagCheckBoxEmpty アイコンとデフォルトラベルを使用します。 |
+| [createRedFlagCheckBox(String label)](#createRedFlagCheckBox-java.lang.String-) | \* 新しいノートのチェックボックスを RedFlagCheckBoxEmpty アイコンと指定されたラベルで作成します。 |
+| [createYellowCheckBox()](#createYellowCheckBox--) | \* 新しいノートタグを YellowCheckBoxEmpty アイコンとデフォルトラベルで作成します。 |
+| [createYellowCheckBox(String label)](#createYellowCheckBox-java.lang.String-) | \* 新しいノートのチェックボックスを YellowCheckBoxEmpty アイコンと指定されたラベルで作成します。 |
+| [createYellowCheckBox1()](#createYellowCheckBox1--) | \* 新しいノートタグを YellowCheckBox1Empty アイコンとデフォルトラベルで作成します。 |
+| [createYellowCheckBox1(String label)](#createYellowCheckBox1-java.lang.String-) | \* 新しいノートのチェックボックスを YellowCheckBox1Empty アイコンと指定されたラベルで作成します。 |
+| [createYellowCheckBox2()](#createYellowCheckBox2--) | \* 新しいノートタグを YellowCheckBox2Empty アイコンとデフォルトラベルで作成します。 |
+| [createYellowCheckBox2(String label)](#createYellowCheckBox2-java.lang.String-) | \* 新しいノートのチェックボックスを YellowCheckBox2Empty アイコンと指定されたラベルで作成します。 |
+| [createYellowCheckBox3()](#createYellowCheckBox3--) | \* 新しいノートタグを YellowCheckBox3Empty アイコンとデフォルトラベルで作成します。 |
+| [createYellowCheckBox3(String label)](#createYellowCheckBox3-java.lang.String-) | \* 新しいノートのチェックボックスを YellowCheckBox3Empty アイコンと指定されたラベルで作成します。 |
+| [createYellowExclamationCheckBox()](#createYellowExclamationCheckBox--) | \* 新しいノートタグを YellowExclamationCheckBoxEmpty アイコンとデフォルトラベルで作成します。 |
+| [createYellowExclamationCheckBox(String label)](#createYellowExclamationCheckBox-java.lang.String-) | \* 新しいノートのチェックボックスを YellowExclamationCheckBoxEmpty アイコンと指定されたラベルで作成します。 |
+| [createYellowPersonCheckBox()](#createYellowPersonCheckBox--) | \* 新しいノートタグを YellowPersonCheckBoxEmpty アイコンとデフォルトラベルで作成します。 |
+| [createYellowPersonCheckBox(String label)](#createYellowPersonCheckBox-java.lang.String-) | \* 新しいノートのチェックボックスを YellowPersonCheckBoxEmpty アイコンと指定されたラベルで作成します。 |
+| [createYellowRightArrowCheckBox()](#createYellowRightArrowCheckBox--) | \* 新しいノートタグを YellowRightArrowCheckBoxEmpty アイコンとデフォルトラベルで作成します。 |
+| [createYellowRightArrowCheckBox(String label)](#createYellowRightArrowCheckBox-java.lang.String-) | \* 新しいノートのチェックボックスを YellowRightArrowCheckBoxEmpty アイコンと指定されたラベルで作成します。 |
+| [createYellowStarCheckBox()](#createYellowStarCheckBox--) | \* 新しいノートタグを YellowStarCheckBoxEmpty アイコンとデフォルトラベルで作成します。 |
+| [createYellowStarCheckBox(String label)](#createYellowStarCheckBox-java.lang.String-) | \* 新しいノートのチェックボックスを YellowStarCheckBoxEmpty アイコンと指定されたラベルで作成します。 |
+| [equals(NoteCheckBox other)](#equals-com.aspose.note.NoteCheckBox-) | 指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。 |
+| [equals(Object obj)](#equals-java.lang.Object-) | 指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。 |
+| [getFontColor()](#getFontColor--) | フォントの色を取得または設定します。 |
+| [getHighlight()](#getHighlight--) | ハイライト色を取得または設定します。 |
+| [getIcon()](#getIcon--) | アイコンを取得または設定します。 |
+| [getLabel()](#getLabel--) | ラベルテキストを取得または設定します。 |
+| [hashCode()](#hashCode--) | 型のハッシュ関数として機能します。 |
+| [setFontColor(Color value)](#setFontColor-java.awt.Color-) | フォントの色を取得または設定します。 |
+| [setHighlight(Color value)](#setHighlight-java.awt.Color-) | ハイライト色を取得または設定します。 |
+| [setLabel(String value)](#setLabel-java.lang.String-) | ラベルテキストを取得または設定します。 |
+### createBlueCheckBox() {#createBlueCheckBox--}
+```
+public static NoteCheckBox createBlueCheckBox()
+```
+
+
+\* 新しいノートタグを作成します（BlueCheckBoxEmpty アイコン、デフォルトラベル）。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox(String label) {#createBlueCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createBlueCheckBox(String label)
+```
+
+
+\* 新しいノートチェックボックスを作成します（BlueCheckBoxEmpty アイコン、指定されたラベル）。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox1() {#createBlueCheckBox1--}
+```
+public static NoteCheckBox createBlueCheckBox1()
+```
+
+
+\* 新しいノートタグを作成します（BlueCheckBox1Empty アイコン、デフォルトラベル）。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox1(String label) {#createBlueCheckBox1-java.lang.String-}
+```
+public static NoteCheckBox createBlueCheckBox1(String label)
+```
+
+
+\* 新しいノートチェックボックスを作成します（BlueCheckBox1Empty アイコン、指定されたラベル）。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox2() {#createBlueCheckBox2--}
+```
+public static NoteCheckBox createBlueCheckBox2()
+```
+
+
+\* 新しいノートタグを作成します（BlueCheckBox2Empty アイコン、デフォルトラベル）。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox2(String label) {#createBlueCheckBox2-java.lang.String-}
+```
+public static NoteCheckBox createBlueCheckBox2(String label)
+```
+
+
+\* 新しいノートチェックボックスを作成します（BlueCheckBox2Empty アイコン、指定されたラベル）。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox3() {#createBlueCheckBox3--}
+```
+public static NoteCheckBox createBlueCheckBox3()
+```
+
+
+\* 新しいノートタグを作成します（BlueCheckBox3Empty アイコン、デフォルトラベル）。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox3(String label) {#createBlueCheckBox3-java.lang.String-}
+```
+public static NoteCheckBox createBlueCheckBox3(String label)
+```
+
+
+\* 新しいノートチェックボックスを作成します（BlueCheckBox3Empty アイコン、指定されたラベル）。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueExclamationCheckBox() {#createBlueExclamationCheckBox--}
+```
+public static NoteCheckBox createBlueExclamationCheckBox()
+```
+
+
+\* 新しいノートタグを作成します（BlueExclamationCheckBoxEmpty アイコン、デフォルトラベル）。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueExclamationCheckBox(String label) {#createBlueExclamationCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createBlueExclamationCheckBox(String label)
+```
+
+
+\* 新しいノートチェックボックスを作成します（BlueExclamationCheckBoxEmpty アイコン、指定されたラベル）。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueFlagCheckBox() {#createBlueFlagCheckBox--}
+```
+public static NoteCheckBox createBlueFlagCheckBox()
+```
+
+
+\* 新しいノートタグを作成します（BlueFlagCheckBoxEmpty アイコン、デフォルトラベル）。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueFlagCheckBox(String label) {#createBlueFlagCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createBlueFlagCheckBox(String label)
+```
+
+
+\* 新しいノートチェックボックスを作成します（BlueFlagCheckBoxEmpty アイコン、指定されたラベル）。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBluePersonCheckBox() {#createBluePersonCheckBox--}
+```
+public static NoteCheckBox createBluePersonCheckBox()
+```
+
+
+* 新しいノートタグを作成し、BluePersonCheckBoxEmpty アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBluePersonCheckBox(String label) {#createBluePersonCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createBluePersonCheckBox(String label)
+```
+
+
+* 新しいノートチェックボックスを作成し、BluePersonCheckBoxEmpty アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueRightArrowCheckBox() {#createBlueRightArrowCheckBox--}
+```
+public static NoteCheckBox createBlueRightArrowCheckBox()
+```
+
+
+* 新しいノートタグを作成し、BlueRightArrowCheckBoxEmpty アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueRightArrowCheckBox(String label) {#createBlueRightArrowCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createBlueRightArrowCheckBox(String label)
+```
+
+
+* 新しいノートチェックボックスを作成し、BlueRightArrowCheckBoxEmpty アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueStarCheckBox() {#createBlueStarCheckBox--}
+```
+public static NoteCheckBox createBlueStarCheckBox()
+```
+
+
+* 新しいノートタグを作成し、BlueStarCheckBoxEmpty アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueStarCheckBox(String label) {#createBlueStarCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createBlueStarCheckBox(String label)
+```
+
+
+* 新しいノートチェックボックスを作成し、BlueStarCheckBoxEmpty アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox() {#createGreenCheckBox--}
+```
+public static NoteCheckBox createGreenCheckBox()
+```
+
+
+* 新しいノートタグを作成し、GreenCheckBoxEmpty アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox(String label) {#createGreenCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createGreenCheckBox(String label)
+```
+
+
+* 新しいノートチェックボックスを作成し、GreenCheckBoxEmpty アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox1() {#createGreenCheckBox1--}
+```
+public static NoteCheckBox createGreenCheckBox1()
+```
+
+
+* 新しいノートタグを作成し、GreenCheckBox1Empty アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox1(String label) {#createGreenCheckBox1-java.lang.String-}
+```
+public static NoteCheckBox createGreenCheckBox1(String label)
+```
+
+
+* 新しいノートチェックボックスを作成し、GreenCheckBox1Empty アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox2() {#createGreenCheckBox2--}
+```
+public static NoteCheckBox createGreenCheckBox2()
+```
+
+
+* 新しいノートタグを作成し、GreenCheckBox2Empty アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox2(String label) {#createGreenCheckBox2-java.lang.String-}
+```
+public static NoteCheckBox createGreenCheckBox2(String label)
+```
+
+
+* 新しいノートチェックボックスを作成し、GreenCheckBox2Empty アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox3() {#createGreenCheckBox3--}
+```
+public static NoteCheckBox createGreenCheckBox3()
+```
+
+
+* 新しいノートタグを作成し、GreenCheckBox3Empty アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox3(String label) {#createGreenCheckBox3-java.lang.String-}
+```
+public static NoteCheckBox createGreenCheckBox3(String label)
+```
+
+
+* 新しいノートチェックボックスを作成し、GreenCheckBox3Empty アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenExclamationCheckBox() {#createGreenExclamationCheckBox--}
+```
+public static NoteCheckBox createGreenExclamationCheckBox()
+```
+
+
+* 新しいノートタグを作成し、GreenExclamationCheckBoxEmpty アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenExclamationCheckBox(String label) {#createGreenExclamationCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createGreenExclamationCheckBox(String label)
+```
+
+
+* 新しいノートチェックボックスを作成し、GreenExclamationCheckBoxEmpty アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenFlagCheckBox() {#createGreenFlagCheckBox--}
+```
+public static NoteCheckBox createGreenFlagCheckBox()
+```
+
+
+* 新しいノートタグを作成し、GreenFlagCheckBoxEmpty アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenFlagCheckBox(String label) {#createGreenFlagCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createGreenFlagCheckBox(String label)
+```
+
+
+* 新しいノートチェックボックスを作成し、GreenFlagCheckBoxEmpty アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenPersonCheckBox() {#createGreenPersonCheckBox--}
+```
+public static NoteCheckBox createGreenPersonCheckBox()
+```
+
+
+* 新しいノートタグを作成し、GreenPersonCheckBoxEmpty アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenPersonCheckBox(String label) {#createGreenPersonCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createGreenPersonCheckBox(String label)
+```
+
+
+* 新しいノートチェックボックスを作成し、GreenPersonCheckBoxEmpty アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenRightArrowCheckBox() {#createGreenRightArrowCheckBox--}
+```
+public static NoteCheckBox createGreenRightArrowCheckBox()
+```
+
+
+* 新しいノートタグを作成し、GreenRightArrowCheckBoxEmpty アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenRightArrowCheckBox(String label) {#createGreenRightArrowCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createGreenRightArrowCheckBox(String label)
+```
+
+
+* 新しいノートチェックボックスを作成し、GreenRightArrowCheckBoxEmpty アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenStarCheckBox() {#createGreenStarCheckBox--}
+```
+public static NoteCheckBox createGreenStarCheckBox()
+```
+
+
+* 新しいノートタグを作成し、GreenStarCheckBoxEmpty アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenStarCheckBox(String label) {#createGreenStarCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createGreenStarCheckBox(String label)
+```
+
+
+* 新しいノートチェックボックスを作成し、GreenStarCheckBoxEmpty アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createRedFlagCheckBox() {#createRedFlagCheckBox--}
+```
+public static NoteCheckBox createRedFlagCheckBox()
+```
+
+
+* 新しいノートタグを作成し、RedFlagCheckBoxEmpty アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createRedFlagCheckBox(String label) {#createRedFlagCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createRedFlagCheckBox(String label)
+```
+
+
+\* 新しいノートのチェックボックスを RedFlagCheckBoxEmpty アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox() {#createYellowCheckBox--}
+```
+public static NoteCheckBox createYellowCheckBox()
+```
+
+
+\* 新しいノートタグを YellowCheckBoxEmpty アイコンとデフォルトラベルで作成します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox(String label) {#createYellowCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createYellowCheckBox(String label)
+```
+
+
+\* 新しいノートのチェックボックスを YellowCheckBoxEmpty アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox1() {#createYellowCheckBox1--}
+```
+public static NoteCheckBox createYellowCheckBox1()
+```
+
+
+\* 新しいノートタグを YellowCheckBox1Empty アイコンとデフォルトラベルで作成します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox1(String label) {#createYellowCheckBox1-java.lang.String-}
+```
+public static NoteCheckBox createYellowCheckBox1(String label)
+```
+
+
+\* 新しいノートのチェックボックスを YellowCheckBox1Empty アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox2() {#createYellowCheckBox2--}
+```
+public static NoteCheckBox createYellowCheckBox2()
+```
+
+
+\* 新しいノートタグを YellowCheckBox2Empty アイコンとデフォルトラベルで作成します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox2(String label) {#createYellowCheckBox2-java.lang.String-}
+```
+public static NoteCheckBox createYellowCheckBox2(String label)
+```
+
+
+\* 新しいノートのチェックボックスを YellowCheckBox2Empty アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox3() {#createYellowCheckBox3--}
+```
+public static NoteCheckBox createYellowCheckBox3()
+```
+
+
+\* 新しいノートタグを YellowCheckBox3Empty アイコンとデフォルトラベルで作成します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox3(String label) {#createYellowCheckBox3-java.lang.String-}
+```
+public static NoteCheckBox createYellowCheckBox3(String label)
+```
+
+
+\* 新しいノートのチェックボックスを YellowCheckBox3Empty アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowExclamationCheckBox() {#createYellowExclamationCheckBox--}
+```
+public static NoteCheckBox createYellowExclamationCheckBox()
+```
+
+
+\* 新しいノートタグを YellowExclamationCheckBoxEmpty アイコンとデフォルトラベルで作成します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowExclamationCheckBox(String label) {#createYellowExclamationCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createYellowExclamationCheckBox(String label)
+```
+
+
+\* 新しいノートのチェックボックスを YellowExclamationCheckBoxEmpty アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowPersonCheckBox() {#createYellowPersonCheckBox--}
+```
+public static NoteCheckBox createYellowPersonCheckBox()
+```
+
+
+\* 新しいノートタグを YellowPersonCheckBoxEmpty アイコンとデフォルトラベルで作成します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowPersonCheckBox(String label) {#createYellowPersonCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createYellowPersonCheckBox(String label)
+```
+
+
+\* 新しいノートのチェックボックスを YellowPersonCheckBoxEmpty アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowRightArrowCheckBox() {#createYellowRightArrowCheckBox--}
+```
+public static NoteCheckBox createYellowRightArrowCheckBox()
+```
+
+
+\* 新しいノートタグを YellowRightArrowCheckBoxEmpty アイコンとデフォルトラベルで作成します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowRightArrowCheckBox(String label) {#createYellowRightArrowCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createYellowRightArrowCheckBox(String label)
+```
+
+
+\* 新しいノートのチェックボックスを YellowRightArrowCheckBoxEmpty アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowStarCheckBox() {#createYellowStarCheckBox--}
+```
+public static NoteCheckBox createYellowStarCheckBox()
+```
+
+
+\* 新しいノートタグを YellowStarCheckBoxEmpty アイコンとデフォルトラベルで作成します。
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowStarCheckBox(String label) {#createYellowStarCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createYellowStarCheckBox(String label)
+```
+
+
+\* 新しいノートのチェックボックスを YellowStarCheckBoxEmpty アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### equals(NoteCheckBox other) {#equals-com.aspose.note.NoteCheckBox-}
+```
+public final boolean equals(NoteCheckBox other)
+```
+
+
+指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| other | [NoteCheckBox](../../com.aspose.note/notecheckbox) | オブジェクトです。 |
+
+**Returns:**
+boolean - `boolean`。
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| obj | java.lang.Object | オブジェクトです。 |
+
+**Returns:**
+boolean - `boolean`。
+### getFontColor() {#getFontColor--}
+```
+public final Color getFontColor()
+```
+
+
+フォントの色を取得または設定します。
+
+**Returns:**
+java.awt.Color
+### getHighlight() {#getHighlight--}
+```
+public final Color getHighlight()
+```
+
+
+ハイライト色を取得または設定します。
+
+**Returns:**
+java.awt.Color
+### getIcon() {#getIcon--}
+```
+public int getIcon()
+```
+
+
+アイコンを取得または設定します。
+
+値: [TagIcon](../../com.aspose.note.infrastructure/tagicon)です。
+
+**Returns:**
+int
+### getLabel() {#getLabel--}
+```
+public final String getLabel()
+```
+
+
+ラベルテキストを取得または設定します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+型のハッシュ関数として機能します。
+
+**Returns:**
+int - `int`です。
+### setFontColor(Color value) {#setFontColor-java.awt.Color-}
+```
+public final void setFontColor(Color value)
+```
+
+
+フォントの色を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.awt.Color |  |
+
+### setHighlight(Color value) {#setHighlight-java.awt.Color-}
+```
+public final void setHighlight(Color value)
+```
+
+
+ハイライト色を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.awt.Color |  |
+
+### setLabel(String value) {#setLabel-java.lang.String-}
+```
+public final void setLabel(String value)
+```
+
+
+ラベルテキストを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+

--- a/japanese/java/com.aspose.note/notetag/_index.md
+++ b/japanese/java/com.aspose.note/notetag/_index.md
@@ -1,0 +1,3262 @@
+---
+title: "NoteTag"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ノートタグを表します。"
+type: docs
+weight: 54
+url: /ja/java/com.aspose.note/notetag/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.note.TagExtended
+
+**All Implemented Interfaces:**
+[com.aspose.note.INoteTag](../../com.aspose.note/inotetag), com.aspose.ms.System.IEquatable
+```
+public final class NoteTag extends TagExtended implements INoteTag, System.IEquatable<NoteTag>
+```
+
+ノートタグを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [NoteTag()](#NoteTag--) | アイコンなしで [NoteTag](../../com.aspose.note/notetag) クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [createAwardRibbon()](#createAwardRibbon--) | * AwardRibbon アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createAwardRibbon(String label)](#createAwardRibbon-java.lang.String-) | * AwardRibbon アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createBinoculars()](#createBinoculars--) | * Binoculars アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createBinoculars(String label)](#createBinoculars-java.lang.String-) | * Binoculars アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createBlankPaperWithLines()](#createBlankPaperWithLines--) | * BlankPaperWithLines アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createBlankPaperWithLines(String label)](#createBlankPaperWithLines-java.lang.String-) | * BlankPaperWithLines アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createBlueCheckMark()](#createBlueCheckMark--) | * BlueCheckMark アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createBlueCheckMark(String label)](#createBlueCheckMark-java.lang.String-) | * BlueCheckMark アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createBlueCircle()](#createBlueCircle--) | * BlueCircle アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createBlueCircle(String label)](#createBlueCircle-java.lang.String-) | * BlueCircle アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createBlueCircle1()](#createBlueCircle1--) | * BlueCircle1 アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createBlueCircle1(String label)](#createBlueCircle1-java.lang.String-) | * BlueCircle1 アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createBlueCircle2()](#createBlueCircle2--) | * BlueCircle2 アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createBlueCircle2(String label)](#createBlueCircle2-java.lang.String-) | * BlueCircle2 アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createBlueCircle3()](#createBlueCircle3--) | * BlueCircle3 アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createBlueCircle3(String label)](#createBlueCircle3-java.lang.String-) | * BlueCircle3 アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createBlueDownArrow()](#createBlueDownArrow--) | * BlueDownArrow アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createBlueDownArrow(String label)](#createBlueDownArrow-java.lang.String-) | * BlueDownArrow アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createBlueEightPointStar()](#createBlueEightPointStar--) | * BlueEightPointStar アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createBlueEightPointStar(String label)](#createBlueEightPointStar-java.lang.String-) | * BlueEightPointStar アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createBlueFollowUpFlag()](#createBlueFollowUpFlag--) | * BlueFollowUpFlag アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createBlueFollowUpFlag(String label)](#createBlueFollowUpFlag-java.lang.String-) | * デフォルトラベルで、BlueFollowUpFlag アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueLeftArrow()](#createBlueLeftArrow--) | * デフォルトラベルで、BlueLeftArrow アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueLeftArrow(String label)](#createBlueLeftArrow-java.lang.String-) | * 指定されたラベルで、BlueLeftArrow アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueRightArrow()](#createBlueRightArrow--) | * デフォルトラベルで、BlueRightArrow アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueRightArrow(String label)](#createBlueRightArrow-java.lang.String-) | * 指定されたラベルで、BlueRightArrow アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueSolidTarget()](#createBlueSolidTarget--) | * デフォルトラベルで、BlueSolidTarget アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueSolidTarget(String label)](#createBlueSolidTarget-java.lang.String-) | * 指定されたラベルで、BlueSolidTarget アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueSquare()](#createBlueSquare--) | * デフォルトラベルで、BlueSquare アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueSquare(String label)](#createBlueSquare-java.lang.String-) | * 指定されたラベルで、BlueSquare アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueStar()](#createBlueStar--) | * デフォルトラベルで、BlueStar アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueStar(String label)](#createBlueStar-java.lang.String-) | * 指定されたラベルで、BlueStar アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueSun()](#createBlueSun--) | * デフォルトラベルで、BlueSun アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueSun(String label)](#createBlueSun-java.lang.String-) | * 指定されたラベルで、BlueSun アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueTarget()](#createBlueTarget--) | * デフォルトラベルで、BlueTarget アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueTarget(String label)](#createBlueTarget-java.lang.String-) | * 指定されたラベルで、BlueTarget アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueTriangle()](#createBlueTriangle--) | * デフォルトラベルで、BlueTriangle アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueTriangle(String label)](#createBlueTriangle-java.lang.String-) | * 指定されたラベルで、BlueTriangle アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueUmbrella()](#createBlueUmbrella--) | * デフォルトラベルで、BlueUmbrella アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueUmbrella(String label)](#createBlueUmbrella-java.lang.String-) | * 指定されたラベルで、BlueUmbrella アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueUpArrow()](#createBlueUpArrow--) | * デフォルトラベルで、BlueUpArrow アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueUpArrow(String label)](#createBlueUpArrow-java.lang.String-) | * 指定されたラベルで、BlueUpArrow アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueXNo()](#createBlueXNo--) | * デフォルトラベルで、BlueXNo アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueXNo(String label)](#createBlueXNo-java.lang.String-) | * 指定されたラベルで、BlueXNo アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueXWithDots()](#createBlueXWithDots--) | * デフォルトラベルで、BlueXWithDots アイコンを使用した新しいノートタグを作成します。 |
+| [createBlueXWithDots(String label)](#createBlueXWithDots-java.lang.String-) | * 指定されたラベルで、BlueXWithDots アイコンを使用した新しいノートタグを作成します。 |
+| [createCalendarDateWithClock()](#createCalendarDateWithClock--) | \* CalendarDateWithClock アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createCalendarDateWithClock(String label)](#createCalendarDateWithClock-java.lang.String-) | \* CalendarDateWithClock アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createCar()](#createCar--) | \* Car アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createCar(String label)](#createCar-java.lang.String-) | \* Car アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createClosedEnvelope()](#createClosedEnvelope--) | \* ClosedEnvelope アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createClosedEnvelope(String label)](#createClosedEnvelope-java.lang.String-) | \* ClosedEnvelope アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createCloud()](#createCloud--) | \* Cloud アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createCloud(String label)](#createCloud-java.lang.String-) | \* Cloud アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createCoinsWithWindowBackdrop()](#createCoinsWithWindowBackdrop--) | \* CoinsWithWindowBackdrop アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createCoinsWithWindowBackdrop(String label)](#createCoinsWithWindowBackdrop-java.lang.String-) | \* CoinsWithWindowBackdrop アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createCommentBubble()](#createCommentBubble--) | \* CommentBubble アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createCommentBubble(String label)](#createCommentBubble-java.lang.String-) | \* CommentBubble アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createContactInformation()](#createContactInformation--) | \* ContactInformation アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createContactInformation(String label)](#createContactInformation-java.lang.String-) | \* ContactInformation アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createContactPersonOnCard()](#createContactPersonOnCard--) | \* ContactPersonOnCard アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createContactPersonOnCard(String label)](#createContactPersonOnCard-java.lang.String-) | \* ContactPersonOnCard アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createDollarSign()](#createDollarSign--) | \* DollarSign アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createDollarSign(String label)](#createDollarSign-java.lang.String-) | \* DollarSign アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createEMailMessage()](#createEMailMessage--) | \* EMailMessage アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createEMailMessage(String label)](#createEMailMessage-java.lang.String-) | \* EMailMessage アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createFrowningFace()](#createFrowningFace--) | \* FrowningFace アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createFrowningFace(String label)](#createFrowningFace-java.lang.String-) | \* FrowningFace アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createGlobe()](#createGlobe--) | \* Globe アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createGlobe(String label)](#createGlobe-java.lang.String-) | \* Globe アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createGreenCheckMark()](#createGreenCheckMark--) | \* GreenCheckMark アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createGreenCheckMark(String label)](#createGreenCheckMark-java.lang.String-) | * 新しいノートタグを作成し、GreenCheckMark アイコンと指定ラベルを使用します。 |
+| [createGreenCircle()](#createGreenCircle--) | * 新しいノートタグを作成し、GreenCircle アイコンとデフォルトラベルを使用します。 |
+| [createGreenCircle(String label)](#createGreenCircle-java.lang.String-) | * 新しいノートタグを作成し、GreenCircle アイコンと指定ラベルを使用します。 |
+| [createGreenCircle1()](#createGreenCircle1--) | * 新しいノートタグを作成し、GreenCircle1 アイコンとデフォルトラベルを使用します。 |
+| [createGreenCircle1(String label)](#createGreenCircle1-java.lang.String-) | * 新しいノートタグを作成し、GreenCircle1 アイコンと指定ラベルを使用します。 |
+| [createGreenCircle2()](#createGreenCircle2--) | * 新しいノートタグを作成し、GreenCircle2 アイコンとデフォルトラベルを使用します。 |
+| [createGreenCircle2(String label)](#createGreenCircle2-java.lang.String-) | * 新しいノートタグを作成し、GreenCircle2 アイコンと指定ラベルを使用します。 |
+| [createGreenCircle3()](#createGreenCircle3--) | * 新しいノートタグを作成し、GreenCircle3 アイコンとデフォルトラベルを使用します。 |
+| [createGreenCircle3(String label)](#createGreenCircle3-java.lang.String-) | * 新しいノートタグを作成し、GreenCircle3 アイコンと指定ラベルを使用します。 |
+| [createGreenDownArrow()](#createGreenDownArrow--) | * 新しいノートタグを作成し、GreenDownArrow アイコンとデフォルトラベルを使用します。 |
+| [createGreenDownArrow(String label)](#createGreenDownArrow-java.lang.String-) | * 新しいノートタグを作成し、GreenDownArrow アイコンと指定ラベルを使用します。 |
+| [createGreenEightPointStar()](#createGreenEightPointStar--) | * 新しいノートタグを作成し、GreenEightPointStar アイコンとデフォルトラベルを使用します。 |
+| [createGreenEightPointStar(String label)](#createGreenEightPointStar-java.lang.String-) | * 新しいノートタグを作成し、GreenEightPointStar アイコンと指定ラベルを使用します。 |
+| [createGreenLeftArrow()](#createGreenLeftArrow--) | * 新しいノートタグを作成し、GreenLeftArrow アイコンとデフォルトラベルを使用します。 |
+| [createGreenLeftArrow(String label)](#createGreenLeftArrow-java.lang.String-) | * 新しいノートタグを作成し、GreenLeftArrow アイコンと指定ラベルを使用します。 |
+| [createGreenRightArrow()](#createGreenRightArrow--) | * 新しいノートタグを作成し、GreenRightArrow アイコンとデフォルトラベルを使用します。 |
+| [createGreenRightArrow(String label)](#createGreenRightArrow-java.lang.String-) | * 新しいノートタグを作成し、GreenRightArrow アイコンと指定ラベルを使用します。 |
+| [createGreenSolidArrow()](#createGreenSolidArrow--) | * 新しいノートタグを作成し、GreenSolidArrow アイコンとデフォルトラベルを使用します。 |
+| [createGreenSolidArrow(String label)](#createGreenSolidArrow-java.lang.String-) | * 新しいノートタグを作成し、GreenSolidArrow アイコンと指定ラベルを使用します。 |
+| [createGreenSquare()](#createGreenSquare--) | * 新しいノートタグを作成し、GreenSquare アイコンとデフォルトラベルを使用します。 |
+| [createGreenSquare(String label)](#createGreenSquare-java.lang.String-) | * 新しいノートタグを作成し、GreenSquare アイコンと指定ラベルを使用します。 |
+| [createGreenStar()](#createGreenStar--) | * 新しいノートタグを作成し、GreenStar アイコンとデフォルトラベルを使用します。 |
+| [createGreenStar(String label)](#createGreenStar-java.lang.String-) | * 新しいノートタグを作成し、GreenStar アイコンと指定ラベルを使用します。 |
+| [createGreenSun()](#createGreenSun--) | * 新しいノートタグを作成し、GreenSun アイコンとデフォルトラベルを使用します。 |
+| [createGreenSun(String label)](#createGreenSun-java.lang.String-) | * 新しいノートタグを作成し、GreenSun アイコンと指定ラベルを使用します。 |
+| [createGreenTarget()](#createGreenTarget--) | * GreenTarget アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createGreenTarget(String label)](#createGreenTarget-java.lang.String-) | * GreenTarget アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createGreenTriangle()](#createGreenTriangle--) | * GreenTriangle アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createGreenTriangle(String label)](#createGreenTriangle-java.lang.String-) | * GreenTriangle アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createGreenUmbrella()](#createGreenUmbrella--) | * GreenUmbrella アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createGreenUmbrella(String label)](#createGreenUmbrella-java.lang.String-) | * GreenUmbrella アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createGreenUpArrow()](#createGreenUpArrow--) | * GreenUpArrow アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createGreenUpArrow(String label)](#createGreenUpArrow-java.lang.String-) | * GreenUpArrow アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createGreenXNo()](#createGreenXNo--) | * GreenXNo アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createGreenXNo(String label)](#createGreenXNo-java.lang.String-) | * GreenXNo アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createGreenXWithDots()](#createGreenXWithDots--) | * GreenXWithDots アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createGreenXWithDots(String label)](#createGreenXWithDots-java.lang.String-) | * GreenXWithDots アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createHeart()](#createHeart--) | * Heart アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createHeart(String label)](#createHeart-java.lang.String-) | * Heart アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createHighPriority()](#createHighPriority--) | * HighPriority アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createHighPriority(String label)](#createHighPriority-java.lang.String-) | * HighPriority アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createHome()](#createHome--) | * Home アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createHome(String label)](#createHome-java.lang.String-) | * Home アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createHyperlinkGlobe()](#createHyperlinkGlobe--) | * HyperlinkGlobe アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createHyperlinkGlobe(String label)](#createHyperlinkGlobe-java.lang.String-) | * HyperlinkGlobe アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createInstantMessagingContactPerson()](#createInstantMessagingContactPerson--) | * InstantMessagingContactPerson アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createInstantMessagingContactPerson(String label)](#createInstantMessagingContactPerson-java.lang.String-) | * InstantMessagingContactPerson アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createLaptop()](#createLaptop--) | * Laptop アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createLaptop(String label)](#createLaptop-java.lang.String-) | * Laptop アイコンと指定ラベルで新しいノートタグを作成します。 |
+| [createLightBulb()](#createLightBulb--) | * LightBulb アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createLightBulb(String label)](#createLightBulb-java.lang.String-) | * 新しいノートタグを LightBulb アイコンと指定されたラベルで作成します。 |
+| [createLightningBolt()](#createLightningBolt--) | * 新しいノートタグを LightningBolt アイコンとデフォルトラベルで作成します。 |
+| [createLightningBolt(String label)](#createLightningBolt-java.lang.String-) | * 新しいノートタグを LightningBolt アイコンと指定されたラベルで作成します。 |
+| [createMeeting()](#createMeeting--) | * 新しいノートタグを Meeting アイコンとデフォルトラベルで作成します。 |
+| [createMeeting(String label)](#createMeeting-java.lang.String-) | * 新しいノートタグを Meeting アイコンと指定されたラベルで作成します。 |
+| [createMobilePhone()](#createMobilePhone--) | * 新しいノートタグを MobilePhone アイコンとデフォルトラベルで作成します。 |
+| [createMobilePhone(String label)](#createMobilePhone-java.lang.String-) | * 新しいノートタグを MobilePhone アイコンと指定されたラベルで作成します。 |
+| [createMovieClip()](#createMovieClip--) | * 新しいノートタグを MovieClip アイコンとデフォルトラベルで作成します。 |
+| [createMovieClip(String label)](#createMovieClip-java.lang.String-) | * 新しいノートタグを MovieClip アイコンと指定されたラベルで作成します。 |
+| [createMusicalNote()](#createMusicalNote--) | * 新しいノートタグを MusicalNote アイコンとデフォルトラベルで作成します。 |
+| [createMusicalNote(String label)](#createMusicalNote-java.lang.String-) | * 新しいノートタグを MusicalNote アイコンと指定されたラベルで作成します。 |
+| [createNoIcon()](#createNoIcon--) | * アイコンなしで新しいノートタグをデフォルトラベルで作成します。 |
+| [createNoIcon(String label)](#createNoIcon-java.lang.String-) | * アイコンなしで新しいノートタグを作成します。 |
+| [createNotebookWithClock()](#createNotebookWithClock--) | * 新しいノートタグを NotebookWithClock アイコンとデフォルトラベルで作成します。 |
+| [createNotebookWithClock(String label)](#createNotebookWithClock-java.lang.String-) | * 新しいノートタグを NotebookWithClock アイコンと指定されたラベルで作成します。 |
+| [createOpenBook()](#createOpenBook--) | * 新しいノートタグを OpenBook アイコンとデフォルトラベルで作成します。 |
+| [createOpenBook(String label)](#createOpenBook-java.lang.String-) | * 新しいノートタグを OpenBook アイコンと指定されたラベルで作成します。 |
+| [createOpenEnvelope()](#createOpenEnvelope--) | * 新しいノートタグを OpenEnvelope アイコンとデフォルトラベルで作成します。 |
+| [createOpenEnvelope(String label)](#createOpenEnvelope-java.lang.String-) | * 新しいノートタグを OpenEnvelope アイコンと指定されたラベルで作成します。 |
+| [createOrangeSquare()](#createOrangeSquare--) | * 新しいノートタグを OrangeSquare アイコンとデフォルトラベルで作成します。 |
+| [createOrangeSquare(String label)](#createOrangeSquare-java.lang.String-) | * 新しいノートタグを OrangeSquare アイコンと指定されたラベルで作成します。 |
+| [createPadlock()](#createPadlock--) | * 新しいノートタグを Padlock アイコンとデフォルトラベルで作成します。 |
+| [createPadlock(String label)](#createPadlock-java.lang.String-) | * 新しいノートタグを Padlock アイコンと指定されたラベルで作成します。 |
+| [createPaperClip()](#createPaperClip--) | * 新しいノートタグを PaperClip アイコンとデフォルトラベルで作成します。 |
+| [createPaperClip(String label)](#createPaperClip-java.lang.String-) | * 新しいノートタグを PaperClip アイコンと指定されたラベルで作成します。 |
+| [createPen()](#createPen--) | * ペンアイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createPen(String label)](#createPen-java.lang.String-) | * ペンアイコンで新しいノートタグを作成し、指定されたラベルを使用します。 |
+| [createPersonWithExclamationMark()](#createPersonWithExclamationMark--) | * PersonWithExclamationMark アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createPersonWithExclamationMark(String label)](#createPersonWithExclamationMark-java.lang.String-) | * PersonWithExclamationMark アイコンで新しいノートタグを作成し、指定されたラベルを使用します。 |
+| [createPinkSquare()](#createPinkSquare--) | * PinkSquare アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createPinkSquare(String label)](#createPinkSquare-java.lang.String-) | * PinkSquare アイコンで新しいノートタグを作成し、指定されたラベルを使用します。 |
+| [createPlane()](#createPlane--) | * Plane アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createPlane(String label)](#createPlane-java.lang.String-) | * Plane アイコンで新しいノートタグを作成し、指定されたラベルを使用します。 |
+| [createPresentationSlide()](#createPresentationSlide--) | * PresentationSlide アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createPresentationSlide(String label)](#createPresentationSlide-java.lang.String-) | * PresentationSlide アイコンで新しいノートタグを作成し、指定されたラベルを使用します。 |
+| [createPushpin()](#createPushpin--) | * Pushpin アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createPushpin(String label)](#createPushpin-java.lang.String-) | * Pushpin アイコンで新しいノートタグを作成し、指定されたラベルを使用します。 |
+| [createQuestionBalloon()](#createQuestionBalloon--) | * QuestionBalloon アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createQuestionBalloon(String label)](#createQuestionBalloon-java.lang.String-) | * QuestionBalloon アイコンで新しいノートタグを作成し、指定されたラベルを使用します。 |
+| [createQuestionMark()](#createQuestionMark--) | * QuestionMark アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createQuestionMark(String label)](#createQuestionMark-java.lang.String-) | * QuestionMark アイコンで新しいノートタグを作成し、指定されたラベルを使用します。 |
+| [createQuotationMark()](#createQuotationMark--) | * QuotationMark アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createQuotationMark(String label)](#createQuotationMark-java.lang.String-) | * QuotationMark アイコンで新しいノートタグを作成し、指定されたラベルを使用します。 |
+| [createRedSquare()](#createRedSquare--) | * RedSquare アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createRedSquare(String label)](#createRedSquare-java.lang.String-) | * RedSquare アイコンで新しいノートタグを作成し、指定されたラベルを使用します。 |
+| [createReminderBell()](#createReminderBell--) | * ReminderBell アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createReminderBell(String label)](#createReminderBell-java.lang.String-) | * ReminderBell アイコンで新しいノートタグを作成し、指定されたラベルを使用します。 |
+| [createResearch()](#createResearch--) | * Research アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createResearch(String label)](#createResearch-java.lang.String-) | * Research アイコンで新しいノートタグを作成し、指定されたラベルを使用します。 |
+| [createRoseOnStem()](#createRoseOnStem--) | * RoseOnStem アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createRoseOnStem(String label)](#createRoseOnStem-java.lang.String-) | * RoseOnStem アイコンと指定されたラベルで新しいノートタグを作成します。 |
+| [createScheduledTask()](#createScheduledTask--) | * ScheduledTask アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createScheduledTask(String label)](#createScheduledTask-java.lang.String-) | * ScheduledTask アイコンと指定されたラベルで新しいノートタグを作成します。 |
+| [createSmilingFace()](#createSmilingFace--) | * SmilingFace アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createSmilingFace(String label)](#createSmilingFace-java.lang.String-) | * SmilingFace アイコンと指定されたラベルで新しいノートタグを作成します。 |
+| [createSunflower()](#createSunflower--) | * Sunflower アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createSunflower(String label)](#createSunflower-java.lang.String-) | * Sunflower アイコンと指定されたラベルで新しいノートタグを作成します。 |
+| [createTelephoneWithClock()](#createTelephoneWithClock--) | * TelephoneWithClock アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createTelephoneWithClock(String label)](#createTelephoneWithClock-java.lang.String-) | * TelephoneWithClock アイコンと指定されたラベルで新しいノートタグを作成します。 |
+| [createTimeSensitive()](#createTimeSensitive--) | * TimeSensitive アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createTimeSensitive(String label)](#createTimeSensitive-java.lang.String-) | * TimeSensitive アイコンと指定されたラベルで新しいノートタグを作成します。 |
+| [createTwoPeople()](#createTwoPeople--) | * TwoPeople アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createTwoPeople(String label)](#createTwoPeople-java.lang.String-) | * TwoPeople アイコンと指定されたラベルで新しいノートタグを作成します。 |
+| [createYellowCheckMark()](#createYellowCheckMark--) | * YellowCheckMark アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createYellowCheckMark(String label)](#createYellowCheckMark-java.lang.String-) | * YellowCheckMark アイコンと指定されたラベルで新しいノートタグを作成します。 |
+| [createYellowCircle()](#createYellowCircle--) | * YellowCircle アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createYellowCircle(String label)](#createYellowCircle-java.lang.String-) | * YellowCircle アイコンと指定されたラベルで新しいノートタグを作成します。 |
+| [createYellowCircle1()](#createYellowCircle1--) | * YellowCircle1 アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createYellowCircle1(String label)](#createYellowCircle1-java.lang.String-) | * YellowCircle1 アイコンと指定されたラベルで新しいノートタグを作成します。 |
+| [createYellowCircle2()](#createYellowCircle2--) | * YellowCircle2 アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createYellowCircle2(String label)](#createYellowCircle2-java.lang.String-) | * YellowCircle2 アイコンと指定されたラベルで新しいノートタグを作成します。 |
+| [createYellowCircle3()](#createYellowCircle3--) | * YellowCircle3 アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createYellowCircle3(String label)](#createYellowCircle3-java.lang.String-) | * YellowCircle3 アイコンと指定されたラベルで新しいノートタグを作成します。 |
+| [createYellowDownArrow()](#createYellowDownArrow--) | * YellowDownArrow アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createYellowDownArrow(String label)](#createYellowDownArrow-java.lang.String-) | * YellowDownArrow アイコンと指定されたラベルで新しいノートタグを作成します。 |
+| [createYellowEightPointStar()](#createYellowEightPointStar--) | \* YellowEightPointStar アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createYellowEightPointStar(String label)](#createYellowEightPointStar-java.lang.String-) | \* YellowEightPointStar アイコンで新しいノートタグを作成し、指定ラベルを使用します。 |
+| [createYellowKey()](#createYellowKey--) | \* YellowKey アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createYellowKey(String label)](#createYellowKey-java.lang.String-) | \* YellowKey アイコンで新しいノートタグを作成し、指定ラベルを使用します。 |
+| [createYellowLeftArrow()](#createYellowLeftArrow--) | \* YellowLeftArrow アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createYellowLeftArrow(String label)](#createYellowLeftArrow-java.lang.String-) | \* YellowLeftArrow アイコンで新しいノートタグを作成し、指定ラベルを使用します。 |
+| [createYellowRightArrow()](#createYellowRightArrow--) | \* YellowRightArrow アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createYellowRightArrow(String label)](#createYellowRightArrow-java.lang.String-) | \* YellowRightArrow アイコンで新しいノートタグを作成し、指定ラベルを使用します。 |
+| [createYellowSolidTarget()](#createYellowSolidTarget--) | \* YellowSolidTarget アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createYellowSolidTarget(String label)](#createYellowSolidTarget-java.lang.String-) | \* YellowSolidTarget アイコンで新しいノートタグを作成し、指定ラベルを使用します。 |
+| [createYellowSquare()](#createYellowSquare--) | \* YellowSquare アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createYellowSquare(String label)](#createYellowSquare-java.lang.String-) | \* YellowSquare アイコンで新しいノートタグを作成し、指定ラベルを使用します。 |
+| [createYellowStar()](#createYellowStar--) | \* YellowStar アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createYellowStar(String label)](#createYellowStar-java.lang.String-) | \* YellowStar アイコンで新しいノートタグを作成し、指定ラベルを使用します。 |
+| [createYellowSun()](#createYellowSun--) | \* YellowSun アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createYellowSun(String label)](#createYellowSun-java.lang.String-) | \* YellowSun アイコンで新しいノートタグを作成し、指定ラベルを使用します。 |
+| [createYellowTarget()](#createYellowTarget--) | \* YellowTarget アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createYellowTarget(String label)](#createYellowTarget-java.lang.String-) | \* YellowTarget アイコンで新しいノートタグを作成し、指定ラベルを使用します。 |
+| [createYellowTriangle()](#createYellowTriangle--) | \* YellowTriangle アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createYellowTriangle(String label)](#createYellowTriangle-java.lang.String-) | \* YellowTriangle アイコンで新しいノートタグを作成し、指定ラベルを使用します。 |
+| [createYellowUmbrella()](#createYellowUmbrella--) | \* YellowUmbrella アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createYellowUmbrella(String label)](#createYellowUmbrella-java.lang.String-) | \* YellowUmbrella アイコンで新しいノートタグを作成し、指定ラベルを使用します。 |
+| [createYellowUpArrow()](#createYellowUpArrow--) | \* YellowUpArrow アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createYellowUpArrow(String label)](#createYellowUpArrow-java.lang.String-) | \* YellowUpArrow アイコンで新しいノートタグを作成し、指定ラベルを使用します。 |
+| [createYellowX()](#createYellowX--) | \* YellowX アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。 |
+| [createYellowX(String label)](#createYellowX-java.lang.String-) | * 指定されたラベルと YellowX アイコンで新しいノートタグを作成します。 |
+| [createYellowXWithDots()](#createYellowXWithDots--) | * YellowXWithDots アイコンとデフォルトラベルで新しいノートタグを作成します。 |
+| [createYellowXWithDots(String label)](#createYellowXWithDots-java.lang.String-) | * YellowXWithDots アイコンと指定されたラベルで新しいノートタグを作成します。 |
+| [equals(NoteTag other)](#equals-com.aspose.note.NoteTag-) | 指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。 |
+| [equals(Object obj)](#equals-java.lang.Object-) | 指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。 |
+| [getCompletedTime()](#getCompletedTime--) | 完了時間を取得または設定します。 |
+| [getCreationTime()](#getCreationTime--) | 作成時間を取得または設定します。 |
+| [getFontColor()](#getFontColor--) | フォントの色を取得または設定します。 |
+| [getHighlight()](#getHighlight--) | ハイライト色を取得または設定します。 |
+| [getIcon()](#getIcon--) | アイコンを取得または設定します。 |
+| [getLabel()](#getLabel--) | ラベルテキストを取得します。 |
+| [getStatus()](#getStatus--) | ステータスを取得または設定します。 |
+| [hashCode()](#hashCode--) | 型のハッシュ関数として機能します。 |
+| [setCreationTime(Date value)](#setCreationTime-java.util.Date-) | 作成時間を取得または設定します。 |
+| [setFontColor(Color value)](#setFontColor-java.awt.Color-) | フォントの色を取得または設定します。 |
+| [setHighlight(Color value)](#setHighlight-java.awt.Color-) | ハイライト色を取得または設定します。 |
+| [setIcon(int value)](#setIcon-int-) | アイコンを取得または設定します。 |
+| [setLabel(String value)](#setLabel-java.lang.String-) | ラベルテキストを設定します。 |
+### NoteTag() {#NoteTag--}
+```
+public NoteTag()
+```
+
+
+アイコンなしで [NoteTag](../../com.aspose.note/notetag) クラスの新しいインスタンスを初期化します。
+
+### createAwardRibbon() {#createAwardRibbon--}
+```
+public static NoteTag createAwardRibbon()
+```
+
+
+* AwardRibbon アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createAwardRibbon(String label) {#createAwardRibbon-java.lang.String-}
+```
+public static NoteTag createAwardRibbon(String label)
+```
+
+
+* AwardRibbon アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBinoculars() {#createBinoculars--}
+```
+public static NoteTag createBinoculars()
+```
+
+
+* Binoculars アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBinoculars(String label) {#createBinoculars-java.lang.String-}
+```
+public static NoteTag createBinoculars(String label)
+```
+
+
+* Binoculars アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlankPaperWithLines() {#createBlankPaperWithLines--}
+```
+public static NoteTag createBlankPaperWithLines()
+```
+
+
+* BlankPaperWithLines アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlankPaperWithLines(String label) {#createBlankPaperWithLines-java.lang.String-}
+```
+public static NoteTag createBlankPaperWithLines(String label)
+```
+
+
+* BlankPaperWithLines アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCheckMark() {#createBlueCheckMark--}
+```
+public static NoteTag createBlueCheckMark()
+```
+
+
+* BlueCheckMark アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCheckMark(String label) {#createBlueCheckMark-java.lang.String-}
+```
+public static NoteTag createBlueCheckMark(String label)
+```
+
+
+* BlueCheckMark アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle() {#createBlueCircle--}
+```
+public static NoteTag createBlueCircle()
+```
+
+
+* BlueCircle アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle(String label) {#createBlueCircle-java.lang.String-}
+```
+public static NoteTag createBlueCircle(String label)
+```
+
+
+* BlueCircle アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle1() {#createBlueCircle1--}
+```
+public static NoteTag createBlueCircle1()
+```
+
+
+* BlueCircle1 アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle1(String label) {#createBlueCircle1-java.lang.String-}
+```
+public static NoteTag createBlueCircle1(String label)
+```
+
+
+* BlueCircle1 アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle2() {#createBlueCircle2--}
+```
+public static NoteTag createBlueCircle2()
+```
+
+
+* BlueCircle2 アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle2(String label) {#createBlueCircle2-java.lang.String-}
+```
+public static NoteTag createBlueCircle2(String label)
+```
+
+
+* BlueCircle2 アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle3() {#createBlueCircle3--}
+```
+public static NoteTag createBlueCircle3()
+```
+
+
+* BlueCircle3 アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle3(String label) {#createBlueCircle3-java.lang.String-}
+```
+public static NoteTag createBlueCircle3(String label)
+```
+
+
+* BlueCircle3 アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueDownArrow() {#createBlueDownArrow--}
+```
+public static NoteTag createBlueDownArrow()
+```
+
+
+* BlueDownArrow アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueDownArrow(String label) {#createBlueDownArrow-java.lang.String-}
+```
+public static NoteTag createBlueDownArrow(String label)
+```
+
+
+* BlueDownArrow アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueEightPointStar() {#createBlueEightPointStar--}
+```
+public static NoteTag createBlueEightPointStar()
+```
+
+
+* BlueEightPointStar アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueEightPointStar(String label) {#createBlueEightPointStar-java.lang.String-}
+```
+public static NoteTag createBlueEightPointStar(String label)
+```
+
+
+* BlueEightPointStar アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueFollowUpFlag() {#createBlueFollowUpFlag--}
+```
+public static NoteTag createBlueFollowUpFlag()
+```
+
+
+* BlueFollowUpFlag アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueFollowUpFlag(String label) {#createBlueFollowUpFlag-java.lang.String-}
+```
+public static NoteTag createBlueFollowUpFlag(String label)
+```
+
+
+* デフォルトラベルで、BlueFollowUpFlag アイコンを使用した新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueLeftArrow() {#createBlueLeftArrow--}
+```
+public static NoteTag createBlueLeftArrow()
+```
+
+
+* デフォルトラベルで、BlueLeftArrow アイコンを使用した新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueLeftArrow(String label) {#createBlueLeftArrow-java.lang.String-}
+```
+public static NoteTag createBlueLeftArrow(String label)
+```
+
+
+* 指定されたラベルで、BlueLeftArrow アイコンを使用した新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueRightArrow() {#createBlueRightArrow--}
+```
+public static NoteTag createBlueRightArrow()
+```
+
+
+* デフォルトラベルで、BlueRightArrow アイコンを使用した新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueRightArrow(String label) {#createBlueRightArrow-java.lang.String-}
+```
+public static NoteTag createBlueRightArrow(String label)
+```
+
+
+* 指定されたラベルで、BlueRightArrow アイコンを使用した新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueSolidTarget() {#createBlueSolidTarget--}
+```
+public static NoteTag createBlueSolidTarget()
+```
+
+
+* デフォルトラベルで、BlueSolidTarget アイコンを使用した新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueSolidTarget(String label) {#createBlueSolidTarget-java.lang.String-}
+```
+public static NoteTag createBlueSolidTarget(String label)
+```
+
+
+* 指定されたラベルで、BlueSolidTarget アイコンを使用した新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueSquare() {#createBlueSquare--}
+```
+public static NoteTag createBlueSquare()
+```
+
+
+* デフォルトラベルで、BlueSquare アイコンを使用した新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueSquare(String label) {#createBlueSquare-java.lang.String-}
+```
+public static NoteTag createBlueSquare(String label)
+```
+
+
+* 指定されたラベルで、BlueSquare アイコンを使用した新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueStar() {#createBlueStar--}
+```
+public static NoteTag createBlueStar()
+```
+
+
+* デフォルトラベルで、BlueStar アイコンを使用した新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueStar(String label) {#createBlueStar-java.lang.String-}
+```
+public static NoteTag createBlueStar(String label)
+```
+
+
+* 指定されたラベルで、BlueStar アイコンを使用した新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueSun() {#createBlueSun--}
+```
+public static NoteTag createBlueSun()
+```
+
+
+* デフォルトラベルで、BlueSun アイコンを使用した新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueSun(String label) {#createBlueSun-java.lang.String-}
+```
+public static NoteTag createBlueSun(String label)
+```
+
+
+* 指定されたラベルで、BlueSun アイコンを使用した新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueTarget() {#createBlueTarget--}
+```
+public static NoteTag createBlueTarget()
+```
+
+
+* デフォルトラベルで、BlueTarget アイコンを使用した新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueTarget(String label) {#createBlueTarget-java.lang.String-}
+```
+public static NoteTag createBlueTarget(String label)
+```
+
+
+* 指定されたラベルで、BlueTarget アイコンを使用した新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueTriangle() {#createBlueTriangle--}
+```
+public static NoteTag createBlueTriangle()
+```
+
+
+* デフォルトラベルで、BlueTriangle アイコンを使用した新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueTriangle(String label) {#createBlueTriangle-java.lang.String-}
+```
+public static NoteTag createBlueTriangle(String label)
+```
+
+
+* 指定されたラベルで、BlueTriangle アイコンを使用した新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueUmbrella() {#createBlueUmbrella--}
+```
+public static NoteTag createBlueUmbrella()
+```
+
+
+* デフォルトラベルで、BlueUmbrella アイコンを使用した新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueUmbrella(String label) {#createBlueUmbrella-java.lang.String-}
+```
+public static NoteTag createBlueUmbrella(String label)
+```
+
+
+* 指定されたラベルで、BlueUmbrella アイコンを使用した新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueUpArrow() {#createBlueUpArrow--}
+```
+public static NoteTag createBlueUpArrow()
+```
+
+
+* デフォルトラベルで、BlueUpArrow アイコンを使用した新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueUpArrow(String label) {#createBlueUpArrow-java.lang.String-}
+```
+public static NoteTag createBlueUpArrow(String label)
+```
+
+
+* 指定されたラベルで、BlueUpArrow アイコンを使用した新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueXNo() {#createBlueXNo--}
+```
+public static NoteTag createBlueXNo()
+```
+
+
+* デフォルトラベルで、BlueXNo アイコンを使用した新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueXNo(String label) {#createBlueXNo-java.lang.String-}
+```
+public static NoteTag createBlueXNo(String label)
+```
+
+
+* 指定されたラベルで、BlueXNo アイコンを使用した新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueXWithDots() {#createBlueXWithDots--}
+```
+public static NoteTag createBlueXWithDots()
+```
+
+
+* デフォルトラベルで、BlueXWithDots アイコンを使用した新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueXWithDots(String label) {#createBlueXWithDots-java.lang.String-}
+```
+public static NoteTag createBlueXWithDots(String label)
+```
+
+
+* 指定されたラベルで、BlueXWithDots アイコンを使用した新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCalendarDateWithClock() {#createCalendarDateWithClock--}
+```
+public static NoteTag createCalendarDateWithClock()
+```
+
+
+\* CalendarDateWithClock アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCalendarDateWithClock(String label) {#createCalendarDateWithClock-java.lang.String-}
+```
+public static NoteTag createCalendarDateWithClock(String label)
+```
+
+
+\* CalendarDateWithClock アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCar() {#createCar--}
+```
+public static NoteTag createCar()
+```
+
+
+\* Car アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCar(String label) {#createCar-java.lang.String-}
+```
+public static NoteTag createCar(String label)
+```
+
+
+\* Car アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createClosedEnvelope() {#createClosedEnvelope--}
+```
+public static NoteTag createClosedEnvelope()
+```
+
+
+\* ClosedEnvelope アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createClosedEnvelope(String label) {#createClosedEnvelope-java.lang.String-}
+```
+public static NoteTag createClosedEnvelope(String label)
+```
+
+
+\* ClosedEnvelope アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCloud() {#createCloud--}
+```
+public static NoteTag createCloud()
+```
+
+
+\* Cloud アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCloud(String label) {#createCloud-java.lang.String-}
+```
+public static NoteTag createCloud(String label)
+```
+
+
+\* Cloud アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCoinsWithWindowBackdrop() {#createCoinsWithWindowBackdrop--}
+```
+public static NoteTag createCoinsWithWindowBackdrop()
+```
+
+
+\* CoinsWithWindowBackdrop アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCoinsWithWindowBackdrop(String label) {#createCoinsWithWindowBackdrop-java.lang.String-}
+```
+public static NoteTag createCoinsWithWindowBackdrop(String label)
+```
+
+
+\* CoinsWithWindowBackdrop アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCommentBubble() {#createCommentBubble--}
+```
+public static NoteTag createCommentBubble()
+```
+
+
+\* CommentBubble アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCommentBubble(String label) {#createCommentBubble-java.lang.String-}
+```
+public static NoteTag createCommentBubble(String label)
+```
+
+
+\* CommentBubble アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createContactInformation() {#createContactInformation--}
+```
+public static NoteTag createContactInformation()
+```
+
+
+\* ContactInformation アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createContactInformation(String label) {#createContactInformation-java.lang.String-}
+```
+public static NoteTag createContactInformation(String label)
+```
+
+
+\* ContactInformation アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createContactPersonOnCard() {#createContactPersonOnCard--}
+```
+public static NoteTag createContactPersonOnCard()
+```
+
+
+\* ContactPersonOnCard アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createContactPersonOnCard(String label) {#createContactPersonOnCard-java.lang.String-}
+```
+public static NoteTag createContactPersonOnCard(String label)
+```
+
+
+\* ContactPersonOnCard アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createDollarSign() {#createDollarSign--}
+```
+public static NoteTag createDollarSign()
+```
+
+
+\* DollarSign アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createDollarSign(String label) {#createDollarSign-java.lang.String-}
+```
+public static NoteTag createDollarSign(String label)
+```
+
+
+\* DollarSign アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createEMailMessage() {#createEMailMessage--}
+```
+public static NoteTag createEMailMessage()
+```
+
+
+\* EMailMessage アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createEMailMessage(String label) {#createEMailMessage-java.lang.String-}
+```
+public static NoteTag createEMailMessage(String label)
+```
+
+
+\* EMailMessage アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createFrowningFace() {#createFrowningFace--}
+```
+public static NoteTag createFrowningFace()
+```
+
+
+\* FrowningFace アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createFrowningFace(String label) {#createFrowningFace-java.lang.String-}
+```
+public static NoteTag createFrowningFace(String label)
+```
+
+
+\* FrowningFace アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGlobe() {#createGlobe--}
+```
+public static NoteTag createGlobe()
+```
+
+
+\* Globe アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGlobe(String label) {#createGlobe-java.lang.String-}
+```
+public static NoteTag createGlobe(String label)
+```
+
+
+\* Globe アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCheckMark() {#createGreenCheckMark--}
+```
+public static NoteTag createGreenCheckMark()
+```
+
+
+\* GreenCheckMark アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCheckMark(String label) {#createGreenCheckMark-java.lang.String-}
+```
+public static NoteTag createGreenCheckMark(String label)
+```
+
+
+* 新しいノートタグを作成し、GreenCheckMark アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle() {#createGreenCircle--}
+```
+public static NoteTag createGreenCircle()
+```
+
+
+* 新しいノートタグを作成し、GreenCircle アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle(String label) {#createGreenCircle-java.lang.String-}
+```
+public static NoteTag createGreenCircle(String label)
+```
+
+
+* 新しいノートタグを作成し、GreenCircle アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle1() {#createGreenCircle1--}
+```
+public static NoteTag createGreenCircle1()
+```
+
+
+* 新しいノートタグを作成し、GreenCircle1 アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle1(String label) {#createGreenCircle1-java.lang.String-}
+```
+public static NoteTag createGreenCircle1(String label)
+```
+
+
+* 新しいノートタグを作成し、GreenCircle1 アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle2() {#createGreenCircle2--}
+```
+public static NoteTag createGreenCircle2()
+```
+
+
+* 新しいノートタグを作成し、GreenCircle2 アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle2(String label) {#createGreenCircle2-java.lang.String-}
+```
+public static NoteTag createGreenCircle2(String label)
+```
+
+
+* 新しいノートタグを作成し、GreenCircle2 アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle3() {#createGreenCircle3--}
+```
+public static NoteTag createGreenCircle3()
+```
+
+
+* 新しいノートタグを作成し、GreenCircle3 アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle3(String label) {#createGreenCircle3-java.lang.String-}
+```
+public static NoteTag createGreenCircle3(String label)
+```
+
+
+* 新しいノートタグを作成し、GreenCircle3 アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenDownArrow() {#createGreenDownArrow--}
+```
+public static NoteTag createGreenDownArrow()
+```
+
+
+* 新しいノートタグを作成し、GreenDownArrow アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenDownArrow(String label) {#createGreenDownArrow-java.lang.String-}
+```
+public static NoteTag createGreenDownArrow(String label)
+```
+
+
+* 新しいノートタグを作成し、GreenDownArrow アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenEightPointStar() {#createGreenEightPointStar--}
+```
+public static NoteTag createGreenEightPointStar()
+```
+
+
+* 新しいノートタグを作成し、GreenEightPointStar アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenEightPointStar(String label) {#createGreenEightPointStar-java.lang.String-}
+```
+public static NoteTag createGreenEightPointStar(String label)
+```
+
+
+* 新しいノートタグを作成し、GreenEightPointStar アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenLeftArrow() {#createGreenLeftArrow--}
+```
+public static NoteTag createGreenLeftArrow()
+```
+
+
+* 新しいノートタグを作成し、GreenLeftArrow アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenLeftArrow(String label) {#createGreenLeftArrow-java.lang.String-}
+```
+public static NoteTag createGreenLeftArrow(String label)
+```
+
+
+* 新しいノートタグを作成し、GreenLeftArrow アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenRightArrow() {#createGreenRightArrow--}
+```
+public static NoteTag createGreenRightArrow()
+```
+
+
+* 新しいノートタグを作成し、GreenRightArrow アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenRightArrow(String label) {#createGreenRightArrow-java.lang.String-}
+```
+public static NoteTag createGreenRightArrow(String label)
+```
+
+
+* 新しいノートタグを作成し、GreenRightArrow アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenSolidArrow() {#createGreenSolidArrow--}
+```
+public static NoteTag createGreenSolidArrow()
+```
+
+
+* 新しいノートタグを作成し、GreenSolidArrow アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenSolidArrow(String label) {#createGreenSolidArrow-java.lang.String-}
+```
+public static NoteTag createGreenSolidArrow(String label)
+```
+
+
+* 新しいノートタグを作成し、GreenSolidArrow アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenSquare() {#createGreenSquare--}
+```
+public static NoteTag createGreenSquare()
+```
+
+
+* 新しいノートタグを作成し、GreenSquare アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenSquare(String label) {#createGreenSquare-java.lang.String-}
+```
+public static NoteTag createGreenSquare(String label)
+```
+
+
+* 新しいノートタグを作成し、GreenSquare アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenStar() {#createGreenStar--}
+```
+public static NoteTag createGreenStar()
+```
+
+
+* 新しいノートタグを作成し、GreenStar アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenStar(String label) {#createGreenStar-java.lang.String-}
+```
+public static NoteTag createGreenStar(String label)
+```
+
+
+* 新しいノートタグを作成し、GreenStar アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenSun() {#createGreenSun--}
+```
+public static NoteTag createGreenSun()
+```
+
+
+* 新しいノートタグを作成し、GreenSun アイコンとデフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenSun(String label) {#createGreenSun-java.lang.String-}
+```
+public static NoteTag createGreenSun(String label)
+```
+
+
+* 新しいノートタグを作成し、GreenSun アイコンと指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenTarget() {#createGreenTarget--}
+```
+public static NoteTag createGreenTarget()
+```
+
+
+* GreenTarget アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenTarget(String label) {#createGreenTarget-java.lang.String-}
+```
+public static NoteTag createGreenTarget(String label)
+```
+
+
+* GreenTarget アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenTriangle() {#createGreenTriangle--}
+```
+public static NoteTag createGreenTriangle()
+```
+
+
+* GreenTriangle アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenTriangle(String label) {#createGreenTriangle-java.lang.String-}
+```
+public static NoteTag createGreenTriangle(String label)
+```
+
+
+* GreenTriangle アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenUmbrella() {#createGreenUmbrella--}
+```
+public static NoteTag createGreenUmbrella()
+```
+
+
+* GreenUmbrella アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenUmbrella(String label) {#createGreenUmbrella-java.lang.String-}
+```
+public static NoteTag createGreenUmbrella(String label)
+```
+
+
+* GreenUmbrella アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenUpArrow() {#createGreenUpArrow--}
+```
+public static NoteTag createGreenUpArrow()
+```
+
+
+* GreenUpArrow アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenUpArrow(String label) {#createGreenUpArrow-java.lang.String-}
+```
+public static NoteTag createGreenUpArrow(String label)
+```
+
+
+* GreenUpArrow アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenXNo() {#createGreenXNo--}
+```
+public static NoteTag createGreenXNo()
+```
+
+
+* GreenXNo アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenXNo(String label) {#createGreenXNo-java.lang.String-}
+```
+public static NoteTag createGreenXNo(String label)
+```
+
+
+* GreenXNo アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenXWithDots() {#createGreenXWithDots--}
+```
+public static NoteTag createGreenXWithDots()
+```
+
+
+* GreenXWithDots アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenXWithDots(String label) {#createGreenXWithDots-java.lang.String-}
+```
+public static NoteTag createGreenXWithDots(String label)
+```
+
+
+* GreenXWithDots アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHeart() {#createHeart--}
+```
+public static NoteTag createHeart()
+```
+
+
+* Heart アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHeart(String label) {#createHeart-java.lang.String-}
+```
+public static NoteTag createHeart(String label)
+```
+
+
+* Heart アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHighPriority() {#createHighPriority--}
+```
+public static NoteTag createHighPriority()
+```
+
+
+* HighPriority アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHighPriority(String label) {#createHighPriority-java.lang.String-}
+```
+public static NoteTag createHighPriority(String label)
+```
+
+
+* HighPriority アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHome() {#createHome--}
+```
+public static NoteTag createHome()
+```
+
+
+* Home アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHome(String label) {#createHome-java.lang.String-}
+```
+public static NoteTag createHome(String label)
+```
+
+
+* Home アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHyperlinkGlobe() {#createHyperlinkGlobe--}
+```
+public static NoteTag createHyperlinkGlobe()
+```
+
+
+* HyperlinkGlobe アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHyperlinkGlobe(String label) {#createHyperlinkGlobe-java.lang.String-}
+```
+public static NoteTag createHyperlinkGlobe(String label)
+```
+
+
+* HyperlinkGlobe アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createInstantMessagingContactPerson() {#createInstantMessagingContactPerson--}
+```
+public static NoteTag createInstantMessagingContactPerson()
+```
+
+
+* InstantMessagingContactPerson アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createInstantMessagingContactPerson(String label) {#createInstantMessagingContactPerson-java.lang.String-}
+```
+public static NoteTag createInstantMessagingContactPerson(String label)
+```
+
+
+* InstantMessagingContactPerson アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createLaptop() {#createLaptop--}
+```
+public static NoteTag createLaptop()
+```
+
+
+* Laptop アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createLaptop(String label) {#createLaptop-java.lang.String-}
+```
+public static NoteTag createLaptop(String label)
+```
+
+
+* Laptop アイコンと指定ラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createLightBulb() {#createLightBulb--}
+```
+public static NoteTag createLightBulb()
+```
+
+
+* LightBulb アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createLightBulb(String label) {#createLightBulb-java.lang.String-}
+```
+public static NoteTag createLightBulb(String label)
+```
+
+
+* 新しいノートタグを LightBulb アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createLightningBolt() {#createLightningBolt--}
+```
+public static NoteTag createLightningBolt()
+```
+
+
+* 新しいノートタグを LightningBolt アイコンとデフォルトラベルで作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createLightningBolt(String label) {#createLightningBolt-java.lang.String-}
+```
+public static NoteTag createLightningBolt(String label)
+```
+
+
+* 新しいノートタグを LightningBolt アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMeeting() {#createMeeting--}
+```
+public static NoteTag createMeeting()
+```
+
+
+* 新しいノートタグを Meeting アイコンとデフォルトラベルで作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMeeting(String label) {#createMeeting-java.lang.String-}
+```
+public static NoteTag createMeeting(String label)
+```
+
+
+* 新しいノートタグを Meeting アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMobilePhone() {#createMobilePhone--}
+```
+public static NoteTag createMobilePhone()
+```
+
+
+* 新しいノートタグを MobilePhone アイコンとデフォルトラベルで作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMobilePhone(String label) {#createMobilePhone-java.lang.String-}
+```
+public static NoteTag createMobilePhone(String label)
+```
+
+
+* 新しいノートタグを MobilePhone アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMovieClip() {#createMovieClip--}
+```
+public static NoteTag createMovieClip()
+```
+
+
+* 新しいノートタグを MovieClip アイコンとデフォルトラベルで作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMovieClip(String label) {#createMovieClip-java.lang.String-}
+```
+public static NoteTag createMovieClip(String label)
+```
+
+
+* 新しいノートタグを MovieClip アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMusicalNote() {#createMusicalNote--}
+```
+public static NoteTag createMusicalNote()
+```
+
+
+* 新しいノートタグを MusicalNote アイコンとデフォルトラベルで作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMusicalNote(String label) {#createMusicalNote-java.lang.String-}
+```
+public static NoteTag createMusicalNote(String label)
+```
+
+
+* 新しいノートタグを MusicalNote アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createNoIcon() {#createNoIcon--}
+```
+public static NoteTag createNoIcon()
+```
+
+
+* アイコンなしで新しいノートタグをデフォルトラベルで作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createNoIcon(String label) {#createNoIcon-java.lang.String-}
+```
+public static NoteTag createNoIcon(String label)
+```
+
+
+* アイコンなしで新しいノートタグを作成します。アイコンと指定されたラベル。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createNotebookWithClock() {#createNotebookWithClock--}
+```
+public static NoteTag createNotebookWithClock()
+```
+
+
+* 新しいノートタグを NotebookWithClock アイコンとデフォルトラベルで作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createNotebookWithClock(String label) {#createNotebookWithClock-java.lang.String-}
+```
+public static NoteTag createNotebookWithClock(String label)
+```
+
+
+* 新しいノートタグを NotebookWithClock アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createOpenBook() {#createOpenBook--}
+```
+public static NoteTag createOpenBook()
+```
+
+
+* 新しいノートタグを OpenBook アイコンとデフォルトラベルで作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createOpenBook(String label) {#createOpenBook-java.lang.String-}
+```
+public static NoteTag createOpenBook(String label)
+```
+
+
+* 新しいノートタグを OpenBook アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createOpenEnvelope() {#createOpenEnvelope--}
+```
+public static NoteTag createOpenEnvelope()
+```
+
+
+* 新しいノートタグを OpenEnvelope アイコンとデフォルトラベルで作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createOpenEnvelope(String label) {#createOpenEnvelope-java.lang.String-}
+```
+public static NoteTag createOpenEnvelope(String label)
+```
+
+
+* 新しいノートタグを OpenEnvelope アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createOrangeSquare() {#createOrangeSquare--}
+```
+public static NoteTag createOrangeSquare()
+```
+
+
+* 新しいノートタグを OrangeSquare アイコンとデフォルトラベルで作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createOrangeSquare(String label) {#createOrangeSquare-java.lang.String-}
+```
+public static NoteTag createOrangeSquare(String label)
+```
+
+
+* 新しいノートタグを OrangeSquare アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPadlock() {#createPadlock--}
+```
+public static NoteTag createPadlock()
+```
+
+
+* 新しいノートタグを Padlock アイコンとデフォルトラベルで作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPadlock(String label) {#createPadlock-java.lang.String-}
+```
+public static NoteTag createPadlock(String label)
+```
+
+
+* 新しいノートタグを Padlock アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPaperClip() {#createPaperClip--}
+```
+public static NoteTag createPaperClip()
+```
+
+
+* 新しいノートタグを PaperClip アイコンとデフォルトラベルで作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPaperClip(String label) {#createPaperClip-java.lang.String-}
+```
+public static NoteTag createPaperClip(String label)
+```
+
+
+* 新しいノートタグを PaperClip アイコンと指定されたラベルで作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPen() {#createPen--}
+```
+public static NoteTag createPen()
+```
+
+
+* ペンアイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPen(String label) {#createPen-java.lang.String-}
+```
+public static NoteTag createPen(String label)
+```
+
+
+* ペンアイコンで新しいノートタグを作成し、指定されたラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPersonWithExclamationMark() {#createPersonWithExclamationMark--}
+```
+public static NoteTag createPersonWithExclamationMark()
+```
+
+
+* PersonWithExclamationMark アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPersonWithExclamationMark(String label) {#createPersonWithExclamationMark-java.lang.String-}
+```
+public static NoteTag createPersonWithExclamationMark(String label)
+```
+
+
+* PersonWithExclamationMark アイコンで新しいノートタグを作成し、指定されたラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPinkSquare() {#createPinkSquare--}
+```
+public static NoteTag createPinkSquare()
+```
+
+
+* PinkSquare アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPinkSquare(String label) {#createPinkSquare-java.lang.String-}
+```
+public static NoteTag createPinkSquare(String label)
+```
+
+
+* PinkSquare アイコンで新しいノートタグを作成し、指定されたラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPlane() {#createPlane--}
+```
+public static NoteTag createPlane()
+```
+
+
+* Plane アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPlane(String label) {#createPlane-java.lang.String-}
+```
+public static NoteTag createPlane(String label)
+```
+
+
+* Plane アイコンで新しいノートタグを作成し、指定されたラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPresentationSlide() {#createPresentationSlide--}
+```
+public static NoteTag createPresentationSlide()
+```
+
+
+* PresentationSlide アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPresentationSlide(String label) {#createPresentationSlide-java.lang.String-}
+```
+public static NoteTag createPresentationSlide(String label)
+```
+
+
+* PresentationSlide アイコンで新しいノートタグを作成し、指定されたラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPushpin() {#createPushpin--}
+```
+public static NoteTag createPushpin()
+```
+
+
+* Pushpin アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPushpin(String label) {#createPushpin-java.lang.String-}
+```
+public static NoteTag createPushpin(String label)
+```
+
+
+* Pushpin アイコンで新しいノートタグを作成し、指定されたラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createQuestionBalloon() {#createQuestionBalloon--}
+```
+public static NoteTag createQuestionBalloon()
+```
+
+
+* QuestionBalloon アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createQuestionBalloon(String label) {#createQuestionBalloon-java.lang.String-}
+```
+public static NoteTag createQuestionBalloon(String label)
+```
+
+
+* QuestionBalloon アイコンで新しいノートタグを作成し、指定されたラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createQuestionMark() {#createQuestionMark--}
+```
+public static NoteTag createQuestionMark()
+```
+
+
+* QuestionMark アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createQuestionMark(String label) {#createQuestionMark-java.lang.String-}
+```
+public static NoteTag createQuestionMark(String label)
+```
+
+
+* QuestionMark アイコンで新しいノートタグを作成し、指定されたラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createQuotationMark() {#createQuotationMark--}
+```
+public static NoteTag createQuotationMark()
+```
+
+
+* QuotationMark アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createQuotationMark(String label) {#createQuotationMark-java.lang.String-}
+```
+public static NoteTag createQuotationMark(String label)
+```
+
+
+* QuotationMark アイコンで新しいノートタグを作成し、指定されたラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createRedSquare() {#createRedSquare--}
+```
+public static NoteTag createRedSquare()
+```
+
+
+* RedSquare アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createRedSquare(String label) {#createRedSquare-java.lang.String-}
+```
+public static NoteTag createRedSquare(String label)
+```
+
+
+* RedSquare アイコンで新しいノートタグを作成し、指定されたラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createReminderBell() {#createReminderBell--}
+```
+public static NoteTag createReminderBell()
+```
+
+
+* ReminderBell アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createReminderBell(String label) {#createReminderBell-java.lang.String-}
+```
+public static NoteTag createReminderBell(String label)
+```
+
+
+* ReminderBell アイコンで新しいノートタグを作成し、指定されたラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createResearch() {#createResearch--}
+```
+public static NoteTag createResearch()
+```
+
+
+* Research アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createResearch(String label) {#createResearch-java.lang.String-}
+```
+public static NoteTag createResearch(String label)
+```
+
+
+* Research アイコンで新しいノートタグを作成し、指定されたラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createRoseOnStem() {#createRoseOnStem--}
+```
+public static NoteTag createRoseOnStem()
+```
+
+
+* RoseOnStem アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createRoseOnStem(String label) {#createRoseOnStem-java.lang.String-}
+```
+public static NoteTag createRoseOnStem(String label)
+```
+
+
+* RoseOnStem アイコンと指定されたラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createScheduledTask() {#createScheduledTask--}
+```
+public static NoteTag createScheduledTask()
+```
+
+
+* ScheduledTask アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createScheduledTask(String label) {#createScheduledTask-java.lang.String-}
+```
+public static NoteTag createScheduledTask(String label)
+```
+
+
+* ScheduledTask アイコンと指定されたラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createSmilingFace() {#createSmilingFace--}
+```
+public static NoteTag createSmilingFace()
+```
+
+
+* SmilingFace アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createSmilingFace(String label) {#createSmilingFace-java.lang.String-}
+```
+public static NoteTag createSmilingFace(String label)
+```
+
+
+* SmilingFace アイコンと指定されたラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createSunflower() {#createSunflower--}
+```
+public static NoteTag createSunflower()
+```
+
+
+* Sunflower アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createSunflower(String label) {#createSunflower-java.lang.String-}
+```
+public static NoteTag createSunflower(String label)
+```
+
+
+* Sunflower アイコンと指定されたラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createTelephoneWithClock() {#createTelephoneWithClock--}
+```
+public static NoteTag createTelephoneWithClock()
+```
+
+
+* TelephoneWithClock アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createTelephoneWithClock(String label) {#createTelephoneWithClock-java.lang.String-}
+```
+public static NoteTag createTelephoneWithClock(String label)
+```
+
+
+* TelephoneWithClock アイコンと指定されたラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createTimeSensitive() {#createTimeSensitive--}
+```
+public static NoteTag createTimeSensitive()
+```
+
+
+* TimeSensitive アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createTimeSensitive(String label) {#createTimeSensitive-java.lang.String-}
+```
+public static NoteTag createTimeSensitive(String label)
+```
+
+
+* TimeSensitive アイコンと指定されたラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createTwoPeople() {#createTwoPeople--}
+```
+public static NoteTag createTwoPeople()
+```
+
+
+* TwoPeople アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createTwoPeople(String label) {#createTwoPeople-java.lang.String-}
+```
+public static NoteTag createTwoPeople(String label)
+```
+
+
+* TwoPeople アイコンと指定されたラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCheckMark() {#createYellowCheckMark--}
+```
+public static NoteTag createYellowCheckMark()
+```
+
+
+* YellowCheckMark アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCheckMark(String label) {#createYellowCheckMark-java.lang.String-}
+```
+public static NoteTag createYellowCheckMark(String label)
+```
+
+
+* YellowCheckMark アイコンと指定されたラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle() {#createYellowCircle--}
+```
+public static NoteTag createYellowCircle()
+```
+
+
+* YellowCircle アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle(String label) {#createYellowCircle-java.lang.String-}
+```
+public static NoteTag createYellowCircle(String label)
+```
+
+
+* YellowCircle アイコンと指定されたラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle1() {#createYellowCircle1--}
+```
+public static NoteTag createYellowCircle1()
+```
+
+
+* YellowCircle1 アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle1(String label) {#createYellowCircle1-java.lang.String-}
+```
+public static NoteTag createYellowCircle1(String label)
+```
+
+
+* YellowCircle1 アイコンと指定されたラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle2() {#createYellowCircle2--}
+```
+public static NoteTag createYellowCircle2()
+```
+
+
+* YellowCircle2 アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle2(String label) {#createYellowCircle2-java.lang.String-}
+```
+public static NoteTag createYellowCircle2(String label)
+```
+
+
+* YellowCircle2 アイコンと指定されたラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle3() {#createYellowCircle3--}
+```
+public static NoteTag createYellowCircle3()
+```
+
+
+* YellowCircle3 アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle3(String label) {#createYellowCircle3-java.lang.String-}
+```
+public static NoteTag createYellowCircle3(String label)
+```
+
+
+* YellowCircle3 アイコンと指定されたラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowDownArrow() {#createYellowDownArrow--}
+```
+public static NoteTag createYellowDownArrow()
+```
+
+
+* YellowDownArrow アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowDownArrow(String label) {#createYellowDownArrow-java.lang.String-}
+```
+public static NoteTag createYellowDownArrow(String label)
+```
+
+
+* YellowDownArrow アイコンと指定されたラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowEightPointStar() {#createYellowEightPointStar--}
+```
+public static NoteTag createYellowEightPointStar()
+```
+
+
+\* YellowEightPointStar アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowEightPointStar(String label) {#createYellowEightPointStar-java.lang.String-}
+```
+public static NoteTag createYellowEightPointStar(String label)
+```
+
+
+\* YellowEightPointStar アイコンで新しいノートタグを作成し、指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowKey() {#createYellowKey--}
+```
+public static NoteTag createYellowKey()
+```
+
+
+\* YellowKey アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowKey(String label) {#createYellowKey-java.lang.String-}
+```
+public static NoteTag createYellowKey(String label)
+```
+
+
+\* YellowKey アイコンで新しいノートタグを作成し、指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowLeftArrow() {#createYellowLeftArrow--}
+```
+public static NoteTag createYellowLeftArrow()
+```
+
+
+\* YellowLeftArrow アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowLeftArrow(String label) {#createYellowLeftArrow-java.lang.String-}
+```
+public static NoteTag createYellowLeftArrow(String label)
+```
+
+
+\* YellowLeftArrow アイコンで新しいノートタグを作成し、指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowRightArrow() {#createYellowRightArrow--}
+```
+public static NoteTag createYellowRightArrow()
+```
+
+
+\* YellowRightArrow アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowRightArrow(String label) {#createYellowRightArrow-java.lang.String-}
+```
+public static NoteTag createYellowRightArrow(String label)
+```
+
+
+\* YellowRightArrow アイコンで新しいノートタグを作成し、指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowSolidTarget() {#createYellowSolidTarget--}
+```
+public static NoteTag createYellowSolidTarget()
+```
+
+
+\* YellowSolidTarget アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowSolidTarget(String label) {#createYellowSolidTarget-java.lang.String-}
+```
+public static NoteTag createYellowSolidTarget(String label)
+```
+
+
+\* YellowSolidTarget アイコンで新しいノートタグを作成し、指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowSquare() {#createYellowSquare--}
+```
+public static NoteTag createYellowSquare()
+```
+
+
+\* YellowSquare アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowSquare(String label) {#createYellowSquare-java.lang.String-}
+```
+public static NoteTag createYellowSquare(String label)
+```
+
+
+\* YellowSquare アイコンで新しいノートタグを作成し、指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowStar() {#createYellowStar--}
+```
+public static NoteTag createYellowStar()
+```
+
+
+\* YellowStar アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowStar(String label) {#createYellowStar-java.lang.String-}
+```
+public static NoteTag createYellowStar(String label)
+```
+
+
+\* YellowStar アイコンで新しいノートタグを作成し、指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowSun() {#createYellowSun--}
+```
+public static NoteTag createYellowSun()
+```
+
+
+\* YellowSun アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowSun(String label) {#createYellowSun-java.lang.String-}
+```
+public static NoteTag createYellowSun(String label)
+```
+
+
+\* YellowSun アイコンで新しいノートタグを作成し、指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowTarget() {#createYellowTarget--}
+```
+public static NoteTag createYellowTarget()
+```
+
+
+\* YellowTarget アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowTarget(String label) {#createYellowTarget-java.lang.String-}
+```
+public static NoteTag createYellowTarget(String label)
+```
+
+
+\* YellowTarget アイコンで新しいノートタグを作成し、指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowTriangle() {#createYellowTriangle--}
+```
+public static NoteTag createYellowTriangle()
+```
+
+
+\* YellowTriangle アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowTriangle(String label) {#createYellowTriangle-java.lang.String-}
+```
+public static NoteTag createYellowTriangle(String label)
+```
+
+
+\* YellowTriangle アイコンで新しいノートタグを作成し、指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowUmbrella() {#createYellowUmbrella--}
+```
+public static NoteTag createYellowUmbrella()
+```
+
+
+\* YellowUmbrella アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowUmbrella(String label) {#createYellowUmbrella-java.lang.String-}
+```
+public static NoteTag createYellowUmbrella(String label)
+```
+
+
+\* YellowUmbrella アイコンで新しいノートタグを作成し、指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowUpArrow() {#createYellowUpArrow--}
+```
+public static NoteTag createYellowUpArrow()
+```
+
+
+\* YellowUpArrow アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowUpArrow(String label) {#createYellowUpArrow-java.lang.String-}
+```
+public static NoteTag createYellowUpArrow(String label)
+```
+
+
+\* YellowUpArrow アイコンで新しいノートタグを作成し、指定ラベルを使用します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowX() {#createYellowX--}
+```
+public static NoteTag createYellowX()
+```
+
+
+\* YellowX アイコンで新しいノートタグを作成し、デフォルトラベルを使用します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowX(String label) {#createYellowX-java.lang.String-}
+```
+public static NoteTag createYellowX(String label)
+```
+
+
+* 指定されたラベルと YellowX アイコンで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowXWithDots() {#createYellowXWithDots--}
+```
+public static NoteTag createYellowXWithDots()
+```
+
+
+* YellowXWithDots アイコンとデフォルトラベルで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowXWithDots(String label) {#createYellowXWithDots-java.lang.String-}
+```
+public static NoteTag createYellowXWithDots(String label)
+```
+
+
+* YellowXWithDots アイコンと指定されたラベルで新しいノートタグを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ラベル | java.lang.String | タグのラベルです。 |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### equals(NoteTag other) {#equals-com.aspose.note.NoteTag-}
+```
+public boolean equals(NoteTag other)
+```
+
+
+指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| other | [NoteTag](../../com.aspose.note/notetag) | オブジェクトです。 |
+
+**Returns:**
+boolean - `bool`です。
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| obj | java.lang.Object | オブジェクトです。 |
+
+**Returns:**
+boolean - `bool`です。
+### getCompletedTime() {#getCompletedTime--}
+```
+public final Date getCompletedTime()
+```
+
+
+完了時間を取得または設定します。
+
+値: `Nullable\{DateTime\}`です。
+
+**Returns:**
+java.util.Date
+### getCreationTime() {#getCreationTime--}
+```
+public final Date getCreationTime()
+```
+
+
+作成時間を取得または設定します。
+
+値: java.util.Dateです。
+
+**Returns:**
+java.util.Date
+### getFontColor() {#getFontColor--}
+```
+public Color getFontColor()
+```
+
+
+フォントの色を取得または設定します。
+
+**Returns:**
+java.awt.Color
+### getHighlight() {#getHighlight--}
+```
+public Color getHighlight()
+```
+
+
+ハイライト色を取得または設定します。
+
+**Returns:**
+java.awt.Color
+### getIcon() {#getIcon--}
+```
+public final int getIcon()
+```
+
+
+アイコンを取得または設定します。
+
+値: [TagIcon](../../com.aspose.note.infrastructure/tagicon)です。
+
+**Returns:**
+int
+### getLabel() {#getLabel--}
+```
+public String getLabel()
+```
+
+
+ラベルテキストを取得します。
+
+**Returns:**
+java.lang.String
+### getStatus() {#getStatus--}
+```
+public final int getStatus()
+```
+
+
+ステータスを取得または設定します。
+
+値: [TagStatus](../../com.aspose.note/tagstatus)です。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+型のハッシュ関数として機能します。
+
+**Returns:**
+int - `int`です。
+### setCreationTime(Date value) {#setCreationTime-java.util.Date-}
+```
+public final void setCreationTime(Date value)
+```
+
+
+作成時間を取得または設定します。
+
+値: java.util.Dateです。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Date |  |
+
+### setFontColor(Color value) {#setFontColor-java.awt.Color-}
+```
+public void setFontColor(Color value)
+```
+
+
+フォントの色を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.awt.Color |  |
+
+### setHighlight(Color value) {#setHighlight-java.awt.Color-}
+```
+public void setHighlight(Color value)
+```
+
+
+ハイライト色を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.awt.Color |  |
+
+### setIcon(int value) {#setIcon-int-}
+```
+public final void setIcon(int value)
+```
+
+
+アイコンを取得または設定します。
+
+値: [TagIcon](../../com.aspose.note.infrastructure/tagicon)です。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setLabel(String value) {#setLabel-java.lang.String-}
+```
+public void setLabel(String value)
+```
+
+
+ラベルテキストを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+

--- a/japanese/java/com.aspose.note/notetask/_index.md
+++ b/japanese/java/com.aspose.note/notetask/_index.md
@@ -1,0 +1,196 @@
+---
+title: "NoteTask"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ノートタスクを表します。"
+type: docs
+weight: 55
+url: /ja/java/com.aspose.note/notetask/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.note.TagExtended, [com.aspose.note.CheckBox](../../com.aspose.note/checkbox)
+```
+public final class NoteTask extends CheckBox
+```
+
+ノートタスクを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [createCustomFollowUpDate(Date dueDate)](#createCustomFollowUpDate-java.util.Date-) | NoFollowUpDateFlag アイコンと指定された期限日で新しいノートタスクを作成します。 |
+| [createFollowUpNextWeek()](#createFollowUpNextWeek--) | \* FollowUpNextWeekFlag アイコンで新しいノートタグを作成します。 |
+| [createFollowUpThisWeek()](#createFollowUpThisWeek--) | \* FollowUpThisWeekFlag アイコンで新しいノートタグを作成します。 |
+| [createFollowUpToday()](#createFollowUpToday--) | \* FollowUpTodayFlag アイコンで新しいノートタグを作成します。 |
+| [createFollowUpTomorrow()](#createFollowUpTomorrow--) | \* FollowUpTomorrowFlag アイコンで新しいノートタグを作成します。 |
+| [createNoFollowUpDate()](#createNoFollowUpDate--) | \* NoFollowUpDateFlag アイコンで新しいノートタグを作成します。 |
+| [equals(NoteTask other)](#equals-com.aspose.note.NoteTask-) | 指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。 |
+| [equals(Object obj)](#equals-java.lang.Object-) | 指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。 |
+| [getDueDate()](#getDueDate--) | 期限日を取得または設定します。 |
+| [getIcon()](#getIcon--) | アイコンを取得または設定します。 |
+| [getLabel()](#getLabel--) |  |
+| [hashCode()](#hashCode--) | 型のハッシュ関数として機能します。 |
+| [setDueDate(Date value)](#setDueDate-java.util.Date-) | 期限日を取得または設定します。 |
+| [setOpen()](#setOpen--) | タグを開いた状態に設定します。 |
+### createCustomFollowUpDate(Date dueDate) {#createCustomFollowUpDate-java.util.Date-}
+```
+public static NoteTask createCustomFollowUpDate(Date dueDate)
+```
+
+
+NoFollowUpDateFlag アイコンと指定された期限日で新しいノートタスクを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| dueDate | java.util.Date | 期限日。 |
+
+**Returns:**
+[NoteTask](../../com.aspose.note/notetask) - The [NoteTask](../../com.aspose.note/notetask).
+### createFollowUpNextWeek() {#createFollowUpNextWeek--}
+```
+public static NoteTask createFollowUpNextWeek()
+```
+
+
+\* FollowUpNextWeekFlag アイコンで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTask](../../com.aspose.note/notetask) - The [NoteTask](../../com.aspose.note/notetask).
+### createFollowUpThisWeek() {#createFollowUpThisWeek--}
+```
+public static NoteTask createFollowUpThisWeek()
+```
+
+
+\* FollowUpThisWeekFlag アイコンで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTask](../../com.aspose.note/notetask) - The [NoteTask](../../com.aspose.note/notetask).
+### createFollowUpToday() {#createFollowUpToday--}
+```
+public static NoteTask createFollowUpToday()
+```
+
+
+\* FollowUpTodayFlag アイコンで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTask](../../com.aspose.note/notetask) - The [NoteTask](../../com.aspose.note/notetask).
+### createFollowUpTomorrow() {#createFollowUpTomorrow--}
+```
+public static NoteTask createFollowUpTomorrow()
+```
+
+
+\* FollowUpTomorrowFlag アイコンで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTask](../../com.aspose.note/notetask) - The [NoteTask](../../com.aspose.note/notetask).
+### createNoFollowUpDate() {#createNoFollowUpDate--}
+```
+public static NoteTask createNoFollowUpDate()
+```
+
+
+\* NoFollowUpDateFlag アイコンで新しいノートタグを作成します。
+
+**Returns:**
+[NoteTask](../../com.aspose.note/notetask) - The [NoteTask](../../com.aspose.note/notetask).
+### equals(NoteTask other) {#equals-com.aspose.note.NoteTask-}
+```
+public boolean equals(NoteTask other)
+```
+
+
+指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| other | [NoteTask](../../com.aspose.note/notetask) | オブジェクトです。 |
+
+**Returns:**
+boolean - `bool`です。
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| obj | java.lang.Object | オブジェクトです。 |
+
+**Returns:**
+boolean - `bool`です。
+### getDueDate() {#getDueDate--}
+```
+public Date getDueDate()
+```
+
+
+期限日を取得または設定します。
+
+値: `DateTime`。
+
+**Returns:**
+java.util.Date
+### getIcon() {#getIcon--}
+```
+public int getIcon()
+```
+
+
+アイコンを取得または設定します。
+
+値: [TagIcon](../../com.aspose.note.infrastructure/tagicon)です。
+
+**Returns:**
+int
+### getLabel() {#getLabel--}
+```
+public String getLabel()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+型のハッシュ関数として機能します。
+
+**Returns:**
+int - `int`です。
+### setDueDate(Date value) {#setDueDate-java.util.Date-}
+```
+public void setDueDate(Date value)
+```
+
+
+期限日を取得または設定します。
+
+値: `DateTime`。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Date |  |
+
+### setOpen() {#setOpen--}
+```
+public void setOpen()
+```
+
+
+タグを開いた状態に設定します。
+

--- a/japanese/java/com.aspose.note/numberformat/_index.md
+++ b/japanese/java/com.aspose.note/numberformat/_index.md
@@ -1,0 +1,104 @@
+---
+title: "NumberFormat"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "自動番号付けオブジェクトのグループに使用できる番号形式を指定します。"
+type: docs
+weight: 63
+url: /ja/java/com.aspose.note/numberformat/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class NumberFormat extends System.Enum
+```
+
+自動的に番号付けされるオブジェクトのグループで使用できる番号形式を指定します。完全な一覧は `[MSDN][]` に記載されています。
+
+
+[MSDN]: https://msdn.microsoft.com/en-us/library/dd923798%28v=office.12%29.aspx
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [ChineseCounting](#ChineseCounting) | シーケンスが中国の数え方に基づく連続番号で構成されることを指定します。 |
+| [ChineseCountingThousand](#ChineseCountingThousand) | シーケンスが中国の千単位数え方に基づく連続番号で構成されることを指定します。 |
+| [DecimalNumbers](#DecimalNumbers) | シーケンスが十進数で構成されることを指定します。 |
+| [LowerLetter](#LowerLetter) | シーケンスがラテン文字アルファベットの小文字1文字の1回以上の繰り返しで構成されることを指定します。 |
+| [LowerRoman](#LowerRoman) | シーケンスが小文字のローマ数字で構成されることを指定します。 |
+| [TaiwaneseCounting](#TaiwaneseCounting) | シーケンスが台湾の数え方に基づく連続番号で構成されることを指定します。 |
+| [TaiwaneseCountingThousand](#TaiwaneseCountingThousand) | シーケンスが台湾の千単位数え方に基づく連続番号で構成されることを指定します。 |
+| [UpperLetter](#UpperLetter) | シーケンスがラテン文字アルファベットの大文字1文字の1回以上の繰り返しで構成されることを指定します。 |
+| [UpperRoman](#UpperRoman) | シーケンスが大文字のローマ数字で構成されることを指定します。 |
+### ChineseCounting {#ChineseCounting}
+```
+public static final byte ChineseCounting
+```
+
+
+シーケンスが中国の数え方に基づく連続番号で構成されることを指定します。
+
+### ChineseCountingThousand {#ChineseCountingThousand}
+```
+public static final byte ChineseCountingThousand
+```
+
+
+シーケンスが中国の千単位数え方に基づく連続番号で構成されることを指定します。
+
+### DecimalNumbers {#DecimalNumbers}
+```
+public static final byte DecimalNumbers
+```
+
+
+シーケンスが十進数で構成されることを指定します。例: 1, 2, 3, \\\\\\u2026, 8, 9, 10, 11, 12, \\\\\\u2026, 18, 19, 20, 21.
+
+### LowerLetter {#LowerLetter}
+```
+public static final byte LowerLetter
+```
+
+
+シーケンスがラテン文字アルファベットの小文字1文字の1回以上の繰り返しで構成されることを指定します。例: a, b, c, \\\\\\u2026, y, z, aa, bb, cc, \\\\\\u2026, yy, zz, aaa, bbb, ccc.
+
+### LowerRoman {#LowerRoman}
+```
+public static final byte LowerRoman
+```
+
+
+シーケンスが小文字のローマ数字で構成されることを指定します。例: i, ii, iii, iv, \\\\\\u2026, xviii, xix, xx, xxi.
+
+### TaiwaneseCounting {#TaiwaneseCounting}
+```
+public static final byte TaiwaneseCounting
+```
+
+
+シーケンスが台湾の数え方に基づく連続番号で構成されることを指定します。
+
+### TaiwaneseCountingThousand {#TaiwaneseCountingThousand}
+```
+public static final byte TaiwaneseCountingThousand
+```
+
+
+シーケンスが台湾の千単位数え方に基づく連続番号で構成されることを指定します。
+
+### UpperLetter {#UpperLetter}
+```
+public static final byte UpperLetter
+```
+
+
+シーケンスがラテン文字アルファベットの大文字1文字の1回以上の繰り返しで構成されることを指定します。例: A, B, C, \\\\\\u2026, Y, Z, AA, BB, CC, \\\\\\u2026, YY, ZZ, AAA, BBB, CCC.
+
+### UpperRoman {#UpperRoman}
+```
+public static final byte UpperRoman
+```
+
+
+シーケンスが大文字のローマ数字で構成されることを指定します。例: I, II, III, IV, \\\\\\u2026, XVIII, XIX, XX, XXI.
+

--- a/japanese/java/com.aspose.note/numberlist/_index.md
+++ b/japanese/java/com.aspose.note/numberlist/_index.md
@@ -1,0 +1,341 @@
+---
+title: "NumberList"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "番号付きまたは箇条書きリストを表します。"
+type: docs
+weight: 64
+url: /ja/java/com.aspose.note/numberlist/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class NumberList
+```
+
+番号付きまたは箇条書きリストを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [NumberList(String bulletedSymbol, String font, int fontSize)](#NumberList-java.lang.String-java.lang.String-int-) | `NumberList` クラスの新しいインスタンスを初期化します。 |
+| [NumberList(String format, byte numberFormat, String font, int fontSize)](#NumberList-java.lang.String-byte-java.lang.String-int-) | `NumberList` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(NumberList other)](#equals-com.aspose.note.NumberList-) | 指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。 |
+| [equals(Object obj)](#equals-java.lang.Object-) | 指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。 |
+| [getFont()](#getFont--) | フォントの名前を取得または設定します。 |
+| [getFontColor()](#getFontColor--) | フォントの色を取得または設定します。 |
+| [getFontSize()](#getFontSize--) | フォントサイズを取得または設定します。 |
+| [getFormat()](#getFormat--) | 行ヘッダーの形式を取得または設定します。 |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 最終更新時刻を取得または設定します。 |
+| [getNumberFormat()](#getNumberFormat--) | 自動的に番号付けされたオブジェクトのグループに使用される番号形式を取得または設定します。 |
+| [getNumberedListHeader(int sequenceNumber)](#getNumberedListHeader-int-) | 番号付きリストのヘッダーを取得します。 |
+| [getRestart()](#getRestart--) | リスト項目の自動番号値を上書きする数値を取得または設定します。 |
+| [hashCode()](#hashCode--) | 型のハッシュ関数として機能します。 |
+| [isBold()](#isBold--) | テキストスタイルが太字かどうかを示す値を取得または設定します。 |
+| [isItalic()](#isItalic--) | テキストスタイルが斜体かどうかを示す値を取得または設定します。 |
+| [setBold(boolean value)](#setBold-boolean-) | テキストスタイルが太字かどうかを示す値を取得または設定します。 |
+| [setFont(String value)](#setFont-java.lang.String-) | フォントの名前を取得または設定します。 |
+| [setFontColor(Color value)](#setFontColor-java.awt.Color-) | フォントの色を取得または設定します。 |
+| [setFontSize(int value)](#setFontSize-int-) | フォントサイズを取得または設定します。 |
+| [setFormat(String value)](#setFormat-java.lang.String-) | 行ヘッダーの形式を取得または設定します。 |
+| [setItalic(boolean value)](#setItalic-boolean-) | テキストスタイルが斜体かどうかを示す値を取得または設定します。 |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 最終更新時刻を取得または設定します。 |
+| [setNumberFormat(Byte value)](#setNumberFormat-java.lang.Byte-) | 自動的に番号付けされたオブジェクトのグループに使用される番号形式を取得または設定します。 |
+| [setRestart(int value)](#setRestart-int-) | リスト項目の自動番号値を上書きする数値を取得または設定します。 |
+### NumberList(String bulletedSymbol, String font, int fontSize) {#NumberList-java.lang.String-java.lang.String-int-}
+```
+public NumberList(String bulletedSymbol, String font, int fontSize)
+```
+
+
+`NumberList` クラスの新しいインスタンスを初期化します。このインスタンスは箇条書きリストを表します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 箇条書きシンボル | java.lang.String | 箇条書きを表すシンボルです。 |
+| フォント | java.lang.String | 箇条書き用のフォントです。 |
+| フォントサイズ | int | 箇条書き用のフォントサイズです。 |
+
+### NumberList(String format, byte numberFormat, String font, int fontSize) {#NumberList-java.lang.String-byte-java.lang.String-int-}
+```
+public NumberList(String format, byte numberFormat, String font, int fontSize)
+```
+
+
+`NumberList` クラスの新しいインスタンスを初期化します。このインスタンスは番号付きリストを表します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| format | java.lang.String | 番号付きヘッダーの形式です。 |
+| 番号形式 | byte | ヘッダーの番号の形式です。 |
+| フォント | java.lang.String | 番号付きヘッダー用のフォントです。 |
+| フォントサイズ | int | 番号付きヘッダー用のフォントサイズです。 |
+
+### equals(NumberList other) {#equals-com.aspose.note.NumberList-}
+```
+public boolean equals(NumberList other)
+```
+
+
+指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| other | [NumberList](../../com.aspose.note/numberlist) | オブジェクトです。 |
+
+**Returns:**
+boolean - `bool`です。
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| obj | java.lang.Object | オブジェクトです。 |
+
+**Returns:**
+boolean - `bool`です。
+### getFont() {#getFont--}
+```
+public String getFont()
+```
+
+
+フォントの名前を取得または設定します。
+
+**Returns:**
+java.lang.String
+### getFontColor() {#getFontColor--}
+```
+public Color getFontColor()
+```
+
+
+フォントの色を取得または設定します。
+
+**Returns:**
+java.awt.Color
+### getFontSize() {#getFontSize--}
+```
+public int getFontSize()
+```
+
+
+フォントサイズを取得または設定します。
+
+**Returns:**
+int
+### getFormat() {#getFormat--}
+```
+public String getFormat()
+```
+
+
+行ヘッダーの形式を取得または設定します。箇条書きリストの場合は箇条記号を表します。
+
+**Returns:**
+java.lang.String
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+最終更新時刻を取得または設定します。
+
+**Returns:**
+java.util.Date
+### getNumberFormat() {#getNumberFormat--}
+```
+public Byte getNumberFormat()
+```
+
+
+自動番号付けオブジェクトのグループに使用される番号形式を取得または設定します。箇条書きリストの場合は null にする必要があります。
+
+**Returns:**
+java.lang.Byte
+### getNumberedListHeader(int sequenceNumber) {#getNumberedListHeader-int-}
+```
+public String getNumberedListHeader(int sequenceNumber)
+```
+
+
+番号付きリストのヘッダーを取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| sequenceNumber | int | 番号付きリストのシーケンス番号です。 |
+
+**Returns:**
+java.lang.String - 指定されたシーケンス番号の文字列表現です。
+### getRestart() {#getRestart--}
+```
+public int getRestart()
+```
+
+
+リスト項目の自動番号値を上書きする数値を取得または設定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+型のハッシュ関数として機能します。
+
+**Returns:**
+int - `int`です。
+### isBold() {#isBold--}
+```
+public boolean isBold()
+```
+
+
+テキストスタイルが太字かどうかを示す値を取得または設定します。
+
+**Returns:**
+boolean
+### isItalic() {#isItalic--}
+```
+public boolean isItalic()
+```
+
+
+テキストスタイルが斜体かどうかを示す値を取得または設定します。
+
+**Returns:**
+boolean
+### setBold(boolean value) {#setBold-boolean-}
+```
+public void setBold(boolean value)
+```
+
+
+テキストスタイルが太字かどうかを示す値を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setFont(String value) {#setFont-java.lang.String-}
+```
+public void setFont(String value)
+```
+
+
+フォントの名前を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setFontColor(Color value) {#setFontColor-java.awt.Color-}
+```
+public void setFontColor(Color value)
+```
+
+
+フォントの色を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.awt.Color |  |
+
+### setFontSize(int value) {#setFontSize-int-}
+```
+public void setFontSize(int value)
+```
+
+
+フォントサイズを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setFormat(String value) {#setFormat-java.lang.String-}
+```
+public void setFormat(String value)
+```
+
+
+行ヘッダーの形式を取得または設定します。箇条書きリストの場合は箇条記号を表します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setItalic(boolean value) {#setItalic-boolean-}
+```
+public void setItalic(boolean value)
+```
+
+
+テキストスタイルが斜体かどうかを示す値を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+最終更新時刻を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Date |  |
+
+### setNumberFormat(Byte value) {#setNumberFormat-java.lang.Byte-}
+```
+public void setNumberFormat(Byte value)
+```
+
+
+自動番号付けオブジェクトのグループに使用される番号形式を取得または設定します。箇条書きリストの場合は null にする必要があります。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Byte |  |
+
+### setRestart(int value) {#setRestart-int-}
+```
+public void setRestart(int value)
+```
+
+
+リスト項目の自動番号値を上書きする数値を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+

--- a/japanese/java/com.aspose.note/onesaveoptions/_index.md
+++ b/japanese/java/com.aspose.note/onesaveoptions/_index.md
@@ -1,0 +1,58 @@
+---
+title: "OneSaveOptions"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ドキュメントを OneNote 形式で保存する際に追加オプションを指定できます。"
+type: docs
+weight: 65
+url: /ja/java/com.aspose.note/onesaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.SaveOptions](../../com.aspose.note/saveoptions)
+```
+public final class OneSaveOptions extends SaveOptions
+```
+
+ドキュメントを OneNote 形式で保存する際に追加オプションを指定できます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [OneSaveOptions()](#OneSaveOptions--) | `OneSaveOptions` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getDocumentPassword()](#getDocumentPassword--) | ドキュメントの内容を暗号化するためのパスワードを取得または設定します。 |
+| [setDocumentPassword(String value)](#setDocumentPassword-java.lang.String-) | ドキュメントの内容を暗号化するためのパスワードを取得または設定します。 |
+### OneSaveOptions() {#OneSaveOptions--}
+```
+public OneSaveOptions()
+```
+
+
+`OneSaveOptions` クラスの新しいインスタンスを初期化します。
+
+### getDocumentPassword() {#getDocumentPassword--}
+```
+public String getDocumentPassword()
+```
+
+
+ドキュメントの内容を暗号化するためのパスワードを取得または設定します。
+
+**Returns:**
+java.lang.String
+### setDocumentPassword(String value) {#setDocumentPassword-java.lang.String-}
+```
+public void setDocumentPassword(String value)
+```
+
+
+ドキュメントの内容を暗号化するためのパスワードを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+

--- a/japanese/java/com.aspose.note/outline/_index.md
+++ b/japanese/java/com.aspose.note/outline/_index.md
@@ -1,0 +1,261 @@
+---
+title: "アウトライン"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "アウトラインを表します。"
+type: docs
+weight: 66
+url: /ja/java/com.aspose.note/outline/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode, com.aspose.note.IndentatedNode
+
+**All Implemented Interfaces:**
+[com.aspose.note.IPageChildNode](../../com.aspose.note/ipagechildnode)
+```
+public final class Outline extends IndentatedNode<IOutlineChildNode,Outline> implements IPageChildNode
+```
+
+アウトラインを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Outline()](#Outline--) | 新しい [Outline](../../com.aspose.note/outline) クラスのインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | ノードのビジターを受け入れます。 |
+| [getDescendantsCannotBeMoved()](#getDescendantsCannotBeMoved--) | アウトラインの子孫が移動可能かどうかを取得します。 |
+| [getHorizontalOffset()](#getHorizontalOffset--) | 水平オフセットを取得または設定します。 |
+| [getInternalIndentPosition()](#getInternalIndentPosition--) |  |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 最終更新時刻を取得または設定します。 |
+| [getMaxHeight()](#getMaxHeight--) | 最大高さを取得または設定します。 |
+| [getMaxWidth()](#getMaxWidth--) | 最大幅を取得または設定します。 |
+| [getMinWidth()](#getMinWidth--) | 最小幅を取得または設定します。 |
+| [getReservedWidth()](#getReservedWidth--) | 予約幅を取得または設定します。 |
+| [getVerticalOffset()](#getVerticalOffset--) | 垂直オフセットを取得または設定します。 |
+| [setDescendantsCannotBeMoved(boolean value)](#setDescendantsCannotBeMoved-boolean-) | アウトラインの子孫が移動可能かどうかを取得します。 |
+| [setHorizontalOffset(float value)](#setHorizontalOffset-float-) | 水平オフセットを取得または設定します。 |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 最終更新時刻を取得または設定します。 |
+| [setMaxHeight(float value)](#setMaxHeight-float-) | 最大高さを取得または設定します。 |
+| [setMaxWidth(float value)](#setMaxWidth-float-) | 最大幅を取得または設定します。 |
+| [setMinWidth(float value)](#setMinWidth-float-) | 最小幅を取得または設定します。 |
+| [setReservedWidth(float value)](#setReservedWidth-float-) | 予約幅を取得または設定します。 |
+| [setVerticalOffset(float value)](#setVerticalOffset-float-) | 垂直オフセットを取得または設定します。 |
+### Outline() {#Outline--}
+```
+public Outline()
+```
+
+
+新しい [Outline](../../com.aspose.note/outline) クラスのインスタンスを初期化します。
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+ノードのビジターを受け入れます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor` から派生したクラスのオブジェクト。 |
+
+### getDescendantsCannotBeMoved() {#getDescendantsCannotBeMoved--}
+```
+public boolean getDescendantsCannotBeMoved()
+```
+
+
+アウトラインの子孫が移動可能かどうかを取得します。
+
+**Returns:**
+boolean
+### getHorizontalOffset() {#getHorizontalOffset--}
+```
+public float getHorizontalOffset()
+```
+
+
+水平オフセットを取得または設定します。
+
+**Returns:**
+float
+### getInternalIndentPosition() {#getInternalIndentPosition--}
+```
+public int getInternalIndentPosition()
+```
+
+
+インデントサイズを取得するために RgOutlineIndentDistance 配列で合計する項目数を取得します。
+
+**Returns:**
+int
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+最終更新時刻を取得または設定します。
+
+**Returns:**
+java.util.Date
+### getMaxHeight() {#getMaxHeight--}
+```
+public float getMaxHeight()
+```
+
+
+最大高さを取得または設定します。
+
+**Returns:**
+float
+### getMaxWidth() {#getMaxWidth--}
+```
+public float getMaxWidth()
+```
+
+
+最大幅を取得または設定します。
+
+**Returns:**
+float
+### getMinWidth() {#getMinWidth--}
+```
+public float getMinWidth()
+```
+
+
+最小幅を取得または設定します。
+
+**Returns:**
+float
+### getReservedWidth() {#getReservedWidth--}
+```
+public float getReservedWidth()
+```
+
+
+予約幅を取得または設定します。
+
+**Returns:**
+float
+### getVerticalOffset() {#getVerticalOffset--}
+```
+public float getVerticalOffset()
+```
+
+
+垂直オフセットを取得または設定します。
+
+**Returns:**
+float
+### setDescendantsCannotBeMoved(boolean value) {#setDescendantsCannotBeMoved-boolean-}
+```
+public void setDescendantsCannotBeMoved(boolean value)
+```
+
+
+アウトラインの子孫が移動可能かどうかを取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setHorizontalOffset(float value) {#setHorizontalOffset-float-}
+```
+public void setHorizontalOffset(float value)
+```
+
+
+水平オフセットを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+最終更新時刻を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Date |  |
+
+### setMaxHeight(float value) {#setMaxHeight-float-}
+```
+public void setMaxHeight(float value)
+```
+
+
+最大高さを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setMaxWidth(float value) {#setMaxWidth-float-}
+```
+public void setMaxWidth(float value)
+```
+
+
+最大幅を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setMinWidth(float value) {#setMinWidth-float-}
+```
+public void setMinWidth(float value)
+```
+
+
+最小幅を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setReservedWidth(float value) {#setReservedWidth-float-}
+```
+public void setReservedWidth(float value)
+```
+
+
+予約幅を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setVerticalOffset(float value) {#setVerticalOffset-float-}
+```
+public void setVerticalOffset(float value)
+```
+
+
+垂直オフセットを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+

--- a/japanese/java/com.aspose.note/outlineelement/_index.md
+++ b/japanese/java/com.aspose.note/outlineelement/_index.md
@@ -1,0 +1,151 @@
+---
+title: "OutlineElement"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "OutlineElement を表します。"
+type: docs
+weight: 67
+url: /ja/java/com.aspose.note/outlineelement/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode, com.aspose.note.IndentatedNode
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineChildNode](../../com.aspose.note/ioutlinechildnode), [com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode)
+```
+public final class OutlineElement extends IndentatedNode<IOutlineElementChildNode,OutlineElement> implements IOutlineChildNode, IOutlineElementChildNode
+```
+
+OutlineElement を表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [OutlineElement()](#OutlineElement--) | `OutlineElement` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | ノードのビジターを受け入れます。 |
+| [getAuthorMostRecent()](#getAuthorMostRecent--) | アウトライン要素の最新の作成者を取得します。 |
+| [getAuthorOriginal()](#getAuthorOriginal--) | アウトライン要素の元の作成者を取得します。 |
+| [getCreationTime()](#getCreationTime--) | 作成時間を取得または設定します。 |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 最終更新時刻を取得または設定します。 |
+| [getNumberList()](#getNumberList--) | 番号付きリストヘッダーのスタイルを取得または設定します。 |
+| [setCreationTime(Date value)](#setCreationTime-java.util.Date-) | 作成時間を取得または設定します。 |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 最終更新時刻を取得または設定します。 |
+| [setNumberList(NumberList value)](#setNumberList-com.aspose.note.NumberList-) | 番号付きリストヘッダーのスタイルを取得または設定します。 |
+### OutlineElement() {#OutlineElement--}
+```
+public OutlineElement()
+```
+
+
+`OutlineElement` クラスの新しいインスタンスを初期化します。
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+ノードのビジターを受け入れます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor` から派生したクラスのオブジェクト。 |
+
+### getAuthorMostRecent() {#getAuthorMostRecent--}
+```
+public final String getAuthorMostRecent()
+```
+
+
+アウトライン要素の最新の作成者を取得します。
+
+値: 最新の作成者。
+
+**Returns:**
+java.lang.String
+### getAuthorOriginal() {#getAuthorOriginal--}
+```
+public final String getAuthorOriginal()
+```
+
+
+アウトライン要素の元の作成者を取得します。
+
+値: 元の作成者。
+
+**Returns:**
+java.lang.String
+### getCreationTime() {#getCreationTime--}
+```
+public Date getCreationTime()
+```
+
+
+作成時間を取得または設定します。
+
+**Returns:**
+java.util.Date
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+最終更新時刻を取得または設定します。
+
+**Returns:**
+java.util.Date
+### getNumberList() {#getNumberList--}
+```
+public NumberList getNumberList()
+```
+
+
+番号付きリストヘッダーのスタイルを取得または設定します。
+
+**Returns:**
+[NumberList](../../com.aspose.note/numberlist)
+### setCreationTime(Date value) {#setCreationTime-java.util.Date-}
+```
+public void setCreationTime(Date value)
+```
+
+
+作成時間を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Date |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+最終更新時刻を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Date |  |
+
+### setNumberList(NumberList value) {#setNumberList-com.aspose.note.NumberList-}
+```
+public void setNumberList(NumberList value)
+```
+
+
+番号付きリストヘッダーのスタイルを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [NumberList](../../com.aspose.note/numberlist) |  |
+

--- a/japanese/java/com.aspose.note/outlinegroup/_index.md
+++ b/japanese/java/com.aspose.note/outlinegroup/_index.md
@@ -1,0 +1,50 @@
+---
+title: "OutlineGroup"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "OutlineGroup を表します。"
+type: docs
+weight: 68
+url: /ja/java/com.aspose.note/outlinegroup/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode, com.aspose.note.IndentatedNode
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineChildNode](../../com.aspose.note/ioutlinechildnode), [com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode)
+```
+public final class OutlineGroup extends IndentatedNode<IOutlineChildNode,OutlineGroup> implements IOutlineChildNode, IOutlineElementChildNode
+```
+
+OutlineGroup を表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [OutlineGroup()](#OutlineGroup--) | 新しい `OutlineGroup` クラスのインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | ノードのビジターを受け入れます。 |
+### OutlineGroup() {#OutlineGroup--}
+```
+public OutlineGroup()
+```
+
+
+新しい `OutlineGroup` クラスのインスタンスを初期化します。
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+ノードのビジターを受け入れます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor` から派生したクラスのオブジェクト。 |
+

--- a/japanese/java/com.aspose.note/page/_index.md
+++ b/japanese/java/com.aspose.note/page/_index.md
@@ -1,0 +1,385 @@
+---
+title: "Page"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ページを表します。"
+type: docs
+weight: 69
+url: /ja/java/com.aspose.note/page/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode
+```
+public final class Page extends CompositeNode<IPageChildNode>
+```
+
+ページを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Page()](#Page--) | `Page` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | ノードのビジターを受け入れます。 |
+| [deepClone()](#deepClone--) | ページをクローンします。 |
+| [deepClone(boolean cloneHistory)](#deepClone-boolean-) | ページをクローンします。 |
+| [getAuthor()](#getAuthor--) | 作者を取得または設定します。 |
+| [getBackgroundColor()](#getBackgroundColor--) | ページの背景色を取得または設定します。 |
+| [getCreationTime()](#getCreationTime--) | 作成時間を取得または設定します。 |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 最終更新時刻を取得または設定します。 |
+| [getLevel()](#getLevel--) | レベルを取得または設定します。 |
+| [getMargin()](#getMargin--) | 余白を取得または設定します。 |
+| [getPageContentRevisionSummary()](#getPageContentRevisionSummary--) | ページとその子ノードのリビジョンサマリーを取得または設定します。 |
+| [getPageLayoutSize()](#getPageLayoutSize--) | エディタに表示されるページのレイアウトサイズを取得します。 |
+| [getSizeType()](#getSizeType--) | ページのサイズタイプを取得または設定します。 |
+| [getTitle()](#getTitle--) | タイトルを取得または設定します。 |
+| [isConflictPage()](#isConflictPage--) | このページが競合ページかどうかを示す値を取得または設定します。 |
+| [setAuthor(String value)](#setAuthor-java.lang.String-) | 作者を取得または設定します。 |
+| [setBackgroundColor(Color value)](#setBackgroundColor-java.awt.Color-) | ページの背景色を取得または設定します。 |
+| [setConflictPage(boolean value)](#setConflictPage-boolean-) | このページが競合ページかどうかを示す値を取得または設定します。 |
+| [setCreationTime(Date value)](#setCreationTime-java.util.Date-) | 作成時間を取得または設定します。 |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 最終更新時刻を取得または設定します。 |
+| [setLevel(byte value)](#setLevel-byte-) | レベルを取得または設定します。 |
+| [setMargin(Margins value)](#setMargin-com.aspose.note.Margins-) | 余白を取得または設定します。 |
+| [setPageContentRevisionSummary(RevisionSummary value)](#setPageContentRevisionSummary-com.aspose.note.RevisionSummary-) | ページとその子ノードのリビジョンサマリーを取得または設定します。 |
+| [setPageLayoutSize(Dimension2D value)](#setPageLayoutSize-java.awt.geom.Dimension2D-) | エディターに表示されるページのレイアウトサイズを設定します。 |
+| [setSizeType(int value)](#setSizeType-int-) | ページのサイズタイプを取得または設定します。 |
+| [setTitle(Title value)](#setTitle-com.aspose.note.Title-) | タイトルを取得または設定します。 |
+### Page() {#Page--}
+```
+public Page()
+```
+
+
+`Page` クラスの新しいインスタンスを初期化します。
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+ノードのビジターを受け入れます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor` から派生したクラスのオブジェクト。 |
+
+### deepClone() {#deepClone--}
+```
+public final Page deepClone()
+```
+
+
+ページをクローンします。
+
+**Returns:**
+[Page](../../com.aspose.note/page) - A clone of the page.
+### deepClone(boolean cloneHistory) {#deepClone-boolean-}
+```
+public final Page deepClone(boolean cloneHistory)
+```
+
+
+ページをクローンします。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| cloneHistory | boolean | ページの履歴をクローンするかどうかを指定します。 |
+
+**Returns:**
+[Page](../../com.aspose.note/page) - A clone of the page.
+### getAuthor() {#getAuthor--}
+```
+public String getAuthor()
+```
+
+
+作者を取得または設定します。
+
+**Returns:**
+java.lang.String
+### getBackgroundColor() {#getBackgroundColor--}
+```
+public final Color getBackgroundColor()
+```
+
+
+ページの背景色を取得または設定します。
+
+**Returns:**
+java.awt.Color
+### getCreationTime() {#getCreationTime--}
+```
+public Date getCreationTime()
+```
+
+
+作成時間を取得または設定します。
+
+**Returns:**
+java.util.Date
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+最終更新時刻を取得または設定します。
+
+**Returns:**
+java.util.Date
+### getLevel() {#getLevel--}
+```
+public byte getLevel()
+```
+
+
+レベルを取得または設定します。
+
+**Returns:**
+byte
+### getMargin() {#getMargin--}
+```
+public Margins getMargin()
+```
+
+
+余白を取得または設定します。
+
+**Returns:**
+[Margins](../../com.aspose.note/margins)
+### getPageContentRevisionSummary() {#getPageContentRevisionSummary--}
+```
+public RevisionSummary getPageContentRevisionSummary()
+```
+
+
+ページとその子ノードのリビジョンサマリーを取得または設定します。
+
+**Returns:**
+[RevisionSummary](../../com.aspose.note/revisionsummary)
+### getPageLayoutSize() {#getPageLayoutSize--}
+```
+public final Dimension2D getPageLayoutSize()
+```
+
+
+エディタに表示されるページのレイアウトサイズを取得します。
+
+--------------------
+
+この値は Microsoft OneNote アプリケーションによって、ドキュメントが開かれたときに基になるページレイアウトを表示するために使用されます。印刷やドキュメントの保存には影響しません。Page.SizeType プロパティが PageSizeType.SizeByContent に設定されている場合、このプロパティはコンテンツの実際のサイズを返します。
+
+**Returns:**
+java.awt.geom.Dimension2D
+### getSizeType() {#getSizeType--}
+```
+public final int getSizeType()
+```
+
+
+ページのサイズタイプを取得または設定します。
+
+--------------------
+
+デフォルトでは、ページは自動的にサイズ変更されます。デフォルト値は [PageSizeType.SizeByContent](../../com.aspose.note/pagesizetype\#SizeByContent) です。
+
+**Returns:**
+int
+### getTitle() {#getTitle--}
+```
+public Title getTitle()
+```
+
+
+タイトルを取得または設定します。
+
+値: `Title`。
+
+**Returns:**
+[Title](../../com.aspose.note/title)
+### isConflictPage() {#isConflictPage--}
+```
+public final boolean isConflictPage()
+```
+
+
+このページが競合ページかどうかを示す値を取得または設定します。
+
+--------------------
+
+競合ページは、2 人のユーザーが同じコンテンツを更新しようとしたときに発生します。この場合、最初のユーザーの変更は通常どおり書き込まれますが、別のユーザーの変更はマージできません。そのため、ページのコピーが作成され、競合としてマークされます。
+
+このバージョンでは、競合は最初のユーザーの変更を優先して解決されます。そのため、ドキュメントに競合ページがある場合、履歴には表示されますが、保存時にはスキップされます。このフラグをリセットすれば、これらのページを通常のページと同様に履歴に保存することが可能です。
+
+競合ページの操作に関する詳細なサンプルはオンラインドキュメントで確認できます。
+
+**Returns:**
+boolean
+### setAuthor(String value) {#setAuthor-java.lang.String-}
+```
+public void setAuthor(String value)
+```
+
+
+作者を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setBackgroundColor(Color value) {#setBackgroundColor-java.awt.Color-}
+```
+public final void setBackgroundColor(Color value)
+```
+
+
+ページの背景色を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.awt.Color |  |
+
+### setConflictPage(boolean value) {#setConflictPage-boolean-}
+```
+public final void setConflictPage(boolean value)
+```
+
+
+このページが競合ページかどうかを示す値を取得または設定します。
+
+--------------------
+
+競合ページは、2 人のユーザーが同じコンテンツを更新しようとしたときに発生します。この場合、最初のユーザーの変更は通常どおり書き込まれますが、別のユーザーの変更はマージできません。そのため、ページのコピーが作成され、競合としてマークされます。
+
+このバージョンでは、競合は最初のユーザーの変更を優先して解決されます。そのため、ドキュメントに競合ページがある場合、履歴には表示されますが、保存時にはスキップされます。このフラグをリセットすれば、これらのページを通常のページと同様に履歴に保存することが可能です。
+
+競合ページの操作に関する詳細なサンプルはオンラインドキュメントで確認できます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setCreationTime(Date value) {#setCreationTime-java.util.Date-}
+```
+public void setCreationTime(Date value)
+```
+
+
+作成時間を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Date |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+最終更新時刻を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Date |  |
+
+### setLevel(byte value) {#setLevel-byte-}
+```
+public void setLevel(byte value)
+```
+
+
+レベルを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte |  |
+
+### setMargin(Margins value) {#setMargin-com.aspose.note.Margins-}
+```
+public void setMargin(Margins value)
+```
+
+
+余白を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Margins](../../com.aspose.note/margins) |  |
+
+### setPageContentRevisionSummary(RevisionSummary value) {#setPageContentRevisionSummary-com.aspose.note.RevisionSummary-}
+```
+public void setPageContentRevisionSummary(RevisionSummary value)
+```
+
+
+ページとその子ノードのリビジョンサマリーを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [RevisionSummary](../../com.aspose.note/revisionsummary) |  |
+
+### setPageLayoutSize(Dimension2D value) {#setPageLayoutSize-java.awt.geom.Dimension2D-}
+```
+public final void setPageLayoutSize(Dimension2D value)
+```
+
+
+エディターに表示されるページのレイアウトサイズを設定します。
+
+--------------------
+
+この値は Microsoft OneNote アプリケーションによって、ドキュメントが開かれたときに基になるページレイアウトを表示するために使用されます。印刷やドキュメントの保存には影響しません。Page.SizeType プロパティが PageSizeType.SizeByContent に設定されている場合、このプロパティはコンテンツの実際のサイズを返します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.awt.geom.Dimension2D |  |
+
+### setSizeType(int value) {#setSizeType-int-}
+```
+public final void setSizeType(int value)
+```
+
+
+ページのサイズタイプを取得または設定します。
+
+--------------------
+
+デフォルトでは、ページは自動的にサイズ変更されます。デフォルト値は [PageSizeType.SizeByContent](../../com.aspose.note/pagesizetype\#SizeByContent) です。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTitle(Title value) {#setTitle-com.aspose.note.Title-}
+```
+public void setTitle(Title value)
+```
+
+
+タイトルを取得または設定します。
+
+値: `Title`。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Title](../../com.aspose.note/title) |  |
+

--- a/japanese/java/com.aspose.note/pagehistory/_index.md
+++ b/japanese/java/com.aspose.note/pagehistory/_index.md
@@ -1,0 +1,260 @@
+---
+title: "PageHistory"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ページ履歴を表します。"
+type: docs
+weight: 70
+url: /ja/java/com.aspose.note/pagehistory/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+com.aspose.ms.System.Collections.Generic.IGenericList
+```
+public class PageHistory implements System.Collections.Generic.IGenericList<Page>
+```
+
+ページ履歴を表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageHistory(Page page)](#PageHistory-com.aspose.note.Page-) | `PageHistory` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addItem(Page item)](#addItem-com.aspose.note.Page-) | `PageHistory` の末尾にページバージョンを追加します。 |
+| [addRange(System.Collections.Generic.IGenericEnumerable&lt;Page&gt; items)](#addRange-com.aspose.ms.System.Collections.Generic.IGenericEnumerable-com.aspose.note.Page--) | `PageHistory` の末尾にページバージョンを追加します。 |
+| [clear()](#clear--) | ページ履歴をクリアします。 |
+| [containsItem(Page item)](#containsItem-com.aspose.note.Page-) | ページ履歴にページバージョンが含まれているかどうかを判断します。 |
+| [copyToTArray(Page[] array, int arrayIndex)](#copyToTArray-com.aspose.note.Page---int-) | ページ バージョンを配列にコピーし、特定のインデックスから開始します.. |
+| [getCurrent()](#getCurrent--) | 現在のページ バージョンを取得します。 |
+| [get_Item(int index)](#get-Item-int-) | 指定されたインデックスの `PageHistory` のページ バージョンを取得または設定します。 |
+| [indexOfItem(Page item)](#indexOfItem-com.aspose.note.Page-) | ページ履歴内の特定のページ バージョンのインデックスを決定します。 |
+| [insertItem(int index, Page item)](#insertItem-int-com.aspose.note.Page-) | ページ履歴にページ バージョンを挿入します。 |
+| [isReadOnly()](#isReadOnly--) | ページ履歴が読み取り専用かどうかを示す値を取得します。 |
+| [iterator()](#iterator--) | `PageHistory` の子ノードを列挙する列挙子を返します。 |
+| [removeAt(int index)](#removeAt-int-) | `PageHistory` の指定インデックスにあるページ バージョンを削除します。 |
+| [removeItem(Page item)](#removeItem-com.aspose.note.Page-) | `PageHistory` からページ バージョンを削除します。 |
+| [removeRange(int index, int count)](#removeRange-int-int-) | `PageHistory` からページ バージョンの範囲を削除します。 |
+| [set_Item(int index, Page value)](#set-Item-int-com.aspose.note.Page-) | 指定されたインデックスの `PageHistory` のページ バージョンを取得または設定します。 |
+| [size()](#size--) | ページ履歴内のページ バージョンの数を取得します。 |
+### PageHistory(Page page) {#PageHistory-com.aspose.note.Page-}
+```
+public PageHistory(Page page)
+```
+
+
+`PageHistory` クラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.note/page) | 現在のページ バージョン。 |
+
+### addItem(Page item) {#addItem-com.aspose.note.Page-}
+```
+public void addItem(Page item)
+```
+
+
+`PageHistory` の末尾にページバージョンを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Page](../../com.aspose.note/page) | ページ バージョン。 |
+
+### addRange(System.Collections.Generic.IGenericEnumerable&lt;Page&gt; items) {#addRange-com.aspose.ms.System.Collections.Generic.IGenericEnumerable-com.aspose.note.Page--}
+```
+public void addRange(System.Collections.Generic.IGenericEnumerable<Page> items)
+```
+
+
+`PageHistory` の末尾にページバージョンを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 項目 | com.aspose.ms.System.Collections.Generic.IGenericEnumerable&lt;com.aspose.note.Page&gt; | ページ バージョンの `IEnumerable\{Page\}` コレクションです。 |
+
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+ページ履歴をクリアします。
+
+### containsItem(Page item) {#containsItem-com.aspose.note.Page-}
+```
+public boolean containsItem(Page item)
+```
+
+
+ページ履歴にページバージョンが含まれているかどうかを判断します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Page](../../com.aspose.note/page) | ページ バージョン。 |
+
+**Returns:**
+boolean - `bool`です。
+### copyToTArray(Page[] array, int arrayIndex) {#copyToTArray-com.aspose.note.Page---int-}
+```
+public void copyToTArray(Page[] array, int arrayIndex)
+```
+
+
+ページ バージョンを配列にコピーし、特定のインデックスから開始します..
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| array | [Page\[\]](../../com.aspose.note/page) | 対象の配列です。 |
+| arrayIndex | int | 配列インデックスです。 |
+
+### getCurrent() {#getCurrent--}
+```
+public Page getCurrent()
+```
+
+
+現在のページ バージョンを取得します。
+
+**Returns:**
+[Page](../../com.aspose.note/page)
+### get_Item(int index) {#get-Item-int-}
+```
+public Page get_Item(int index)
+```
+
+
+指定されたインデックスの `PageHistory` のページ バージョンを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| index | int | インデックスです。 |
+
+**Returns:**
+[Page](../../com.aspose.note/page) - The page version.
+### indexOfItem(Page item) {#indexOfItem-com.aspose.note.Page-}
+```
+public int indexOfItem(Page item)
+```
+
+
+ページ履歴内の特定のページ バージョンのインデックスを決定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Page](../../com.aspose.note/page) | ページ バージョン。 |
+
+**Returns:**
+int - `int`です。
+### insertItem(int index, Page item) {#insertItem-int-com.aspose.note.Page-}
+```
+public void insertItem(int index, Page item)
+```
+
+
+ページ履歴にページ バージョンを挿入します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| index | int | インデックスです。 |
+| item | [Page](../../com.aspose.note/page) | ページ バージョン。 |
+
+### isReadOnly() {#isReadOnly--}
+```
+public boolean isReadOnly()
+```
+
+
+ページ履歴が読み取り専用かどうかを示す値を取得します。
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public System.Collections.Generic.IGenericEnumerator<Page> iterator()
+```
+
+
+`PageHistory` の子ノードを列挙する列挙子を返します。
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;com.aspose.note.Page&gt; - `IEnumerator`。
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+`PageHistory` の指定インデックスにあるページ バージョンを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| index | int | インデックスです。 |
+
+### removeItem(Page item) {#removeItem-com.aspose.note.Page-}
+```
+public boolean removeItem(Page item)
+```
+
+
+`PageHistory` からページ バージョンを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Page](../../com.aspose.note/page) | ページ バージョン。 |
+
+**Returns:**
+boolean - `bool`です。
+### removeRange(int index, int count) {#removeRange-int-int-}
+```
+public void removeRange(int index, int count)
+```
+
+
+`PageHistory` からページ バージョンの範囲を削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| index | int | インデックスです。 |
+| count | int | カウントです。 |
+
+### set_Item(int index, Page value) {#set-Item-int-com.aspose.note.Page-}
+```
+public void set_Item(int index, Page value)
+```
+
+
+指定されたインデックスの `PageHistory` のページ バージョンを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| index | int | インデックスです。 |
+| value | [Page](../../com.aspose.note/page) |  |
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+ページ履歴内のページ バージョンの数を取得します。
+
+**Returns:**
+int

--- a/japanese/java/com.aspose.note/pagesavingargs/_index.md
+++ b/japanese/java/com.aspose.note/pagesavingargs/_index.md
@@ -1,0 +1,31 @@
+---
+title: "PageSavingArgs"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "PageSaving イベントのデータを提供します。"
+type: docs
+weight: 71
+url: /ja/java/com.aspose.note/pagesavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ResourceSavingArgs](../../com.aspose.note/resourcesavingargs)
+```
+public class PageSavingArgs extends ResourceSavingArgs
+```
+
+PageSaving イベントのデータを提供します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getPageIndex()](#getPageIndex--) | 現在のページインデックスです。 |
+### getPageIndex() {#getPageIndex--}
+```
+public final int getPageIndex()
+```
+
+
+現在のページインデックスです。
+
+**Returns:**
+int

--- a/japanese/java/com.aspose.note/pagesettings/_index.md
+++ b/japanese/java/com.aspose.note/pagesettings/_index.md
@@ -1,0 +1,64 @@
+---
+title: "PageSettings"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ページのレイアウト設定を表します。"
+type: docs
+weight: 72
+url: /ja/java/com.aspose.note/pagesettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSettings
+```
+
+ページのレイアウト設定を表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getA4()](#getA4--) | A4 形式ページの設定を取得します。 |
+| [getA4NoHeightLimit()](#getA4NoHeightLimit--) | 高さ無制限の A4 形式ページの設定を取得します。 |
+| [getLetter()](#getLetter--) | レター 形式ページの設定を取得します。 |
+| [getLetterNoHeightLimit()](#getLetterNoHeightLimit--) | 高さ無制限のレター 形式ページの設定を取得します。 |
+### getA4() {#getA4--}
+```
+public static PageSettings getA4()
+```
+
+
+A4 形式ページの設定を取得します。
+
+**Returns:**
+[PageSettings](../../com.aspose.note/pagesettings)
+### getA4NoHeightLimit() {#getA4NoHeightLimit--}
+```
+public static PageSettings getA4NoHeightLimit()
+```
+
+
+高さ無制限の A4 形式ページの設定を取得します。
+
+**Returns:**
+[PageSettings](../../com.aspose.note/pagesettings)
+### getLetter() {#getLetter--}
+```
+public static PageSettings getLetter()
+```
+
+
+レター 形式ページの設定を取得します。
+
+**Returns:**
+[PageSettings](../../com.aspose.note/pagesettings)
+### getLetterNoHeightLimit() {#getLetterNoHeightLimit--}
+```
+public static PageSettings getLetterNoHeightLimit()
+```
+
+
+高さ無制限のレター 形式ページの設定を取得します。
+
+**Returns:**
+[PageSettings](../../com.aspose.note/pagesettings)

--- a/japanese/java/com.aspose.note/pagesizetype/_index.md
+++ b/japanese/java/com.aspose.note/pagesizetype/_index.md
@@ -1,0 +1,164 @@
+---
+title: "PageSizeType"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ページノードタイプのサイズを指定します。"
+type: docs
+weight: 73
+url: /ja/java/com.aspose.note/pagesizetype/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class PageSizeType extends System.Enum
+```
+
+ページノードタイプのサイズを指定します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [ANSILetter](#ANSILetter) | ANSIレター (8.5" x 11"). |
+| [ANSITabloid](#ANSITabloid) | ANSIタブロイド (11" x 17"). |
+| [Billfold](#Billfold) | ビルフォールド (3.75" x 6.75"). |
+| [Custom](#Custom) | カスタムサイズです。 |
+| [ISOA3](#ISOA3) | ISO A3 (297mm x 420mm). |
+| [ISOA4](#ISOA4) | ISO A4 (210mm x 297mm). |
+| [ISOA5](#ISOA5) | ISO A5 (148mm x 210mm)。 |
+| [ISOA6](#ISOA6) | ISO A6 (105mm x 148mm)。 |
+| [IndexCard](#IndexCard) | インデックスカード (3" x 5"). |
+| [JISB4](#JISB4) | JIS B4 (257mm x 364mm)。 |
+| [JISB5](#JISB5) | JIS B5 (182mm x 257mm)。 |
+| [JISB6](#JISB6) | JIS B6 (128mm x 182mm)。 |
+| [JapanesePostcard](#JapanesePostcard) | 日本のはがき (100mm x 148mm)。 |
+| [SizeByContent](#SizeByContent) | ページには固定サイズがありません。 |
+| [USLegal](#USLegal) | 米国。 |
+| [USStatement](#USStatement) | 米国。 |
+### ANSILetter {#ANSILetter}
+```
+public static final int ANSILetter
+```
+
+
+ANSIレター (8.5" x 11").
+
+### ANSITabloid {#ANSITabloid}
+```
+public static final int ANSITabloid
+```
+
+
+ANSIタブロイド (11" x 17").
+
+### Billfold {#Billfold}
+```
+public static final int Billfold
+```
+
+
+ビルフォールド (3.75" x 6.75").
+
+### Custom {#Custom}
+```
+public static final int Custom
+```
+
+
+カスタムサイズです。
+
+### ISOA3 {#ISOA3}
+```
+public static final int ISOA3
+```
+
+
+ISO A3 (297mm x 420mm).
+
+### ISOA4 {#ISOA4}
+```
+public static final int ISOA4
+```
+
+
+ISO A4 (210mm x 297mm).
+
+### ISOA5 {#ISOA5}
+```
+public static final int ISOA5
+```
+
+
+ISO A5 (148mm x 210mm)。
+
+### ISOA6 {#ISOA6}
+```
+public static final int ISOA6
+```
+
+
+ISO A6 (105mm x 148mm)。
+
+### IndexCard {#IndexCard}
+```
+public static final int IndexCard
+```
+
+
+インデックスカード (3" x 5").
+
+### JISB4 {#JISB4}
+```
+public static final int JISB4
+```
+
+
+JIS B4 (257mm x 364mm)。
+
+### JISB5 {#JISB5}
+```
+public static final int JISB5
+```
+
+
+JIS B5 (182mm x 257mm)。
+
+### JISB6 {#JISB6}
+```
+public static final int JISB6
+```
+
+
+JIS B6 (128mm x 182mm)。
+
+### JapanesePostcard {#JapanesePostcard}
+```
+public static final int JapanesePostcard
+```
+
+
+日本のはがき (100mm x 148mm)。
+
+### SizeByContent {#SizeByContent}
+```
+public static final int SizeByContent
+```
+
+
+ページには固定サイズがありません。コンテンツ全体が収まるように自動的にサイズが変更されます。
+
+### USLegal {#USLegal}
+```
+public static final int USLegal
+```
+
+
+米国リーガル (8.5" x 14").
+
+### USStatement {#USStatement}
+```
+public static final int USStatement
+```
+
+
+米国ステートメント (5.5" x 8.5").
+

--- a/japanese/java/com.aspose.note/pagesplittingalgorithm/_index.md
+++ b/japanese/java/com.aspose.note/pagesplittingalgorithm/_index.md
@@ -1,0 +1,27 @@
+---
+title: "PageSplittingAlgorithm"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "オブジェクトが元のページに収まらない場合に分割するための基底クラスです。"
+type: docs
+weight: 74
+url: /ja/java/com.aspose.note/pagesplittingalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class PageSplittingAlgorithm
+```
+
+オブジェクトが元のページに収まらない場合に分割するための基底クラスです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageSplittingAlgorithm()](#PageSplittingAlgorithm--) |  |
+### PageSplittingAlgorithm() {#PageSplittingAlgorithm--}
+```
+public PageSplittingAlgorithm()
+```
+
+

--- a/japanese/java/com.aspose.note/paragraphstyle/_index.md
+++ b/japanese/java/com.aspose.note/paragraphstyle/_index.md
@@ -1,0 +1,90 @@
+---
+title: "ParagraphStyle"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "一致する TextStyle オブジェクトがコレクションに存在しない場合、またはこのオブジェクトが必要な設定を指定していない場合に使用されるテキストスタイル設定です。"
+type: docs
+weight: 75
+url: /ja/java/com.aspose.note/paragraphstyle/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.note.Style
+
+**All Implemented Interfaces:**
+com.aspose.ms.System.IEquatable, java.lang.Cloneable
+```
+public final class ParagraphStyle extends Style<ParagraphStyle> implements System.IEquatable<ParagraphStyle>, Cloneable
+```
+
+一致する TextStyle オブジェクトが [RichText.getStyles](../../com.aspose.note/richtext\#getStyles) コレクションに存在しない場合、またはこのオブジェクトが必要な設定を指定していない場合に使用されるテキストスタイル設定です。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ParagraphStyle()](#ParagraphStyle--) | 新しい [ParagraphStyle](../../com.aspose.note/paragraphstyle) クラスのインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(ParagraphStyle other)](#equals-com.aspose.note.ParagraphStyle-) | 指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。 |
+| [equals(Object obj)](#equals-java.lang.Object-) | 指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。 |
+| [getDefault()](#getDefault--) | デフォルト設定の ParagraphStyle を取得します。 |
+| [hashCode()](#hashCode--) | 型のハッシュ関数として機能します。 |
+### ParagraphStyle() {#ParagraphStyle--}
+```
+public ParagraphStyle()
+```
+
+
+新しい [ParagraphStyle](../../com.aspose.note/paragraphstyle) クラスのインスタンスを初期化します。
+
+### equals(ParagraphStyle other) {#equals-com.aspose.note.ParagraphStyle-}
+```
+public final boolean equals(ParagraphStyle other)
+```
+
+
+指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| other | [ParagraphStyle](../../com.aspose.note/paragraphstyle) | オブジェクトです。 |
+
+**Returns:**
+boolean - `boolean`。
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| obj | java.lang.Object | オブジェクトです。 |
+
+**Returns:**
+boolean - `boolean`。
+### getDefault() {#getDefault--}
+```
+public static ParagraphStyle getDefault()
+```
+
+
+デフォルト設定の ParagraphStyle を取得します。
+
+**Returns:**
+[ParagraphStyle](../../com.aspose.note/paragraphstyle)
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+型のハッシュ関数として機能します。
+
+**Returns:**
+int - `int`です。

--- a/japanese/java/com.aspose.note/pdfimagecompression/_index.md
+++ b/japanese/java/com.aspose.note/pdfimagecompression/_index.md
@@ -1,0 +1,56 @@
+---
+title: "PdfImageCompression"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "PDF ファイル内の画像に適用される圧縮タイプを指定します。"
+type: docs
+weight: 76
+url: /ja/java/com.aspose.note/pdfimagecompression/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class PdfImageCompression extends System.Enum
+```
+
+PDF ファイル内の画像に適用される圧縮タイプを指定します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Auto](#Auto) | 各画像に最適な圧縮方式を自動的に選択します。 |
+| [Flate](#Flate) | Flate 圧縮（ロスレス）。 |
+| [Jpeg](#Jpeg) | Jpeg 圧縮。 |
+| [None](#None) | 画像を保存する際に圧縮は使用されません。 |
+### Auto {#Auto}
+```
+public static final int Auto
+```
+
+
+各画像に最適な圧縮方式を自動的に選択します。
+
+### Flate {#Flate}
+```
+public static final int Flate
+```
+
+
+Flate 圧縮（ロスレス）。
+
+### Jpeg {#Jpeg}
+```
+public static final int Jpeg
+```
+
+
+Jpeg 圧縮。透明性はサポートされていません。
+
+### None {#None}
+```
+public static final int None
+```
+
+
+画像を保存する際に圧縮は使用されません。
+

--- a/japanese/java/com.aspose.note/pdfsaveoptions/_index.md
+++ b/japanese/java/com.aspose.note/pdfsaveoptions/_index.md
@@ -1,0 +1,145 @@
+---
+title: "PdfSaveOptions"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ドキュメントページを PDF にレンダリングする際に、追加オプションを指定できるようにします。"
+type: docs
+weight: 77
+url: /ja/java/com.aspose.note/pdfsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.SaveOptions](../../com.aspose.note/saveoptions)
+```
+public final class PdfSaveOptions extends SaveOptions
+```
+
+ドキュメントページを PDF にレンダリングする際に、追加オプションを指定できるようにします。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PdfSaveOptions()](#PdfSaveOptions--) | `PdfSaveOptions` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getImageCompression()](#getImageCompression--) | PDF ファイルの画像に適用される圧縮タイプを取得します。 |
+| [getJpegQuality()](#getJpegQuality--) | PDF ドキュメント内の JPEG 画像の品質を決定する値を取得します。 |
+| [getPageSettings()](#getPageSettings--) | ドキュメント内の各ページのページ設定を取得または設定します。 |
+| [getPageSplittingAlgorithm()](#getPageSplittingAlgorithm--) | ページ分割に使用されるアルゴリズムを取得または設定します。 |
+| [setImageCompression(int value)](#setImageCompression-int-) | PDF ファイルの画像に適用される圧縮タイプを設定します。 |
+| [setJpegQuality(int value)](#setJpegQuality-int-) | PDF ドキュメント内の JPEG 画像の品質を決定する値を設定します。 |
+| [setPageSettings(PageSettings value)](#setPageSettings-com.aspose.note.PageSettings-) | ドキュメント内の各ページのページ設定を取得または設定します。 |
+| [setPageSplittingAlgorithm(PageSplittingAlgorithm value)](#setPageSplittingAlgorithm-com.aspose.note.PageSplittingAlgorithm-) | ページ分割に使用されるアルゴリズムを取得または設定します。 |
+### PdfSaveOptions() {#PdfSaveOptions--}
+```
+public PdfSaveOptions()
+```
+
+
+`PdfSaveOptions` クラスの新しいインスタンスを初期化します。
+
+### getImageCompression() {#getImageCompression--}
+```
+public final int getImageCompression()
+```
+
+
+PDF ファイルの画像に適用される圧縮タイプを取得します。
+
+**Returns:**
+int
+### getJpegQuality() {#getJpegQuality--}
+```
+public final int getJpegQuality()
+```
+
+
+PDF ドキュメント内の JPEG 画像の品質を決定する値を取得します。値は 0 から 100 の範囲で、0 は最悪の品質だが最大圧縮、100 は最高の品質だが最小圧縮を意味します。
+
+--------------------
+
+デフォルト値は 90 です。
+
+**Returns:**
+int
+### getPageSettings() {#getPageSettings--}
+```
+public PageSettings getPageSettings()
+```
+
+
+ドキュメント内の各ページのページ設定を取得または設定します。デフォルトでは CurrentUICulture に依存し、\*US 文化圏はレター設定、その他は A4 設定です。
+
+**Returns:**
+[PageSettings](../../com.aspose.note/pagesettings)
+### getPageSplittingAlgorithm() {#getPageSplittingAlgorithm--}
+```
+public PageSplittingAlgorithm getPageSplittingAlgorithm()
+```
+
+
+ページ分割に使用されるアルゴリズムを取得または設定します。
+
+値: `PageSplittingAlgorithm`。
+
+**Returns:**
+[PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm)
+### setImageCompression(int value) {#setImageCompression-int-}
+```
+public final void setImageCompression(int value)
+```
+
+
+PDF ファイルの画像に適用される圧縮タイプを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setJpegQuality(int value) {#setJpegQuality-int-}
+```
+public final void setJpegQuality(int value)
+```
+
+
+PDF ドキュメント内の JPEG 画像の品質を決定する値を設定します。値は 0 から 100 の範囲で、0 は最悪の品質だが最大圧縮、100 は最高の品質だが最小圧縮を意味します。
+
+--------------------
+
+デフォルト値は 90 です。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPageSettings(PageSettings value) {#setPageSettings-com.aspose.note.PageSettings-}
+```
+public void setPageSettings(PageSettings value)
+```
+
+
+ドキュメント内の各ページのページ設定を取得または設定します。デフォルトでは CurrentUICulture に依存し、\*US 文化圏はレター設定、その他は A4 設定です。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [PageSettings](../../com.aspose.note/pagesettings) |  |
+
+### setPageSplittingAlgorithm(PageSplittingAlgorithm value) {#setPageSplittingAlgorithm-com.aspose.note.PageSplittingAlgorithm-}
+```
+public void setPageSplittingAlgorithm(PageSplittingAlgorithm value)
+```
+
+
+ページ分割に使用されるアルゴリズムを取得または設定します。
+
+値: `PageSplittingAlgorithm`。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm) |  |
+

--- a/japanese/java/com.aspose.note/printoptions/_index.md
+++ b/japanese/java/com.aspose.note/printoptions/_index.md
@@ -1,0 +1,145 @@
+---
+title: "PrintOptions"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ドキュメントの印刷に使用されるオプションです。"
+type: docs
+weight: 78
+url: /ja/java/com.aspose.note/printoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PrintOptions
+```
+
+ドキュメントの印刷に使用されるオプションです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PrintOptions()](#PrintOptions--) | `PrintOptions` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getDocumentName()](#getDocumentName--) | ドキュメントを印刷中に表示する文書名を取得または設定します（例: 印刷ステータス ダイアログ ボックスやプリンター キュー）。 |
+| [getPageSplittingAlgorithm()](#getPageSplittingAlgorithm--) | ページ分割に使用されるアルゴリズムを取得または設定します。 |
+| [getPrinterSettings()](#getPrinterSettings--) | プリンター設定を取得または設定します。 |
+| [getResolution()](#getResolution--) | 生成された画像の解像度（dpi）を取得または設定します。 |
+| [setDocumentName(String value)](#setDocumentName-java.lang.String-) | ドキュメントを印刷中に表示する文書名を取得または設定します（例: 印刷ステータス ダイアログ ボックスやプリンター キュー）。 |
+| [setPageSplittingAlgorithm(PageSplittingAlgorithm value)](#setPageSplittingAlgorithm-com.aspose.note.PageSplittingAlgorithm-) | ページ分割に使用されるアルゴリズムを取得または設定します。 |
+| [setPrinterSettings(AttributeSet value)](#setPrinterSettings-javax.print.attribute.AttributeSet-) | プリンター設定を取得または設定します。 |
+| [setResolution(float value)](#setResolution-float-) | 生成された画像の解像度（dpi）を取得または設定します。 |
+### PrintOptions() {#PrintOptions--}
+```
+public PrintOptions()
+```
+
+
+`PrintOptions` クラスの新しいインスタンスを初期化します。
+
+### getDocumentName() {#getDocumentName--}
+```
+public String getDocumentName()
+```
+
+
+ドキュメントを印刷中に表示する文書名を取得または設定します（例: 印刷ステータス ダイアログ ボックスやプリンター キュー）。
+
+**Returns:**
+java.lang.String
+### getPageSplittingAlgorithm() {#getPageSplittingAlgorithm--}
+```
+public PageSplittingAlgorithm getPageSplittingAlgorithm()
+```
+
+
+ページ分割に使用されるアルゴリズムを取得または設定します。
+
+値: `PageSplittingAlgorithm`。
+
+**Returns:**
+[PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm)
+### getPrinterSettings() {#getPrinterSettings--}
+```
+public AttributeSet getPrinterSettings()
+```
+
+
+プリンター設定を取得または設定します。
+
+**Returns:**
+javax.print.attribute.AttributeSet
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+生成された画像の解像度（dpi）を取得または設定します。
+
+--------------------
+
+デフォルト値は 96 です。
+
+**Returns:**
+float
+### setDocumentName(String value) {#setDocumentName-java.lang.String-}
+```
+public void setDocumentName(String value)
+```
+
+
+ドキュメントを印刷中に表示する文書名を取得または設定します（例: 印刷ステータス ダイアログ ボックスやプリンター キュー）。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setPageSplittingAlgorithm(PageSplittingAlgorithm value) {#setPageSplittingAlgorithm-com.aspose.note.PageSplittingAlgorithm-}
+```
+public void setPageSplittingAlgorithm(PageSplittingAlgorithm value)
+```
+
+
+ページ分割に使用されるアルゴリズムを取得または設定します。
+
+値: `PageSplittingAlgorithm`。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm) |  |
+
+### setPrinterSettings(AttributeSet value) {#setPrinterSettings-javax.print.attribute.AttributeSet-}
+```
+public void setPrinterSettings(AttributeSet value)
+```
+
+
+プリンター設定を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | javax.print.attribute.AttributeSet |  |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+生成された画像の解像度（dpi）を取得または設定します。
+
+--------------------
+
+デフォルト値は 96 です。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+

--- a/japanese/java/com.aspose.note/resourceexporttype/_index.md
+++ b/japanese/java/com.aspose.note/resourceexporttype/_index.md
@@ -1,0 +1,39 @@
+---
+title: "ResourceExportType"
+second_title: "Aspose.Note for Java API リファレンス"
+description: 
+type: docs
+weight: 79
+url: /ja/java/com.aspose.note/resourceexporttype/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class ResourceExportType extends System.Enum
+```
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [ExportAsStream](#ExportAsStream) |  |
+| [ExportEmbedded](#ExportEmbedded) |  |
+| [NoExport](#NoExport) |  |
+### ExportAsStream {#ExportAsStream}
+```
+public static final int ExportAsStream
+```
+
+
+### ExportEmbedded {#ExportEmbedded}
+```
+public static final int ExportEmbedded
+```
+
+
+### NoExport {#NoExport}
+```
+public static final int NoExport
+```
+
+

--- a/japanese/java/com.aspose.note/resourcesavingargs/_index.md
+++ b/japanese/java/com.aspose.note/resourcesavingargs/_index.md
@@ -1,0 +1,117 @@
+---
+title: "ResourceSavingArgs"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ResourceSaving イベントのデータを提供します。"
+type: docs
+weight: 80
+url: /ja/java/com.aspose.note/resourcesavingargs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ResourceSavingArgs
+```
+
+ResourceSaving イベントのデータを提供します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getDocument()](#getDocument--) | 保存ドキュメントを取得します。 |
+| [getFileName()](#getFileName--) | ファイル名を取得します。 |
+| [getKeepStreamOpen()](#getKeepStreamOpen--) | ストリームを開いたままにするかどうかを示す値を取得または設定します。 |
+| [getStream()](#getStream--) | リソースを保存するために使用されるストリームを取得または設定します。 |
+| [getUri()](#getUri--) | 保存されたリソースにアクセスするための URI を取得または設定します。 |
+| [setKeepStreamOpen(boolean value)](#setKeepStreamOpen-boolean-) | ストリームを開いたままにするかどうかを示す値を取得または設定します。 |
+| [setStream(OutputStream value)](#setStream-java.io.OutputStream-) | リソースを保存するために使用されるストリームを取得または設定します。 |
+| [setUri(String value)](#setUri-java.lang.String-) | 保存されたリソースにアクセスするための URI を取得または設定します。 |
+### getDocument() {#getDocument--}
+```
+public final Document getDocument()
+```
+
+
+保存ドキュメントを取得します。
+
+**Returns:**
+[Document](../../com.aspose.note/document)
+### getFileName() {#getFileName--}
+```
+public final String getFileName()
+```
+
+
+ファイル名を取得します。
+
+**Returns:**
+java.lang.String
+### getKeepStreamOpen() {#getKeepStreamOpen--}
+```
+public final boolean getKeepStreamOpen()
+```
+
+
+ストリームを開いたままにするかどうかを示す値を取得または設定します。
+
+**Returns:**
+boolean
+### getStream() {#getStream--}
+```
+public final OutputStream getStream()
+```
+
+
+リソースを保存するために使用されるストリームを取得または設定します。
+
+**Returns:**
+java.io.OutputStream
+### getUri() {#getUri--}
+```
+public final String getUri()
+```
+
+
+保存されたリソースにアクセスするための URI を取得または設定します。
+
+**Returns:**
+java.lang.String
+### setKeepStreamOpen(boolean value) {#setKeepStreamOpen-boolean-}
+```
+public final void setKeepStreamOpen(boolean value)
+```
+
+
+ストリームを開いたままにするかどうかを示す値を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setStream(OutputStream value) {#setStream-java.io.OutputStream-}
+```
+public final void setStream(OutputStream value)
+```
+
+
+リソースを保存するために使用されるストリームを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.io.OutputStream |  |
+
+### setUri(String value) {#setUri-java.lang.String-}
+```
+public final void setUri(String value)
+```
+
+
+保存されたリソースにアクセスするための URI を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+

--- a/japanese/java/com.aspose.note/revisionsummary/_index.md
+++ b/japanese/java/com.aspose.note/revisionsummary/_index.md
@@ -1,0 +1,81 @@
+---
+title: "RevisionSummary"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ノードのリビジョンの概要を表します。"
+type: docs
+weight: 81
+url: /ja/java/com.aspose.note/revisionsummary/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RevisionSummary
+```
+
+ノードのリビジョンの要約を表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [RevisionSummary()](#RevisionSummary--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getAuthorMostRecent()](#getAuthorMostRecent--) | 最も最近の作成者を取得または設定します。 |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 最終更新時刻を取得または設定します。 |
+| [setAuthorMostRecent(String value)](#setAuthorMostRecent-java.lang.String-) | 最も最近の作成者を取得または設定します。 |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 最終更新時刻を取得または設定します。 |
+### RevisionSummary() {#RevisionSummary--}
+```
+public RevisionSummary()
+```
+
+
+### getAuthorMostRecent() {#getAuthorMostRecent--}
+```
+public String getAuthorMostRecent()
+```
+
+
+最も最近の作成者を取得または設定します。
+
+**Returns:**
+java.lang.String
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+最終更新時刻を取得または設定します。
+
+**Returns:**
+java.util.Date
+### setAuthorMostRecent(String value) {#setAuthorMostRecent-java.lang.String-}
+```
+public void setAuthorMostRecent(String value)
+```
+
+
+最も最近の作成者を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+最終更新時刻を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Date |  |
+

--- a/japanese/java/com.aspose.note/richtext/_index.md
+++ b/japanese/java/com.aspose.note/richtext/_index.md
@@ -1,0 +1,804 @@
+---
+title: "RichText"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "リッチテキストを表します。"
+type: docs
+weight: 82
+url: /ja/java/com.aspose.note/richtext/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node)
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode), [com.aspose.note.ITaggable](../../com.aspose.note/itaggable), com.aspose.ms.System.Collections.Generic.IGenericEnumerable
+```
+public class RichText extends Node implements IOutlineElementChildNode, ITaggable, System.Collections.Generic.IGenericEnumerable<Character>
+```
+
+リッチテキストを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [RichText()](#RichText--) | [RichText](../../com.aspose.note/richtext) クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | ノードのビジターを受け入れます。 |
+| [append(String value)](#append-java.lang.String-) | 最後のテキスト範囲に文字列を追加します。 |
+| [append(String value, TextStyle style)](#append-java.lang.String-com.aspose.note.TextStyle-) | 文字列を末尾に追加します。 |
+| [appendFront(String value)](#appendFront-java.lang.String-) | 文字列を最初のテキスト範囲の先頭に追加します。 |
+| [appendFront(String value, TextStyle style)](#appendFront-java.lang.String-com.aspose.note.TextStyle-) | 文字列を先頭に追加します。 |
+| [clear()](#clear--) | このインスタンスの内容をクリアします。 |
+| [getAlignment()](#getAlignment--) | 配置を取得します。 |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 最終更新時刻を取得します。 |
+| [getLength()](#getLength--) |  |
+| [getLineSpacing()](#getLineSpacing--) | 行間隔を取得します。 |
+| [getParagraphStyle()](#getParagraphStyle--) | 段落スタイルを取得します。 |
+| [getSpaceAfter()](#getSpaceAfter--) | 後ろの最小余白を取得します。 |
+| [getSpaceBefore()](#getSpaceBefore--) | 前の最小余白を取得します。 |
+| [getStyles()](#getStyles--) | スタイルを取得します。 |
+| [getTags()](#getTags--) | 段落のすべてのタグの一覧を取得します。 |
+| [getText()](#getText--) | テキストを取得します。 |
+| [getTextRuns()](#getTextRuns--) |  |
+| [indexOf(char value)](#indexOf-char-) | この文字列内で指定された Unicode 文字が最初に出現するゼロベースのインデックスを返します。 |
+| [indexOf(char value, int startIndex)](#indexOf-char-int-) | この文字列内で指定された Unicode 文字が最初に出現するゼロベースのインデックスを返します。 |
+| [indexOf(char value, int startIndex, int count)](#indexOf-char-int-int-) | このインスタンス内で指定された文字が最初に出現するゼロベースのインデックスを返します。 |
+| [indexOf(String value)](#indexOf-java.lang.String-) | このインスタンス内で指定された文字列が最初に出現するゼロベースのインデックスを返します。 |
+| [indexOf(String value, int startIndex)](#indexOf-java.lang.String-int-) | このインスタンス内で指定された文字列が最初に出現するゼロベースのインデックスを返します。 |
+| [indexOf(String value, int startIndex, int count)](#indexOf-java.lang.String-int-int-) | このインスタンス内で指定された文字列が最初に出現するゼロベースのインデックスを返します。 |
+| [indexOf(String value, int startIndex, int count, short comparisonType)](#indexOf-java.lang.String-int-int-short-) | 現在のインスタンス内で指定された文字列が最初に出現するゼロベースのインデックスを返します。 |
+| [indexOf(String value, short comparisonType)](#indexOf-java.lang.String-short-) | 現在のインスタンス内で指定された文字列が最初に出現するゼロベースのインデックスを返します。 |
+| [indexOf_Rename_Namesake(String value, int startIndex, short comparisonType)](#indexOf-Rename-Namesake-java.lang.String-int-short-) | 現在のインスタンス内で指定された文字列が最初に出現するゼロベースのインデックスを返します。 |
+| [insert(int startIndex, String value)](#insert-int-java.lang.String-) | このインスタンスの指定されたインデックス位置に指定された文字列を挿入します。 |
+| [insert(int startIndex, String value, TextStyle style)](#insert-int-java.lang.String-com.aspose.note.TextStyle-) | このインスタンスの指定されたインデックス位置に、指定されたスタイルを持つ文字列を挿入します。 |
+| [iterator()](#iterator--) |  |
+| [remove(int startIndex)](#remove-int-) | 現在のインスタンスで、指定された位置から最後の位置までのすべての文字を削除します。 |
+| [remove(int startIndex, int count)](#remove-int-int-) | 現在のインスタンスで、指定された位置から指定された数の文字を削除します。 |
+| [replace(char oldChar, char newChar)](#replace-char-char-) | このインスタンス内の指定された Unicode 文字のすべての出現を、別の指定された Unicode 文字に置き換えます。 |
+| [replace(String oldValue, String newValue)](#replace-java.lang.String-java.lang.String-) | 現在のインスタンス内の指定された文字列のすべての出現を、別の指定された文字列に置き換えます。 |
+| [replace(String oldValue, String newValue, TextStyle style)](#replace-java.lang.String-java.lang.String-com.aspose.note.TextStyle-) | 現在のインスタンス内の指定された文字列のすべての出現を、指定されたスタイルの別の文字列に置き換えます。 |
+| [setAlignment(int value)](#setAlignment-int-) | 配置を設定します。 |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 最終更新日時を設定します。 |
+| [setLineSpacing(float value)](#setLineSpacing-float-) |  |
+| [setLineSpacing(Float value)](#setLineSpacing-java.lang.Float-) | 行間隔を設定します。 |
+| [setParagraphStyle(ParagraphStyle value)](#setParagraphStyle-com.aspose.note.ParagraphStyle-) | 段落スタイルを設定します。 |
+| [setSpaceAfter(float value)](#setSpaceAfter-float-) |  |
+| [setSpaceAfter(Float value)](#setSpaceAfter-java.lang.Float-) | 後ろの最小余白を設定します。 |
+| [setSpaceBefore(float value)](#setSpaceBefore-float-) |  |
+| [setSpaceBefore(Float value)](#setSpaceBefore-java.lang.Float-) | 前に設定する最小スペース量を設定します。 |
+| [setText(String value)](#setText-java.lang.String-) | テキストを設定します。 |
+| [trim()](#trim--) | 先頭と末尾のすべての空白文字を削除します。 |
+| [trim(char trimChar)](#trim-char-) | 文字の先頭と末尾のすべての出現を削除します。 |
+| [trim(char[] trimChars)](#trim-char...-) | 配列で指定された文字セットの先頭と末尾のすべての出現を削除します。 |
+| [trimEnd()](#trimEnd--) | 末尾のすべての空白文字を削除します。 |
+| [trimEnd(char trimChar)](#trimEnd-char-) | 文字の末尾のすべての出現を削除します。 |
+| [trimEnd(char[] trimChars)](#trimEnd-char...-) | 配列で指定された文字セットの末尾のすべての出現を削除します。 |
+| [trimStart()](#trimStart--) | 先頭のすべての空白文字を削除します。 |
+| [trimStart(char trimChar)](#trimStart-char-) | 指定された文字の先頭のすべての出現を削除します。 |
+| [trimStart(char[] trimChars)](#trimStart-char...-) | 配列で指定された文字セットの先頭のすべての出現を削除します。 |
+### RichText() {#RichText--}
+```
+public RichText()
+```
+
+
+[RichText](../../com.aspose.note/richtext) クラスの新しいインスタンスを初期化します。
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+ノードのビジターを受け入れます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | [DocumentVisitor](../../com.aspose.note/documentvisitor) から派生したクラスのオブジェクトです。 |
+
+### append(String value) {#append-java.lang.String-}
+```
+public RichText append(String value)
+```
+
+
+最後のテキスト範囲に文字列を追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 追加された値です。 |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### append(String value, TextStyle style) {#append-java.lang.String-com.aspose.note.TextStyle-}
+```
+public final RichText append(String value, TextStyle style)
+```
+
+
+文字列を末尾に追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 追加された値です。 |
+| style | [TextStyle](../../com.aspose.note/textstyle) | 追加された文字列のスタイルです。 |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### appendFront(String value) {#appendFront-java.lang.String-}
+```
+public RichText appendFront(String value)
+```
+
+
+文字列を最初のテキスト範囲の先頭に追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 追加された値です。 |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### appendFront(String value, TextStyle style) {#appendFront-java.lang.String-com.aspose.note.TextStyle-}
+```
+public RichText appendFront(String value, TextStyle style)
+```
+
+
+文字列を先頭に追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 追加された値です。 |
+| style | [TextStyle](../../com.aspose.note/textstyle) | 追加された文字列のスタイルです。 |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### clear() {#clear--}
+```
+public final RichText clear()
+```
+
+
+このインスタンスの内容をクリアします。
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+配置を取得します。
+
+**Returns:**
+int
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+最終更新時刻を取得します。
+
+**Returns:**
+java.util.Date
+### getLength() {#getLength--}
+```
+public final int getLength()
+```
+
+
+
+
+**Returns:**
+int
+### getLineSpacing() {#getLineSpacing--}
+```
+public Float getLineSpacing()
+```
+
+
+行間隔を取得します。
+
+**Returns:**
+java.lang.Float
+### getParagraphStyle() {#getParagraphStyle--}
+```
+public final ParagraphStyle getParagraphStyle()
+```
+
+
+段落スタイルを取得します。これらの設定は、[getStyles](../../com.aspose.note/richtext\#getStyles) コレクションに一致する TextStyle オブジェクトが存在しない場合、またはこのオブジェクトが必要な設定を指定していない場合に使用されます。
+
+**Returns:**
+[ParagraphStyle](../../com.aspose.note/paragraphstyle)
+### getSpaceAfter() {#getSpaceAfter--}
+```
+public Float getSpaceAfter()
+```
+
+
+後ろの最小余白を取得します。
+
+**Returns:**
+java.lang.Float
+### getSpaceBefore() {#getSpaceBefore--}
+```
+public Float getSpaceBefore()
+```
+
+
+前の最小余白を取得します。
+
+**Returns:**
+java.lang.Float
+### getStyles() {#getStyles--}
+```
+public System.Collections.Generic.IGenericEnumerable<TextStyle> getStyles()
+```
+
+
+スタイルを取得します。
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerable&lt;com.aspose.note.TextStyle&gt;
+### getTags() {#getTags--}
+```
+public final System.Collections.Generic.List<ITag> getTags()
+```
+
+
+段落のすべてのタグの一覧を取得します。
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List&lt;com.aspose.note.ITag&gt;
+### getText() {#getText--}
+```
+public final String getText()
+```
+
+
+テキストを取得します。文字列は値 10（改行）の文字を含んではいけません。
+
+**Returns:**
+java.lang.String
+### getTextRuns() {#getTextRuns--}
+```
+public final System.Collections.Generic.IGenericEnumerable<TextRun> getTextRuns()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerable&lt;com.aspose.note.TextRun&gt;
+### indexOf(char value) {#indexOf-char-}
+```
+public final int indexOf(char value)
+```
+
+
+この文字列内で指定された Unicode 文字が最初に出現するゼロベースのインデックスを返します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | char | 値です。 |
+
+**Returns:**
+int - `int`です。
+### indexOf(char value, int startIndex) {#indexOf-char-int-}
+```
+public final int indexOf(char value, int startIndex)
+```
+
+
+この文字列内で指定された Unicode 文字の最初の出現のゼロベースインデックスを返します。検索は指定された文字位置から開始します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | char | 値です。 |
+| startIndex | int | 検索開始位置 |
+
+**Returns:**
+int - `int`です。
+### indexOf(char value, int startIndex, int count) {#indexOf-char-int-int-}
+```
+public final int indexOf(char value, int startIndex, int count)
+```
+
+
+このインスタンス内で指定された文字の最初の出現のゼロベースインデックスを返します。検索は指定された文字位置から開始し、指定された文字数だけ調べます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | char | 値です。 |
+| startIndex | int | 検索開始位置 |
+| count | int | カウントです。 |
+
+**Returns:**
+int - `int`です。
+### indexOf(String value) {#indexOf-java.lang.String-}
+```
+public final int indexOf(String value)
+```
+
+
+このインスタンス内で指定された文字列が最初に出現するゼロベースのインデックスを返します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 値です。 |
+
+**Returns:**
+int - `int`です。
+### indexOf(String value, int startIndex) {#indexOf-java.lang.String-int-}
+```
+public final int indexOf(String value, int startIndex)
+```
+
+
+このインスタンスで指定された文字列が最初に出現する位置のゼロベースインデックスを返します。検索は指定された文字位置から開始します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 値です。 |
+| startIndex | int | 検索開始位置 |
+
+**Returns:**
+int - `int`です。
+### indexOf(String value, int startIndex, int count) {#indexOf-java.lang.String-int-int-}
+```
+public final int indexOf(String value, int startIndex, int count)
+```
+
+
+このインスタンスで指定された文字列が最初に出現する位置のゼロベースインデックスを返します。検索は指定された文字位置から開始し、指定された文字数だけ調べます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 値です。 |
+| startIndex | int | 検索開始位置 |
+| count | int | カウントです。 |
+
+**Returns:**
+int - `int`です。
+### indexOf(String value, int startIndex, int count, short comparisonType) {#indexOf-java.lang.String-int-int-short-}
+```
+public final int indexOf(String value, int startIndex, int count, short comparisonType)
+```
+
+
+現在のインスタンス内で指定された文字列が最初に出現するゼロベースのインデックスを返します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 値です。 |
+| startIndex | int | 検索開始位置 |
+| count | int | カウントです。 |
+| comparisonType | short | 指定された文字列に使用する検索の種類 |
+
+**Returns:**
+int - `int`です。
+### indexOf(String value, short comparisonType) {#indexOf-java.lang.String-short-}
+```
+public final int indexOf(String value, short comparisonType)
+```
+
+
+現在のインスタンスで指定された文字列が最初に出現する位置のゼロベースインデックスを返します。パラメータは指定された文字列に使用する検索の種類を指定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 値です。 |
+| comparisonType | short | 指定された文字列に使用する検索の種類 |
+
+**Returns:**
+int - `int`です。
+### indexOf_Rename_Namesake(String value, int startIndex, short comparisonType) {#indexOf-Rename-Namesake-java.lang.String-int-short-}
+```
+public final int indexOf_Rename_Namesake(String value, int startIndex, short comparisonType)
+```
+
+
+現在のインスタンスで指定された文字列が最初に出現する位置のゼロベースインデックスを返します。パラメータは現在の文字列における検索開始位置と、指定された文字列に使用する検索の種類を指定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 値です。 |
+| startIndex | int | 検索開始位置 |
+| comparisonType | short | 指定された文字列に使用する検索の種類 |
+
+**Returns:**
+int - `int`です。
+### insert(int startIndex, String value) {#insert-int-java.lang.String-}
+```
+public final RichText insert(int startIndex, String value)
+```
+
+
+このインスタンスの指定されたインデックス位置に指定された文字列を挿入します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| startIndex | int | 開始インデックス。 |
+| 値 | java.lang.String | 値です。 |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### insert(int startIndex, String value, TextStyle style) {#insert-int-java.lang.String-com.aspose.note.TextStyle-}
+```
+public final RichText insert(int startIndex, String value, TextStyle style)
+```
+
+
+このインスタンスの指定されたインデックス位置に、指定されたスタイルを持つ文字列を挿入します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| startIndex | int | 開始インデックス。 |
+| 値 | java.lang.String | 値です。 |
+| style | [TextStyle](../../com.aspose.note/textstyle) | スタイル。 |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### iterator() {#iterator--}
+```
+public System.Collections.Generic.IGenericEnumerator<Character> iterator()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;java.lang.Character&gt;
+### remove(int startIndex) {#remove-int-}
+```
+public final RichText remove(int startIndex)
+```
+
+
+現在のインスタンスで、指定された位置から最後の位置までのすべての文字を削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| startIndex | int | 開始インデックス。 |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### remove(int startIndex, int count) {#remove-int-int-}
+```
+public final RichText remove(int startIndex, int count)
+```
+
+
+現在のインスタンスで、指定された位置から指定された数の文字を削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| startIndex | int | 開始インデックス。 |
+| count | int | カウントです。 |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### replace(char oldChar, char newChar) {#replace-char-char-}
+```
+public final RichText replace(char oldChar, char newChar)
+```
+
+
+このインスタンス内の指定された Unicode 文字のすべての出現を、別の指定された Unicode 文字に置き換えます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| oldChar | char | 古い文字。 |
+| newChar | char | 新しい文字。 |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### replace(String oldValue, String newValue) {#replace-java.lang.String-java.lang.String-}
+```
+public final RichText replace(String oldValue, String newValue)
+```
+
+
+現在のインスタンス内の指定された文字列のすべての出現を、別の指定された文字列に置き換えます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| oldValue | java.lang.String | 古い値。 |
+| newValue | java.lang.String | 新しい値。 |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### replace(String oldValue, String newValue, TextStyle style) {#replace-java.lang.String-java.lang.String-com.aspose.note.TextStyle-}
+```
+public final RichText replace(String oldValue, String newValue, TextStyle style)
+```
+
+
+現在のインスタンス内の指定された文字列のすべての出現を、指定されたスタイルの別の文字列に置き換えます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| oldValue | java.lang.String | 古い値。 |
+| newValue | java.lang.String | 新しい値。 |
+| style | [TextStyle](../../com.aspose.note/textstyle) | 新しい値のスタイル。 |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+配置を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+最終更新日時を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Date |  |
+
+### setLineSpacing(float value) {#setLineSpacing-float-}
+```
+public void setLineSpacing(float value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setLineSpacing(Float value) {#setLineSpacing-java.lang.Float-}
+```
+public void setLineSpacing(Float value)
+```
+
+
+行間隔を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Float |  |
+
+### setParagraphStyle(ParagraphStyle value) {#setParagraphStyle-com.aspose.note.ParagraphStyle-}
+```
+public final void setParagraphStyle(ParagraphStyle value)
+```
+
+
+段落のスタイルを設定します。これらの設定は、[getStyles](../../com.aspose.note/richtext\#getStyles) コレクションに一致する TextStyle オブジェクトが存在しない場合、またはこのオブジェクトが必要な設定を指定していない場合に使用されます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ParagraphStyle](../../com.aspose.note/paragraphstyle) |  |
+
+### setSpaceAfter(float value) {#setSpaceAfter-float-}
+```
+public void setSpaceAfter(float value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setSpaceAfter(Float value) {#setSpaceAfter-java.lang.Float-}
+```
+public void setSpaceAfter(Float value)
+```
+
+
+後ろの最小余白を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Float |  |
+
+### setSpaceBefore(float value) {#setSpaceBefore-float-}
+```
+public void setSpaceBefore(float value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setSpaceBefore(Float value) {#setSpaceBefore-java.lang.Float-}
+```
+public void setSpaceBefore(Float value)
+```
+
+
+前に設定する最小スペース量を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Float |  |
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public final void setText(String value)
+```
+
+
+テキストを設定します。文字列は値10（改行）に相当する文字を含んではいけません。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### trim() {#trim--}
+```
+public final RichText trim()
+```
+
+
+先頭と末尾のすべての空白文字を削除します。
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trim(char trimChar) {#trim-char-}
+```
+public final RichText trim(char trimChar)
+```
+
+
+文字の先頭と末尾のすべての出現を削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| trimChar | char | トリム文字。 |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trim(char[] trimChars) {#trim-char...-}
+```
+public final RichText trim(char[] trimChars)
+```
+
+
+配列で指定された文字セットの先頭と末尾のすべての出現を削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| trimChars | char[] | トリム文字です。 |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trimEnd() {#trimEnd--}
+```
+public final RichText trimEnd()
+```
+
+
+末尾のすべての空白文字を削除します。
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trimEnd(char trimChar) {#trimEnd-char-}
+```
+public final RichText trimEnd(char trimChar)
+```
+
+
+文字の末尾のすべての出現を削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| trimChar | char | トリム文字。 |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trimEnd(char[] trimChars) {#trimEnd-char...-}
+```
+public final RichText trimEnd(char[] trimChars)
+```
+
+
+配列で指定された文字セットの末尾のすべての出現を削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| trimChars | char[] | トリム文字です。 |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trimStart() {#trimStart--}
+```
+public final RichText trimStart()
+```
+
+
+先頭のすべての空白文字を削除します。
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trimStart(char trimChar) {#trimStart-char-}
+```
+public final RichText trimStart(char trimChar)
+```
+
+
+指定された文字の先頭のすべての出現を削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| trimChar | char | トリム文字。 |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trimStart(char[] trimChars) {#trimStart-char...-}
+```
+public final RichText trimStart(char[] trimChars)
+```
+
+
+配列で指定された文字セットの先頭のすべての出現を削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| trimChars | char[] | トリム文字です。 |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).

--- a/japanese/java/com.aspose.note/saveformat/_index.md
+++ b/japanese/java/com.aspose.note/saveformat/_index.md
@@ -1,0 +1,92 @@
+---
+title: "SaveFormat"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ドキュメントが保存される形式を示します。"
+type: docs
+weight: 83
+url: /ja/java/com.aspose.note/saveformat/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class SaveFormat extends System.Enum
+```
+
+ドキュメントが保存される形式を示します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Bmp](#Bmp) | 出力が BMP ファイルであることを指定します。 |
+| [Gif](#Gif) | 出力が GIF ファイルであることを指定します。 |
+| [Html](#Html) | 出力が HTML ファイルであることを指定します。 |
+| [Jpeg](#Jpeg) | 出力が JPEG ファイルであることを指定します。 |
+| [One](#One) | 出力が OneNote ファイルであることを指定します。 |
+| [Pdf](#Pdf) | 出力が PDF ファイルであることを指定します。 |
+| [Png](#Png) | 出力が PNG ファイルであることを指定します。 |
+| [Tiff](#Tiff) | 出力が TIFF ファイルであることを指定します。 |
+### Bmp {#Bmp}
+```
+public static final int Bmp
+```
+
+
+出力が BMP ファイルであることを指定します。
+
+### Gif {#Gif}
+```
+public static final int Gif
+```
+
+
+出力が GIF ファイルであることを指定します。
+
+### Html {#Html}
+```
+public static final int Html
+```
+
+
+出力が HTML ファイルであることを指定します。
+
+### Jpeg {#Jpeg}
+```
+public static final int Jpeg
+```
+
+
+出力が JPEG ファイルであることを指定します。
+
+### One {#One}
+```
+public static final int One
+```
+
+
+出力が OneNote ファイルであることを指定します。
+
+### Pdf {#Pdf}
+```
+public static final int Pdf
+```
+
+
+出力が PDF ファイルであることを指定します。
+
+### Png {#Png}
+```
+public static final int Png
+```
+
+
+出力が PNG ファイルであることを指定します。
+
+### Tiff {#Tiff}
+```
+public static final int Tiff
+```
+
+
+出力が TIFF ファイルであることを指定します。
+

--- a/japanese/java/com.aspose.note/saveformatconverter/_index.md
+++ b/japanese/java/com.aspose.note/saveformatconverter/_index.md
@@ -1,0 +1,79 @@
+---
+title: "SaveFormatConverter"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "保存形式コンバータです。"
+type: docs
+weight: 84
+url: /ja/java/com.aspose.note/saveformatconverter/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SaveFormatConverter
+```
+
+保存形式コンバータです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [SaveFormatConverter()](#SaveFormatConverter--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [convert(String value)](#convert-java.lang.String-) | 変換です。 |
+| [deduceDocumentFileExtension(int format)](#deduceDocumentFileExtension-int-) |  |
+| [deduceNotebookFileExtension(int format)](#deduceNotebookFileExtension-int-) |  |
+### SaveFormatConverter() {#SaveFormatConverter--}
+```
+public SaveFormatConverter()
+```
+
+
+### convert(String value) {#convert-java.lang.String-}
+```
+public static int convert(String value)
+```
+
+
+変換です。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | 値です。 |
+
+**Returns:**
+int - `SaveFormat`。
+### deduceDocumentFileExtension(int format) {#deduceDocumentFileExtension-int-}
+```
+public static String deduceDocumentFileExtension(int format)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| format | int |  |
+
+**Returns:**
+java.lang.String
+### deduceNotebookFileExtension(int format) {#deduceNotebookFileExtension-int-}
+```
+public static String deduceNotebookFileExtension(int format)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| format | int |  |
+
+**Returns:**
+java.lang.String

--- a/japanese/java/com.aspose.note/saveoptions/_index.md
+++ b/japanese/java/com.aspose.note/saveoptions/_index.md
@@ -1,0 +1,106 @@
+---
+title: "SaveOptions"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "特定の形式に対するドキュメント保存オプションを表す抽象基底クラスです。"
+type: docs
+weight: 85
+url: /ja/java/com.aspose.note/saveoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class SaveOptions
+```
+
+特定の形式に対するドキュメント保存オプションを表す抽象基底クラスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getFontsSubsystem()](#getFontsSubsystem--) | 保存時に使用されるフォント設定を取得または設定します |
+| [getPageCount()](#getPageCount--) | 保存するページ数を取得または設定します。 |
+| [getPageIndex()](#getPageIndex--) | 保存する最初のページのインデックスを取得または設定します。 |
+| [getSaveFormat()](#getSaveFormat--) | ドキュメントが保存される形式を取得または設定します。 |
+| [setFontsSubsystem(FontsSubsystem value)](#setFontsSubsystem-com.aspose.note.fonts.FontsSubsystem-) | 保存時に使用されるフォント設定を取得または設定します |
+| [setPageCount(int value)](#setPageCount-int-) | 保存するページ数を取得または設定します。 |
+| [setPageIndex(int value)](#setPageIndex-int-) | 保存する最初のページのインデックスを取得または設定します。 |
+### getFontsSubsystem() {#getFontsSubsystem--}
+```
+public final FontsSubsystem getFontsSubsystem()
+```
+
+
+保存時に使用されるフォント設定を取得または設定します
+
+**Returns:**
+[FontsSubsystem](../../com.aspose.note.fonts/fontssubsystem)
+### getPageCount() {#getPageCount--}
+```
+public final int getPageCount()
+```
+
+
+保存するページ数を取得または設定します。デフォルトは \{@link int\#Int32Extensions.MaxValue\} で、これはドキュメントのすべてのページがレンダリングされることを意味します。
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public final int getPageIndex()
+```
+
+
+保存する最初のページのインデックスを取得または設定します。デフォルトは 0 です。
+
+**Returns:**
+int
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+ドキュメントが保存される形式を取得または設定します。
+
+**Returns:**
+int
+### setFontsSubsystem(FontsSubsystem value) {#setFontsSubsystem-com.aspose.note.fonts.FontsSubsystem-}
+```
+public final void setFontsSubsystem(FontsSubsystem value)
+```
+
+
+保存時に使用されるフォント設定を取得または設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [FontsSubsystem](../../com.aspose.note.fonts/fontssubsystem) |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public final void setPageCount(int value)
+```
+
+
+保存するページ数を取得または設定します。デフォルトは \{@link int\#Int32Extensions.MaxValue\} で、これはドキュメントのすべてのページがレンダリングされることを意味します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public final void setPageIndex(int value)
+```
+
+
+保存する最初のページのインデックスを取得または設定します。デフォルトは 0 です。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+

--- a/japanese/java/com.aspose.note/style/_index.md
+++ b/japanese/java/com.aspose.note/style/_index.md
@@ -1,0 +1,325 @@
+---
+title: "スタイル"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "このクラスは  と  クラスの共通プロパティを含みます。"
+type: docs
+weight: 86
+url: /ja/java/com.aspose.note/style/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Style<T>
+```
+
+このクラスは [ParagraphStyle](../../com.aspose.note/paragraphstyle) と [TextStyle](../../com.aspose.note/textstyle) クラスの共通プロパティを含みます。
+
+T :
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Style()](#Style--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getFontColor()](#getFontColor--) | フォントの色を取得または設定します。 |
+| [getFontName()](#getFontName--) | フォント名を取得または設定します。 |
+| [getFontSize()](#getFontSize--) | フォントサイズを取得または設定します。 |
+| [getFontStyle()](#getFontStyle--) | フォントスタイルを取得します。 |
+| [getHighlight()](#getHighlight--) | ハイライト色を取得または設定します。 |
+| [hashCode()](#hashCode--) | 型のハッシュ関数として機能します。 |
+| [isBold()](#isBold--) | テキストスタイルが太字かどうかを示す値を取得または設定します。 |
+| [isItalic()](#isItalic--) | テキストスタイルが斜体かどうかを示す値を取得または設定します。 |
+| [isStrikethrough()](#isStrikethrough--) | テキストスタイルが取り消し線かどうかを示す値を取得または設定します。 |
+| [isSubscript()](#isSubscript--) | テキストスタイルが下付き文字かどうかを示す値を取得または設定します。 |
+| [isSuperscript()](#isSuperscript--) | テキストスタイルが上付き文字かどうかを示す値を取得または設定します。 |
+| [isUnderline()](#isUnderline--) | テキストスタイルが下線かどうかを示す値を取得または設定します。 |
+| [setBold(boolean value)](#setBold-boolean-) | テキストスタイルが太字かどうかを示す値を取得または設定します。 |
+| [setFontColor(Color value)](#setFontColor-java.awt.Color-) | フォントの色を取得または設定します。 |
+| [setFontName(String value)](#setFontName-java.lang.String-) | フォント名を取得または設定します。 |
+| [setFontSize(Integer value)](#setFontSize-java.lang.Integer-) | フォントサイズを取得または設定します。 |
+| [setHighlight(Color value)](#setHighlight-java.awt.Color-) | ハイライト色を取得または設定します。 |
+| [setItalic(boolean value)](#setItalic-boolean-) | テキストスタイルが斜体かどうかを示す値を取得または設定します。 |
+| [setStrikethrough(boolean value)](#setStrikethrough-boolean-) | テキストスタイルが取り消し線かどうかを示す値を取得または設定します。 |
+| [setSubscript(boolean value)](#setSubscript-boolean-) | テキストスタイルが下付き文字かどうかを示す値を取得または設定します。 |
+| [setSuperscript(boolean value)](#setSuperscript-boolean-) | テキストスタイルが上付き文字かどうかを示す値を取得または設定します。 |
+| [setUnderline(boolean value)](#setUnderline-boolean-) | テキストスタイルが下線かどうかを示す値を取得または設定します。 |
+### Style() {#Style--}
+```
+public Style()
+```
+
+
+### getFontColor() {#getFontColor--}
+```
+public final Color getFontColor()
+```
+
+
+フォントの色を取得または設定します。
+
+**Returns:**
+java.awt.Color
+### getFontName() {#getFontName--}
+```
+public final String getFontName()
+```
+
+
+フォント名を取得または設定します。
+
+**Returns:**
+java.lang.String
+### getFontSize() {#getFontSize--}
+```
+public final Integer getFontSize()
+```
+
+
+フォントサイズを取得または設定します。
+
+**Returns:**
+java.lang.Integer
+### getFontStyle() {#getFontStyle--}
+```
+public final int getFontStyle()
+```
+
+
+フォントスタイルを取得します。
+
+**Returns:**
+int
+### getHighlight() {#getHighlight--}
+```
+public final Color getHighlight()
+```
+
+
+ハイライト色を取得または設定します。
+
+**Returns:**
+java.awt.Color
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+型のハッシュ関数として機能します。
+
+**Returns:**
+int - `int`です。
+### isBold() {#isBold--}
+```
+public final boolean isBold()
+```
+
+
+テキストスタイルが太字かどうかを示す値を取得または設定します。
+
+**Returns:**
+boolean
+### isItalic() {#isItalic--}
+```
+public final boolean isItalic()
+```
+
+
+テキストスタイルが斜体かどうかを示す値を取得または設定します。
+
+**Returns:**
+boolean
+### isStrikethrough() {#isStrikethrough--}
+```
+public final boolean isStrikethrough()
+```
+
+
+テキストスタイルが取り消し線かどうかを示す値を取得または設定します。
+
+**Returns:**
+boolean
+### isSubscript() {#isSubscript--}
+```
+public final boolean isSubscript()
+```
+
+
+テキストスタイルが下付き文字かどうかを示す値を取得または設定します。
+
+**Returns:**
+boolean
+### isSuperscript() {#isSuperscript--}
+```
+public final boolean isSuperscript()
+```
+
+
+テキストスタイルが上付き文字かどうかを示す値を取得または設定します。
+
+**Returns:**
+boolean
+### isUnderline() {#isUnderline--}
+```
+public final boolean isUnderline()
+```
+
+
+テキストスタイルが下線かどうかを示す値を取得または設定します。
+
+**Returns:**
+boolean
+### setBold(boolean value) {#setBold-boolean-}
+```
+public final T setBold(boolean value)
+```
+
+
+テキストスタイルが太字かどうかを示す値を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+**Returns:**
+T
+### setFontColor(Color value) {#setFontColor-java.awt.Color-}
+```
+public final T setFontColor(Color value)
+```
+
+
+フォントの色を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.awt.Color |  |
+
+**Returns:**
+T
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public final T setFontName(String value)
+```
+
+
+フォント名を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+**Returns:**
+T
+### setFontSize(Integer value) {#setFontSize-java.lang.Integer-}
+```
+public final T setFontSize(Integer value)
+```
+
+
+フォントサイズを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Integer |  |
+
+**Returns:**
+T
+### setHighlight(Color value) {#setHighlight-java.awt.Color-}
+```
+public final T setHighlight(Color value)
+```
+
+
+ハイライト色を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.awt.Color |  |
+
+**Returns:**
+T
+### setItalic(boolean value) {#setItalic-boolean-}
+```
+public final T setItalic(boolean value)
+```
+
+
+テキストスタイルが斜体かどうかを示す値を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+**Returns:**
+T
+### setStrikethrough(boolean value) {#setStrikethrough-boolean-}
+```
+public final T setStrikethrough(boolean value)
+```
+
+
+テキストスタイルが取り消し線かどうかを示す値を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+**Returns:**
+T
+### setSubscript(boolean value) {#setSubscript-boolean-}
+```
+public final T setSubscript(boolean value)
+```
+
+
+テキストスタイルが下付き文字かどうかを示す値を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+**Returns:**
+T
+### setSuperscript(boolean value) {#setSuperscript-boolean-}
+```
+public final T setSuperscript(boolean value)
+```
+
+
+テキストスタイルが上付き文字かどうかを示す値を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+**Returns:**
+T
+### setUnderline(boolean value) {#setUnderline-boolean-}
+```
+public final T setUnderline(boolean value)
+```
+
+
+テキストスタイルが下線かどうかを示す値を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+**Returns:**
+T

--- a/japanese/java/com.aspose.note/table/_index.md
+++ b/japanese/java/com.aspose.note/table/_index.md
@@ -1,0 +1,122 @@
+---
+title: "Table"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "テーブルを表します。"
+type: docs
+weight: 87
+url: /ja/java/com.aspose.note/table/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode), [com.aspose.note.ITaggable](../../com.aspose.note/itaggable)
+```
+public final class Table extends CompositeNode<TableRow> implements IOutlineElementChildNode, ITaggable
+```
+
+テーブルを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Table()](#Table--) | `Table` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | ノードのビジターを受け入れます。 |
+| [getColumns()](#getColumns--) | テーブルの列を取得します。 |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 最終更新時刻を取得または設定します。 |
+| [getTags()](#getTags--) | テーブルのすべてのタグのリストを取得します。 |
+| [isBordersVisible()](#isBordersVisible--) | テーブルの境界線が表示されているかどうかを示す値を取得します。 |
+| [setBordersVisible(boolean value)](#setBordersVisible-boolean-) | テーブルの境界線が表示されているかどうかを示す値を設定します。 |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 最終更新時刻を取得または設定します。 |
+### Table() {#Table--}
+```
+public Table()
+```
+
+
+`Table` クラスの新しいインスタンスを初期化します。
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+ノードのビジターを受け入れます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor` から派生したクラスのオブジェクト。 |
+
+### getColumns() {#getColumns--}
+```
+public System.Collections.Generic.IGenericList<TableColumn> getColumns()
+```
+
+
+テーブルの列を取得します。
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericList&lt;com.aspose.note.TableColumn&gt;
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+最終更新時刻を取得または設定します。
+
+**Returns:**
+java.util.Date
+### getTags() {#getTags--}
+```
+public final System.Collections.Generic.List<ITag> getTags()
+```
+
+
+テーブルのすべてのタグのリストを取得します。
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List&lt;com.aspose.note.ITag&gt;
+### isBordersVisible() {#isBordersVisible--}
+```
+public boolean isBordersVisible()
+```
+
+
+テーブルの境界線が表示されているかどうかを示す値を取得します。
+
+**Returns:**
+boolean
+### setBordersVisible(boolean value) {#setBordersVisible-boolean-}
+```
+public void setBordersVisible(boolean value)
+```
+
+
+テーブルの境界線が表示されているかどうかを示す値を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+最終更新時刻を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Date |  |
+

--- a/japanese/java/com.aspose.note/tablecell/_index.md
+++ b/japanese/java/com.aspose.note/tablecell/_index.md
@@ -1,0 +1,119 @@
+---
+title: "TableCell"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "テーブルセルを表します。"
+type: docs
+weight: 88
+url: /ja/java/com.aspose.note/tablecell/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode, com.aspose.note.IndentatedNode
+```
+public final class TableCell extends IndentatedNode<IOutlineChildNode,TableCell>
+```
+
+テーブルセルを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [TableCell()](#TableCell--) | `TableCell` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | ノードのビジターを受け入れます。 |
+| [getBackgroundColor()](#getBackgroundColor--) | 背景色を取得します。 |
+| [getInternalIndentPosition()](#getInternalIndentPosition--) |  |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 最終更新時刻を取得または設定します。 |
+| [getMaxWidth()](#getMaxWidth--) | 最大幅を取得します。 |
+| [setBackgroundColor(Color value)](#setBackgroundColor-java.awt.Color-) | 背景色を設定します。 |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 最終更新時刻を取得または設定します。 |
+### TableCell() {#TableCell--}
+```
+public TableCell()
+```
+
+
+`TableCell` クラスの新しいインスタンスを初期化します。
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+ノードのビジターを受け入れます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor` から派生したクラスのオブジェクト。 |
+
+### getBackgroundColor() {#getBackgroundColor--}
+```
+public Color getBackgroundColor()
+```
+
+
+背景色を取得します。
+
+**Returns:**
+java.awt.Color
+### getInternalIndentPosition() {#getInternalIndentPosition--}
+```
+public int getInternalIndentPosition()
+```
+
+
+インデントサイズを取得するために RgOutlineIndentDistance 配列で合計する項目数を取得します。
+
+**Returns:**
+int
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+最終更新時刻を取得または設定します。
+
+**Returns:**
+java.util.Date
+### getMaxWidth() {#getMaxWidth--}
+```
+public float getMaxWidth()
+```
+
+
+最大幅を取得します。
+
+**Returns:**
+float
+### setBackgroundColor(Color value) {#setBackgroundColor-java.awt.Color-}
+```
+public void setBackgroundColor(Color value)
+```
+
+
+背景色を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.awt.Color |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+最終更新時刻を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Date |  |
+

--- a/japanese/java/com.aspose.note/tablecolumn/_index.md
+++ b/japanese/java/com.aspose.note/tablecolumn/_index.md
@@ -1,0 +1,81 @@
+---
+title: "TableColumn"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "テーブル列を表します。"
+type: docs
+weight: 89
+url: /ja/java/com.aspose.note/tablecolumn/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TableColumn
+```
+
+テーブル列を表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [TableColumn()](#TableColumn--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getLockedWidth()](#getLockedWidth--) | テーブル列が幅ロックされており、テーブルコンテンツに合わせて自動的にサイズ変更されないかどうかを示す値を取得します。 |
+| [getWidth()](#getWidth--) | 幅を取得します。 |
+| [setLockedWidth(boolean value)](#setLockedWidth-boolean-) | テーブル列が幅ロックされており、テーブルコンテンツに合わせて自動的にサイズ変更されないかどうかを示す値を設定します。 |
+| [setWidth(float value)](#setWidth-float-) | 幅を設定します。 |
+### TableColumn() {#TableColumn--}
+```
+public TableColumn()
+```
+
+
+### getLockedWidth() {#getLockedWidth--}
+```
+public boolean getLockedWidth()
+```
+
+
+テーブル列が幅ロックされており、テーブルコンテンツに合わせて自動的にサイズ変更されないかどうかを示す値を取得します。デフォルトでは、列の幅はロックされていません。
+
+**Returns:**
+boolean
+### getWidth() {#getWidth--}
+```
+public float getWidth()
+```
+
+
+幅を取得します。
+
+**Returns:**
+float
+### setLockedWidth(boolean value) {#setLockedWidth-boolean-}
+```
+public void setLockedWidth(boolean value)
+```
+
+
+テーブル列が幅ロックされており、テーブルコンテンツに合わせて自動的にサイズ変更されないかどうかを示す値を設定します。デフォルトでは、列の幅はロックされていません。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setWidth(float value) {#setWidth-float-}
+```
+public void setWidth(float value)
+```
+
+
+幅を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+

--- a/japanese/java/com.aspose.note/tablerow/_index.md
+++ b/japanese/java/com.aspose.note/tablerow/_index.md
@@ -1,0 +1,72 @@
+---
+title: "TableRow"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "テーブル行を表します。"
+type: docs
+weight: 90
+url: /ja/java/com.aspose.note/tablerow/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode
+```
+public final class TableRow extends CompositeNode<TableCell>
+```
+
+テーブル行を表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [TableRow()](#TableRow--) | `TableRow` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | ノードのビジターを受け入れます。 |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 最終更新時刻を取得または設定します。 |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 最終更新時刻を取得または設定します。 |
+### TableRow() {#TableRow--}
+```
+public TableRow()
+```
+
+
+`TableRow` クラスの新しいインスタンスを初期化します。
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+ノードのビジターを受け入れます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor` から派生したクラスのオブジェクト。 |
+
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+最終更新時刻を取得または設定します。
+
+**Returns:**
+java.util.Date
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+最終更新時刻を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Date |  |
+

--- a/japanese/java/com.aspose.note/tagstatus/_index.md
+++ b/japanese/java/com.aspose.note/tagstatus/_index.md
@@ -1,0 +1,47 @@
+---
+title: "TagStatus"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ノートタグノードのステータスを指定します。"
+type: docs
+weight: 91
+url: /ja/java/com.aspose.note/tagstatus/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class TagStatus extends System.Enum
+```
+
+ノートタグノードのステータスを指定します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Completed](#Completed) | ノートタグは完了しています。 |
+| [Disabled](#Disabled) | ノートタグは無効です。 |
+| [Open](#Open) | ノートタグは開いています。 |
+### Completed {#Completed}
+```
+public static final int Completed
+```
+
+
+ノートタグは完了しています。
+
+### Disabled {#Disabled}
+```
+public static final int Disabled
+```
+
+
+ノートタグは無効です。
+
+### Open {#Open}
+```
+public static final int Open
+```
+
+
+ノートタグは開いています。
+

--- a/japanese/java/com.aspose.note/textrun/_index.md
+++ b/japanese/java/com.aspose.note/textrun/_index.md
@@ -1,0 +1,137 @@
+---
+title: "TextRun"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "関連付けられたスタイルを持つテキストの一部を表すクラスです。"
+type: docs
+weight: 92
+url: /ja/java/com.aspose.note/textrun/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextRun
+```
+
+関連付けられたスタイルを持つテキストの一部を表すクラスです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [TextRun(String text, TextStyle style)](#TextRun-java.lang.String-com.aspose.note.TextStyle-) | 新しい [TextRun](../../com.aspose.note/textrun) クラスのインスタンスを初期化します。 |
+| [TextRun(String text)](#TextRun-java.lang.String-) | デフォルトスタイルで新しい [TextRun](../../com.aspose.note/textrun) クラスのインスタンスを初期化します。 |
+| [TextRun(TextStyle style)](#TextRun-com.aspose.note.TextStyle-) | 空のテキストで新しい [TextRun](../../com.aspose.note/textrun) クラスのインスタンスを初期化します。 |
+| [TextRun()](#TextRun--) | 空のテキストとデフォルトスタイルで新しい [TextRun](../../com.aspose.note/textrun) クラスのインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [getLength()](#getLength--) | 関連するテキストの長さを取得します。 |
+| [getStyle()](#getStyle--) | スタイルを取得します。 |
+| [getText()](#getText--) | テキストを取得します。 |
+| [setStyle(TextStyle value)](#setStyle-com.aspose.note.TextStyle-) | スタイルを設定します。 |
+| [setText(String value)](#setText-java.lang.String-) | テキストを設定します。 |
+### TextRun(String text, TextStyle style) {#TextRun-java.lang.String-com.aspose.note.TextStyle-}
+```
+public TextRun(String text, TextStyle style)
+```
+
+
+新しい [TextRun](../../com.aspose.note/textrun) クラスのインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| テキスト | java.lang.String | 関連するテキストです。 |
+| style | [TextStyle](../../com.aspose.note/textstyle) | スタイル。 |
+
+### TextRun(String text) {#TextRun-java.lang.String-}
+```
+public TextRun(String text)
+```
+
+
+デフォルトスタイルで新しい [TextRun](../../com.aspose.note/textrun) クラスのインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| テキスト | java.lang.String | 関連するテキストです。 |
+
+### TextRun(TextStyle style) {#TextRun-com.aspose.note.TextStyle-}
+```
+public TextRun(TextStyle style)
+```
+
+
+空のテキストで新しい [TextRun](../../com.aspose.note/textrun) クラスのインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| style | [TextStyle](../../com.aspose.note/textstyle) | スタイル。 |
+
+### TextRun() {#TextRun--}
+```
+public TextRun()
+```
+
+
+空のテキストとデフォルトスタイルで新しい [TextRun](../../com.aspose.note/textrun) クラスのインスタンスを初期化します。
+
+### getLength() {#getLength--}
+```
+public final int getLength()
+```
+
+
+関連するテキストの長さを取得します。
+
+**Returns:**
+int
+### getStyle() {#getStyle--}
+```
+public final TextStyle getStyle()
+```
+
+
+スタイルを取得します。
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### getText() {#getText--}
+```
+public final String getText()
+```
+
+
+テキストを取得します。
+
+**Returns:**
+java.lang.String
+### setStyle(TextStyle value) {#setStyle-com.aspose.note.TextStyle-}
+```
+public final void setStyle(TextStyle value)
+```
+
+
+スタイルを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [TextStyle](../../com.aspose.note/textstyle) |  |
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public final void setText(String value)
+```
+
+
+テキストを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+

--- a/japanese/java/com.aspose.note/textstyle/_index.md
+++ b/japanese/java/com.aspose.note/textstyle/_index.md
@@ -1,0 +1,255 @@
+---
+title: "TextStyle"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "テキストのスタイルを指定します。"
+type: docs
+weight: 93
+url: /ja/java/com.aspose.note/textstyle/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.note.Style
+```
+public final class TextStyle extends Style<TextStyle>
+```
+
+テキストのスタイルを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [TextStyle()](#TextStyle--) | 新しい `TextStyle` クラスのインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(TextStyle other)](#equals-com.aspose.note.TextStyle-) | 指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。 |
+| [equals(Object obj)](#equals-java.lang.Object-) | 指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。 |
+| [getDefault()](#getDefault--) | 「en-US」カルチャーのスタイルを取得します。 |
+| [getDefaultMsOneNoteTitleDateStyle()](#getDefaultMsOneNoteTitleDateStyle--) | MS OneNote のタイトル日付のデフォルトスタイルを取得します。 |
+| [getDefaultMsOneNoteTitleTextStyle()](#getDefaultMsOneNoteTitleTextStyle--) | MS OneNote のタイトルテキストのデフォルトスタイルを取得します。 |
+| [getDefaultMsOneNoteTitleTimeStyle()](#getDefaultMsOneNoteTitleTimeStyle--) | MS OneNote のタイトル時間のデフォルトスタイルを取得します。 |
+| [getHyperlinkAddress()](#getHyperlinkAddress--) | ハイパーリンクのアドレスを取得します。 |
+| [getLanguage()](#getLanguage--) | テキストの言語を取得します。 |
+| [hashCode()](#hashCode--) | 型のハッシュ関数として機能します。 |
+| [isHidden()](#isHidden--) | テキストスタイルが非表示かどうかを示す値を取得します。 |
+| [isHyperlink()](#isHyperlink--) | テキストスタイルがハイパーリンクかどうかを示す値を取得します。 |
+| [isMathFormatting()](#isMathFormatting--) | テキストスタイルが数式フォーマットかどうかを示す値を取得または設定します。 |
+| [setHidden(boolean value)](#setHidden-boolean-) | テキストスタイルが非表示かどうかを示す値を設定します。 |
+| [setHyperlink(boolean value)](#setHyperlink-boolean-) | テキストスタイルがハイパーリンクかどうかを示す値を設定します。 |
+| [setHyperlinkAddress(String value)](#setHyperlinkAddress-java.lang.String-) | ハイパーリンクのアドレスを設定します。 |
+| [setLanguage(Locale value)](#setLanguage-java.util.Locale-) | テキストの言語を設定します。 |
+| [setMathFormatting(boolean value)](#setMathFormatting-boolean-) | テキストスタイルが数式形式かどうかを示す値を設定します。 |
+### TextStyle() {#TextStyle--}
+```
+public TextStyle()
+```
+
+
+新しい `TextStyle` クラスのインスタンスを初期化します。
+
+### equals(TextStyle other) {#equals-com.aspose.note.TextStyle-}
+```
+public boolean equals(TextStyle other)
+```
+
+
+指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| other | [TextStyle](../../com.aspose.note/textstyle) | オブジェクトです。 |
+
+**Returns:**
+boolean - `bool`です。
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+指定されたオブジェクトが現在のオブジェクトと等しいかどうかを判断します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| obj | java.lang.Object | オブジェクトです。 |
+
+**Returns:**
+boolean - `bool`です。
+### getDefault() {#getDefault--}
+```
+public static TextStyle getDefault()
+```
+
+
+「en-US」カルチャーのスタイルを取得します。
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### getDefaultMsOneNoteTitleDateStyle() {#getDefaultMsOneNoteTitleDateStyle--}
+```
+public static TextStyle getDefaultMsOneNoteTitleDateStyle()
+```
+
+
+MS OneNote のタイトル日付のデフォルトスタイルを取得します。
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### getDefaultMsOneNoteTitleTextStyle() {#getDefaultMsOneNoteTitleTextStyle--}
+```
+public static TextStyle getDefaultMsOneNoteTitleTextStyle()
+```
+
+
+MS OneNote のタイトルテキストのデフォルトスタイルを取得します。
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### getDefaultMsOneNoteTitleTimeStyle() {#getDefaultMsOneNoteTitleTimeStyle--}
+```
+public static TextStyle getDefaultMsOneNoteTitleTimeStyle()
+```
+
+
+MS OneNote のタイトル時間のデフォルトスタイルを取得します。
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### getHyperlinkAddress() {#getHyperlinkAddress--}
+```
+public String getHyperlinkAddress()
+```
+
+
+ハイパーリンクのアドレスを取得します。プロパティ [isHyperlink](../../com.aspose.note/textstyle\#isHyperlink--) の値が true の場合、設定する必要があります。
+
+**Returns:**
+java.lang.String
+### getLanguage() {#getLanguage--}
+```
+public Locale getLanguage()
+```
+
+
+テキストの言語を取得します。
+
+**Returns:**
+java.util.Locale
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+型のハッシュ関数として機能します。
+
+**Returns:**
+int - `int`です。
+### isHidden() {#isHidden--}
+```
+public boolean isHidden()
+```
+
+
+テキストスタイルが非表示かどうかを示す値を取得します。
+
+**Returns:**
+boolean
+### isHyperlink() {#isHyperlink--}
+```
+public boolean isHyperlink()
+```
+
+
+テキストスタイルがハイパーリンクかどうかを示す値を取得します。
+
+**Returns:**
+boolean
+### isMathFormatting() {#isMathFormatting--}
+```
+public boolean isMathFormatting()
+```
+
+
+テキストスタイルが数式フォーマットかどうかを示す値を取得または設定します。
+
+**Returns:**
+boolean
+### setHidden(boolean value) {#setHidden-boolean-}
+```
+public TextStyle setHidden(boolean value)
+```
+
+
+テキストスタイルが非表示かどうかを示す値を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### setHyperlink(boolean value) {#setHyperlink-boolean-}
+```
+public TextStyle setHyperlink(boolean value)
+```
+
+
+テキストスタイルがハイパーリンクかどうかを示す値を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### setHyperlinkAddress(String value) {#setHyperlinkAddress-java.lang.String-}
+```
+public TextStyle setHyperlinkAddress(String value)
+```
+
+
+ハイパーリンクのアドレスを設定します。プロパティ [isHyperlink](../../com.aspose.note/textstyle\#isHyperlink--) の値が true の場合、設定する必要があります。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### setLanguage(Locale value) {#setLanguage-java.util.Locale-}
+```
+public TextStyle setLanguage(Locale value)
+```
+
+
+テキストの言語を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Locale |  |
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### setMathFormatting(boolean value) {#setMathFormatting-boolean-}
+```
+public TextStyle setMathFormatting(boolean value)
+```
+
+
+テキストスタイルが数式形式かどうかを示す値を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)

--- a/japanese/java/com.aspose.note/tiffcompression/_index.md
+++ b/japanese/java/com.aspose.note/tiffcompression/_index.md
@@ -1,0 +1,83 @@
+---
+title: "TiffCompression"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "ドキュメントを TIFF 形式で保存する際に使用する圧縮タイプを指定します。"
+type: docs
+weight: 94
+url: /ja/java/com.aspose.note/tiffcompression/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class TiffCompression extends System.Enum
+```
+
+ドキュメントを TIFF 形式で保存する際に使用する圧縮タイプを指定します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Ccitt3](#Ccitt3) | CCITT Group 3 ファックスエンコーディングを指定します。 |
+| [Ccitt4](#Ccitt4) | CCITT Group 4 ファックスエンコーディングを指定します。 |
+| [Jpeg](#Jpeg) | JPEG DCT 圧縮を指定します。 |
+| [Lzw](#Lzw) | LZW 圧縮を指定します。 |
+| [None](#None) | 圧縮なしを指定します。 |
+| [PackBits](#PackBits) | Macintosh RLE 圧縮を指定します。 |
+| [Rle](#Rle) | RLE 圧縮を指定します。 |
+### Ccitt3 {#Ccitt3}
+```
+public static final int Ccitt3
+```
+
+
+CCITT Group 3 ファックスエンコーディングを指定します。
+
+### Ccitt4 {#Ccitt4}
+```
+public static final int Ccitt4
+```
+
+
+CCITT Group 4 ファックスエンコーディングを指定します。
+
+### Jpeg {#Jpeg}
+```
+public static final int Jpeg
+```
+
+
+JPEG DCT 圧縮を指定します。
+
+### Lzw {#Lzw}
+```
+public static final int Lzw
+```
+
+
+LZW 圧縮を指定します。
+
+### None {#None}
+```
+public static final int None
+```
+
+
+圧縮なしを指定します。
+
+### PackBits {#PackBits}
+```
+public static final int PackBits
+```
+
+
+Macintosh RLE 圧縮を指定します。
+
+### Rle {#Rle}
+```
+public static final int Rle
+```
+
+
+RLE 圧縮を指定します。
+

--- a/japanese/java/com.aspose.note/title/_index.md
+++ b/japanese/java/com.aspose.note/title/_index.md
@@ -1,0 +1,256 @@
+---
+title: "Title"
+second_title: "Aspose.Note for Java API リファレンス"
+description: "タイトルを表します。"
+type: docs
+weight: 95
+url: /ja/java/com.aspose.note/title/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase)
+
+**All Implemented Interfaces:**
+com.aspose.note.ICompositeNodeT, [com.aspose.note.IPageChildNode](../../com.aspose.note/ipagechildnode)
+```
+public final class Title extends CompositeNodeBase implements ICompositeNodeT<RichText>, IPageChildNode
+```
+
+タイトルを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Title()](#Title--) | `Title` クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [&lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass)](#-T1-getChildNodes-java.lang.Class-T1--) | ノードのタイプで子ノードをすべて取得します。 |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | ノードのビジターを受け入れます。 |
+| [getChildNodes(int type)](#getChildNodes-int-) |  |
+| [getHorizontalOffset()](#getHorizontalOffset--) | 水平オフセットを取得または設定します。 |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 最終更新時刻を取得または設定します。 |
+| [getTitleDate()](#getTitleDate--) | タイトルの日付の文字列表現を取得または設定します。 |
+| [getTitleText()](#getTitleText--) | タイトルのテキストを取得または設定します。 |
+| [getTitleTime()](#getTitleTime--) | タイトルの時刻の文字列表現を取得または設定します。 |
+| [getVerticalOffset()](#getVerticalOffset--) | 垂直オフセットを取得または設定します。 |
+| [isComposite()](#isComposite--) | このノードが複合ノードかどうかを示す値を取得します。 |
+| [iterator()](#iterator--) | [Title](../../com.aspose.note/title) の子ノードを反復処理する列挙子を返します。 |
+| [setHorizontalOffset(float value)](#setHorizontalOffset-float-) | 水平オフセットを取得または設定します。 |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 最終更新時刻を取得または設定します。 |
+| [setTitleDate(RichText value)](#setTitleDate-com.aspose.note.RichText-) | タイトルの日付の文字列表現を取得または設定します。 |
+| [setTitleText(RichText value)](#setTitleText-com.aspose.note.RichText-) | タイトルのテキストを取得または設定します。 |
+| [setTitleTime(RichText value)](#setTitleTime-com.aspose.note.RichText-) | タイトルの時刻の文字列表現を取得または設定します。 |
+| [setVerticalOffset(float value)](#setVerticalOffset-float-) | 垂直オフセットを取得または設定します。 |
+### Title() {#Title--}
+```
+public Title()
+```
+
+
+`Title` クラスの新しいインスタンスを初期化します。
+
+### &lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass) {#-T1-getChildNodes-java.lang.Class-T1--}
+```
+public List<T1> <T1>getChildNodes(Class<T1> typeParameterClass)
+```
+
+
+ノードのタイプで子ノードをすべて取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| typeParameterClass | java.lang.Class&lt;T1&gt; |  |
+
+**Returns:**
+java.util.List&lt;T1&gt; - 子ノードのリスト。
+
+`T1`: 返されたリスト内の要素の型です。
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+ノードのビジターを受け入れます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor` から派生したクラスのオブジェクト。 |
+
+### getChildNodes(int type) {#getChildNodes-int-}
+```
+public List<INode> getChildNodes(int type)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| タイプ | int |  |
+
+**Returns:**
+java.util.List&lt;com.aspose.note.INode&gt;
+### getHorizontalOffset() {#getHorizontalOffset--}
+```
+public final float getHorizontalOffset()
+```
+
+
+水平オフセットを取得または設定します。
+
+**Returns:**
+float
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+最終更新時刻を取得または設定します。
+
+**Returns:**
+java.util.Date
+### getTitleDate() {#getTitleDate--}
+```
+public final RichText getTitleDate()
+```
+
+
+タイトルの日付の文字列表現を取得または設定します。
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext)
+### getTitleText() {#getTitleText--}
+```
+public RichText getTitleText()
+```
+
+
+タイトルのテキストを取得または設定します。
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext)
+### getTitleTime() {#getTitleTime--}
+```
+public final RichText getTitleTime()
+```
+
+
+タイトルの時刻の文字列表現を取得または設定します。
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext)
+### getVerticalOffset() {#getVerticalOffset--}
+```
+public final float getVerticalOffset()
+```
+
+
+垂直オフセットを取得または設定します。
+
+**Returns:**
+float
+### isComposite() {#isComposite--}
+```
+public boolean isComposite()
+```
+
+
+このノードが複合ノードかどうかを示す値を取得します。true の場合、ノードは子ノードを持つことができます。
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public final System.Collections.Generic.IGenericEnumerator<RichText> iterator()
+```
+
+
+[Title](../../com.aspose.note/title) の子ノードを反復処理する列挙子を返します。
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;com.aspose.note.RichText&gt; - IEnumerator。
+### setHorizontalOffset(float value) {#setHorizontalOffset-float-}
+```
+public final void setHorizontalOffset(float value)
+```
+
+
+水平オフセットを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+最終更新時刻を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Date |  |
+
+### setTitleDate(RichText value) {#setTitleDate-com.aspose.note.RichText-}
+```
+public final void setTitleDate(RichText value)
+```
+
+
+タイトルの日付の文字列表現を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [RichText](../../com.aspose.note/richtext) |  |
+
+### setTitleText(RichText value) {#setTitleText-com.aspose.note.RichText-}
+```
+public final void setTitleText(RichText value)
+```
+
+
+タイトルのテキストを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [RichText](../../com.aspose.note/richtext) |  |
+
+### setTitleTime(RichText value) {#setTitleTime-com.aspose.note.RichText-}
+```
+public final void setTitleTime(RichText value)
+```
+
+
+タイトルの時刻の文字列表現を取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [RichText](../../com.aspose.note/richtext) |  |
+
+### setVerticalOffset(float value) {#setVerticalOffset-float-}
+```
+public final void setVerticalOffset(float value)
+```
+
+
+垂直オフセットを取得または設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+


### PR DESCRIPTION
Automated translation of the JAVA API Reference to **Japanese** (`ja`) generated by RDA.

- Pages translated: 107/107
- Errors: 0
- Source: `english/java`
- Output: `japanese/java`

🤖 Generated by RDA