### PR TITLE
[auto] Translate JAVA API Reference to Korean

### DIFF
--- a/korean/java/_index.md
+++ b/korean/java/_index.md
@@ -1,0 +1,14 @@
+---
+title: "Java용 Aspose.Note"
+type: docs
+weight: 11
+url: /ko/java/
+description: "Java용 Aspose.Note API 레퍼런스에는 예제, 코드 스니펫 및 API 문서가 포함되어 있습니다. 패키지, 클래스, 인터페이스 및 기타 API 세부 정보를 제공합니다."
+is_root: true
+---
+
+## Packages
+| 패키지 | 설명 |
+| --- | --- |
+| [com.aspose.note](./com.aspose.note) | ``` com.aspose.note ``` 네임스페이스는 문서 구조를 나타내는 클래스를 포함합니다. |
+| [com.aspose.note.fonts](./com.aspose.note.fonts) | ``` com.aspose.note.fonts ``` 네임스페이스는 문서의 글꼴 환경을 조작하는 기능을 제공하는 클래스를 포함합니다. |

--- a/korean/java/com.aspose.note.fonts/_index.md
+++ b/korean/java/com.aspose.note.fonts/_index.md
@@ -1,0 +1,25 @@
+---
+title: "com.aspose.note.fonts"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "com.aspose.note.fonts 네임스페이스는 문서의 글꼴 환경을 조작하는 기능을 제공하는 클래스를 포함합니다."
+type: docs
+weight: 27
+url: /ko/java/com.aspose.note.fonts/
+---
+
+
+`com.aspose.note.fonts` 네임스페이스는 문서의 글꼴 환경을 조작하는 기능을 제공하는 클래스를 포함합니다.
+
+
+## 클래스
+
+| 클래스 | 설명 |
+| --- | --- |
+| [DocumentFontsSubsystem](../com.aspose.note.fonts/documentfontssubsystem) | Aspose.Note.Fonts.FontsSubsystem의 간단한 구현. |
+| [FontsSubsystem](../com.aspose.note.fonts/fontssubsystem) | com.aspose.note.IFontsSubsystem 인터페이스를 구현하는 기본 클래스. |
+
+## 인터페이스
+
+| 인터페이스 | 설명 |
+| --- | --- |
+| [IFontsSubsystem](../com.aspose.note.fonts/ifontssubsystem) | 문서를 저장할 때 Aspose.Note가 글꼴을 검색하는 방식을 제어하려면 이 인터페이스를 구현하십시오. |

--- a/korean/java/com.aspose.note.fonts/documentfontssubsystem/_index.md
+++ b/korean/java/com.aspose.note.fonts/documentfontssubsystem/_index.md
@@ -1,0 +1,229 @@
+---
+title: "DocumentFontsSubsystem"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "Aspose.Note.Fonts.FontsSubsystem의 간단한 구현."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.note.fonts/documentfontssubsystem/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.fonts.FontsSubsystem](../../com.aspose.note.fonts/fontssubsystem)
+```
+public class DocumentFontsSubsystem extends FontsSubsystem
+```
+
+Aspose.Note.Fonts.FontsSubsystem의 간단한 구현입니다. OS에서 FontFamily 객체를 검색합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentFontsSubsystem(InputStream defaultFontStream, Map&lt;String,String&gt; fontsSubstitutions)](#DocumentFontsSubsystem-java.io.InputStream-java.util.Map-java.lang.String-java.lang.String--) | [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) 클래스의 새 인스턴스를 초기화합니다. |
+| [DocumentFontsSubsystem(InputStream defaultFontStream)](#DocumentFontsSubsystem-java.io.InputStream-) | [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) 클래스의 새 인스턴스를 초기화합니다. |
+| [DocumentFontsSubsystem(String defaultFontFile, Map&lt;String,String&gt; fontsSubstitutions)](#DocumentFontsSubsystem-java.lang.String-java.util.Map-java.lang.String-java.lang.String--) | [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) 클래스의 새 인스턴스를 초기화합니다. |
+| [DocumentFontsSubsystem(String defaultFontFile)](#DocumentFontsSubsystem-java.lang.String-) | [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) 클래스의 새 인스턴스를 초기화합니다. |
+| [DocumentFontsSubsystem(Map&lt;String,String&gt; fontsSubstitutions)](#DocumentFontsSubsystem-java.util.Map-java.lang.String-java.lang.String--) | [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) 클래스의 새 인스턴스를 초기화합니다. |
+| [DocumentFontsSubsystem()](#DocumentFontsSubsystem--) | [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getDefault()](#getDefault--) | 정적 기본 인스턴스를 가져오거나 설정합니다. |
+| [setDefault(DocumentFontsSubsystem value)](#setDefault-com.aspose.note.fonts.DocumentFontsSubsystem-) | 정적 기본 인스턴스를 가져오거나 설정합니다. |
+| [usingDefaultFont(String defaultFontName)](#usingDefaultFont-java.lang.String-) | 지정된 기본 글꼴 이름을 사용하여 새 DocumentFontsSubsystem 인스턴스를 생성합니다. |
+| [usingDefaultFont(String defaultFontName, Map&lt;String,String&gt; fontsSubstitutions)](#usingDefaultFont-java.lang.String-java.util.Map-java.lang.String-java.lang.String--) | 지정된 기본 글꼴 이름을 사용하여 새 DocumentFontsSubsystem 인스턴스를 생성합니다. |
+| [usingDefaultFontFromFile(String filePath)](#usingDefaultFontFromFile-java.lang.String-) | 지정된 기본 글꼴 이름을 사용하여 새 DocumentFontsSubsystem 인스턴스를 생성합니다. |
+| [usingDefaultFontFromFile(String filePath, Map&lt;String,String&gt; fontsSubstitutions)](#usingDefaultFontFromFile-java.lang.String-java.util.Map-java.lang.String-java.lang.String--) | 지정된 파일에서 글꼴을 기본값으로 사용하여 새 DocumentFontsSubsystem 인스턴스를 생성합니다. |
+| [usingDefaultFontFromStream(InputStream defaultFontStream)](#usingDefaultFontFromStream-java.io.InputStream-) | 지정된 스트림에서 글꼴을 기본값으로 사용하여 새 DocumentFontsSubsystem 인스턴스를 생성합니다. |
+| [usingDefaultFontFromStream(InputStream defaultFontStream, Map&lt;String,String&gt; fontsSubstitutions)](#usingDefaultFontFromStream-java.io.InputStream-java.util.Map-java.lang.String-java.lang.String--) | 지정된 스트림에서 글꼴을 기본값으로 사용하여 새 DocumentFontsSubsystem 인스턴스를 생성합니다. |
+### DocumentFontsSubsystem(InputStream defaultFontStream, Map&lt;String,String&gt; fontsSubstitutions) {#DocumentFontsSubsystem-java.io.InputStream-java.util.Map-java.lang.String-java.lang.String--}
+```
+public DocumentFontsSubsystem(InputStream defaultFontStream, Map<String,String> fontsSubstitutions)
+```
+
+
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) 클래스의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| defaultFontStream | java.io.InputStream | 기본 Font를 포함하는 스트림입니다. |
+| fontsSubstitutions | java.util.Map&lt;java.lang.String,java.lang.String&gt; | 글꼴 대체입니다. |
+
+### DocumentFontsSubsystem(InputStream defaultFontStream) {#DocumentFontsSubsystem-java.io.InputStream-}
+```
+public DocumentFontsSubsystem(InputStream defaultFontStream)
+```
+
+
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) 클래스의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| defaultFontStream | java.io.InputStream | 기본 Font를 포함하는 스트림입니다. |
+
+### DocumentFontsSubsystem(String defaultFontFile, Map&lt;String,String&gt; fontsSubstitutions) {#DocumentFontsSubsystem-java.lang.String-java.util.Map-java.lang.String-java.lang.String--}
+```
+public DocumentFontsSubsystem(String defaultFontFile, Map<String,String> fontsSubstitutions)
+```
+
+
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) 클래스의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| defaultFontFile | java.lang.String | 기본 Font를 포함하는 파일의 경로입니다. |
+| fontsSubstitutions | java.util.Map&lt;java.lang.String,java.lang.String&gt; | 글꼴 대체입니다. |
+
+### DocumentFontsSubsystem(String defaultFontFile) {#DocumentFontsSubsystem-java.lang.String-}
+```
+public DocumentFontsSubsystem(String defaultFontFile)
+```
+
+
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) 클래스의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| defaultFontFile | java.lang.String | 기본 Font를 포함하는 파일의 경로입니다. |
+
+### DocumentFontsSubsystem(Map&lt;String,String&gt; fontsSubstitutions) {#DocumentFontsSubsystem-java.util.Map-java.lang.String-java.lang.String--}
+```
+public DocumentFontsSubsystem(Map<String,String> fontsSubstitutions)
+```
+
+
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) 클래스의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontsSubstitutions | java.util.Map&lt;java.lang.String,java.lang.String&gt; | 글꼴 대체입니다. |
+
+### DocumentFontsSubsystem() {#DocumentFontsSubsystem--}
+```
+public DocumentFontsSubsystem()
+```
+
+
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) 클래스의 새 인스턴스를 초기화합니다.
+
+### getDefault() {#getDefault--}
+```
+public static DocumentFontsSubsystem getDefault()
+```
+
+
+정적 기본 인스턴스를 가져오거나 설정합니다.
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem)
+### setDefault(DocumentFontsSubsystem value) {#setDefault-com.aspose.note.fonts.DocumentFontsSubsystem-}
+```
+public static void setDefault(DocumentFontsSubsystem value)
+```
+
+
+정적 기본 인스턴스를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) |  |
+
+### usingDefaultFont(String defaultFontName) {#usingDefaultFont-java.lang.String-}
+```
+public static DocumentFontsSubsystem usingDefaultFont(String defaultFontName)
+```
+
+
+지정된 기본 글꼴 이름을 사용하여 새 DocumentFontsSubsystem 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| defaultFontName | java.lang.String | 기본 글꼴 이름입니다. |
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) - [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+### usingDefaultFont(String defaultFontName, Map&lt;String,String&gt; fontsSubstitutions) {#usingDefaultFont-java.lang.String-java.util.Map-java.lang.String-java.lang.String--}
+```
+public static DocumentFontsSubsystem usingDefaultFont(String defaultFontName, Map<String,String> fontsSubstitutions)
+```
+
+
+지정된 기본 글꼴 이름을 사용하여 새 DocumentFontsSubsystem 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| defaultFontName | java.lang.String | 기본 글꼴 이름입니다. |
+| fontsSubstitutions | java.util.Map&lt;java.lang.String,java.lang.String&gt; | 글꼴 대체입니다. |
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) - [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+### usingDefaultFontFromFile(String filePath) {#usingDefaultFontFromFile-java.lang.String-}
+```
+public static DocumentFontsSubsystem usingDefaultFontFromFile(String filePath)
+```
+
+
+지정된 기본 글꼴 이름을 사용하여 새 DocumentFontsSubsystem 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| filePath | java.lang.String | 기본 글꼴 이름을 포함하는 파일입니다. |
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) - [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+### usingDefaultFontFromFile(String filePath, Map&lt;String,String&gt; fontsSubstitutions) {#usingDefaultFontFromFile-java.lang.String-java.util.Map-java.lang.String-java.lang.String--}
+```
+public static DocumentFontsSubsystem usingDefaultFontFromFile(String filePath, Map<String,String> fontsSubstitutions)
+```
+
+
+지정된 파일에서 글꼴을 기본값으로 사용하여 새 DocumentFontsSubsystem 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| filePath | java.lang.String | 기본 글꼴 이름을 포함하는 파일입니다. |
+| fontsSubstitutions | java.util.Map&lt;java.lang.String,java.lang.String&gt; | 글꼴 대체입니다. |
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) - [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+### usingDefaultFontFromStream(InputStream defaultFontStream) {#usingDefaultFontFromStream-java.io.InputStream-}
+```
+public static DocumentFontsSubsystem usingDefaultFontFromStream(InputStream defaultFontStream)
+```
+
+
+지정된 스트림에서 글꼴을 기본값으로 사용하여 새 DocumentFontsSubsystem 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| defaultFontStream | java.io.InputStream | 기본 글꼴 이름을 포함하는 스트림입니다. |
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) - [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+### usingDefaultFontFromStream(InputStream defaultFontStream, Map&lt;String,String&gt; fontsSubstitutions) {#usingDefaultFontFromStream-java.io.InputStream-java.util.Map-java.lang.String-java.lang.String--}
+```
+public static DocumentFontsSubsystem usingDefaultFontFromStream(InputStream defaultFontStream, Map<String,String> fontsSubstitutions)
+```
+
+
+지정된 스트림에서 글꼴을 기본값으로 사용하여 새 DocumentFontsSubsystem 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| defaultFontStream | java.io.InputStream | 기본 글꼴 이름을 포함하는 스트림입니다. |
+| fontsSubstitutions | java.util.Map&lt;java.lang.String,java.lang.String&gt; | 글꼴 대체입니다. |
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) - [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).

--- a/korean/java/com.aspose.note.fonts/fontssubsystem/_index.md
+++ b/korean/java/com.aspose.note.fonts/fontssubsystem/_index.md
@@ -1,0 +1,107 @@
+---
+title: "FontsSubsystem"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "com.aspose.note.IFontsSubsystem 인터페이스를 구현하는 기본 클래스."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.note.fonts/fontssubsystem/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.note.fonts.IFontsSubsystem](../../com.aspose.note.fonts/ifontssubsystem)
+```
+public abstract class FontsSubsystem implements IFontsSubsystem
+```
+
+com.aspose.note.IFontsSubsystem 인터페이스를 구현하는 기본 클래스입니다. 기본 글꼴 및 글꼴 대체 기능을 제공합니다. 파생 클래스에서 com.aspose.note.FontsSubsystem.fetchFontFamily 보호된 멤버 함수를 재정의하여 Font 객체를 검색하는 로직을 구현합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [addFont(InputStream stream)](#addFont-java.io.InputStream-) | 글꼴을 추가합니다. |
+| [addFont(String file)](#addFont-java.lang.String-) | 글꼴을 추가합니다. |
+| [addFontSubstitution(String substituted, String substitution)](#addFontSubstitution-java.lang.String-java.lang.String-) | 글꼴 대체를 추가합니다. |
+| [getDefaultFont()](#getDefaultFont--) | 기본 글꼴을 가져옵니다. |
+| [getFontFamily(String fontName)](#getFontFamily-java.lang.String-) | 글꼴을 가져옵니다. |
+| [loadFontsFromFolder(String folder)](#loadFontsFromFolder-java.lang.String-) | 지정된 폴더에서 모든 TrueType 글꼴을 내부 컬렉션으로 로드합니다. |
+### addFont(InputStream stream) {#addFont-java.io.InputStream-}
+```
+public final void addFont(InputStream stream)
+```
+
+
+글꼴을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.InputStream | 글꼴을 포함하는 스트림입니다. |
+
+### addFont(String file) {#addFont-java.lang.String-}
+```
+public final void addFont(String file)
+```
+
+
+글꼴을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 파일 | java.lang.String | 글꼴을 포함하는 파일의 경로입니다. |
+
+### addFontSubstitution(String substituted, String substitution) {#addFontSubstitution-java.lang.String-java.lang.String-}
+```
+public final void addFontSubstitution(String substituted, String substitution)
+```
+
+
+글꼴 대체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 대체된 | java.lang.String | 대체된 글꼴 이름입니다. |
+| 대체 | java.lang.String | 대체 글꼴 이름입니다. |
+
+### getDefaultFont() {#getDefaultFont--}
+```
+public Font getDefaultFont()
+```
+
+
+기본 글꼴을 가져옵니다.
+
+**Returns:**
+java.awt.Font
+### getFontFamily(String fontName) {#getFontFamily-java.lang.String-}
+```
+public Font getFontFamily(String fontName)
+```
+
+
+글꼴을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontName | java.lang.String | 글꼴 이름입니다. |
+
+**Returns:**
+java.awt.Font - Font입니다.
+### loadFontsFromFolder(String folder) {#loadFontsFromFolder-java.lang.String-}
+```
+public final void loadFontsFromFolder(String folder)
+```
+
+
+지정된 폴더에서 모든 TrueType 글꼴을 내부 컬렉션으로 로드합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 폴더 | java.lang.String | 글꼴을 포함하는 폴더입니다. |
+

--- a/korean/java/com.aspose.note.fonts/ifontssubsystem/_index.md
+++ b/korean/java/com.aspose.note.fonts/ifontssubsystem/_index.md
@@ -1,0 +1,33 @@
+---
+title: "IFontsSubsystem"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "문서를 저장할 때 Aspose.Note가 글꼴을 검색하는 방식을 제어하려면 이 인터페이스를 구현하십시오."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.note.fonts/ifontssubsystem/
+---
+```
+public interface IFontsSubsystem
+```
+
+문서를 저장할 때 Aspose.Note가 글꼴을 검색하는 방식을 제어하려면 이 인터페이스를 구현하십시오.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getFontFamily(String fontName)](#getFontFamily-java.lang.String-) | 글꼴을 가져옵니다. |
+### getFontFamily(String fontName) {#getFontFamily-java.lang.String-}
+```
+public abstract Font getFontFamily(String fontName)
+```
+
+
+글꼴을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontName | java.lang.String | 글꼴 이름입니다. |
+
+**Returns:**
+java.awt.Font - Font입니다.

--- a/korean/java/com.aspose.note/_index.md
+++ b/korean/java/com.aspose.note/_index.md
@@ -1,0 +1,123 @@
+---
+title: "com.aspose.note"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "com.aspose.note 네임스페이스는 문서 구조를 나타내는 클래스를 포함합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.note/
+---
+
+
+`com.aspose.note` 네임스페이스는 문서 구조를 나타내는 클래스를 포함합니다.
+
+
+## 클래스
+
+| 클래스 | 설명 |
+| --- | --- |
+| [AlwaysSplitObjectsAlgorithm](../com.aspose.note/alwayssplitobjectsalgorithm) | 객체가 원본 페이지에 맞지 않을 경우 여러 부분으로 분할합니다. |
+| [AttachedFile](../com.aspose.note/attachedfile) | 첨부 파일을 나타냅니다. |
+| [BinarizationMethod](../com.aspose.note/binarizationmethod) | 이미지에 대한 이진화 방법을 지정합니다. |
+| [CheckBox](../com.aspose.note/checkbox) | 완료와 미완료 상태를 전환할 수 있는 태그의 기본 클래스입니다. |
+| [ColorMode](../com.aspose.note/colormode) | 이미지의 색상 모드입니다. |
+| [CompositeNode&lt;T&gt;](../com.aspose.note/compositenode) | 다른 노드를 포함할 수 있는 노드의 기본 제네릭 클래스입니다. |
+| [CompositeNodeBase](../com.aspose.note/compositenodebase) | 다른 노드를 포함할 수 있는 노드의 비제네릭 클래스입니다. |
+| [CssSavingArgs](../com.aspose.note/csssavingargs) | CssSaving 이벤트에 대한 데이터를 제공합니다. |
+| [DefaultMsOneNoteValuesAccessor](../com.aspose.note/defaultmsonenotevaluesaccessor) |  |
+| [DisplayUnitsConverter](../com.aspose.note/displayunitsconverter) | 이 클래스는 값 변환 메서드를 포함합니다. |
+| [Document](../com.aspose.note/document) | Aspose.Note 문서를 나타냅니다. |
+| [DocumentPrintAttributeSet](../com.aspose.note/documentprintattributeset) | AttributeSet과 함께 사용자 친화적인 인터페이스를 제공하는 도우미 클래스를 나타냅니다. |
+| [DocumentVisitor](../com.aspose.note/documentvisitor) | 지정된 노드를 루트로 하는 서브트리를 순회하기 위한 추상 클래스입니다. |
+| [ExtendedApsDocument](../com.aspose.note/extendedapsdocument) | 전체 OneNote 문서를 나타내며, 페이지를 페이지 세트로 변환하여 구성됩니다. |
+| [ExtendedApsGlyphs](../com.aspose.note/extendedapsglyphs) | 표준 ApsGlyphs에 대한 래퍼를 나타내며, 일부 그리기 동작을 확장합니다. |
+| [ExtendedApsImage](../com.aspose.note/extendedapsimage) | 표준 ApsImage에 대한 래퍼를 나타내며, 일부 그리기 동작을 확장합니다. |
+| [ExtendedApsNode](../com.aspose.note/extendedapsnode) | 표준 ApsNode에 대한 래퍼를 나타내며, 일부 그리기 동작을 확장합니다. |
+| [ExtendedApsPage](../com.aspose.note/extendedapspage) | 표준 ApsGlyphs에 대한 래퍼를 나타내며, 일부 그리기 동작을 확장합니다. |
+| [ExtendedApsPath](../com.aspose.note/extendedapspath) | 표준 ApsPath에 대한 래퍼를 나타내며, 일부 그리기 동작을 확장합니다. |
+| [ExtendedCompositeNode](../com.aspose.note/extendedcompositenode) | `IExtendedApsNode` 인스턴스를 여러 개 결합합니다. |
+| [FileFormat](../com.aspose.note/fileformat) | OneNote 파일 형식을 나타냅니다. |
+| [FontSavingArgs](../com.aspose.note/fontsavingargs) | FontSaving 이벤트에 대한 데이터를 제공합니다. |
+| [HtmlSaveOptions](../com.aspose.note/htmlsaveoptions) | 문서를 HTML 형식으로 저장할 때 추가 옵션을 지정할 수 있습니다. |
+| [Image](../com.aspose.note/image) | 이미지를 나타냅니다. |
+| [ImageBinarizationOptions](../com.aspose.note/imagebinarizationoptions) | 이미지 이진화 옵션. |
+| [ImageSaveOptions](../com.aspose.note/imagesaveoptions) | 문서 페이지를 이미지로 렌더링할 때 추가 옵션을 지정할 수 있습니다. |
+| [ImageSavingArgs](../com.aspose.note/imagesavingargs) | ImageSaving 이벤트에 대한 데이터를 제공합니다. |
+| [IndentatedNode&lt;T,Self&gt;](../com.aspose.note/indentatednode) | 자식 노드에 대한 상대 들여쓰기를 가진 노드의 기본 클래스입니다. |
+| [InkDrawing](../com.aspose.note/inkdrawing) | 그려진 콘텐츠를 포함하는 잉크 노드를 나타냅니다. |
+| [InkNode](../com.aspose.note/inknode) | 모든 잉크 노드에 대한 공통 인터페이스를 나타냅니다. |
+| [InkParagraph](../com.aspose.note/inkparagraph) | 기울어진 필기와 같은 추가 속성을 가진 손글씨 텍스트를 포함하는 잉크 노드를 나타냅니다. |
+| [InkWord](../com.aspose.note/inkword) | 손글씨 텍스트를 포함하는 잉크 노드를 나타냅니다. |
+| [KeepPartAndCloneSolidObjectToNextPageAlgorithm](../com.aspose.note/keeppartandclonesolidobjecttonextpagealgorithm) | 객체의 상단 부분을 페이지 하단에 추가하고, 원본 페이지에 맞지 않을 경우 전체 객체를 다음 페이지에 복제합니다. |
+| [KeepSolidObjectsAlgorithm](../com.aspose.note/keepsolidobjectsalgorithm) | 원본 페이지에 맞지 않을 경우 전체 객체를 다음 페이지로 이동시킵니다. |
+| [License](../com.aspose.note/license) | 구성 요소를 라이선스하는 메서드를 제공합니다. |
+| [LicenseExceptions](../com.aspose.note/licenseexceptions) |  |
+| [LoadOptions](../com.aspose.note/loadoptions) | 문서를 로드하는 데 사용되는 옵션입니다. |
+| [LocaleOptions](../com.aspose.note/localeoptions) | LocaleOptions 유형은 Aspose.Note에 대한 로케일 구성을 지정합니다. |
+| [Loop](../com.aspose.note/loop) | 루프를 나타냅니다. |
+| [Margins](../com.aspose.note/margins) | 노드 여백의 크기를 지정합니다. |
+| [Metered](../com.aspose.note/metered) | 계량 키를 설정하는 메서드를 제공합니다. |
+| [Node](../com.aspose.note/node) | Aspose.Note 문서의 모든 노드에 대한 기본 클래스입니다. |
+| [NodeType](../com.aspose.note/nodetype) | 노드의 유형을 지정합니다. |
+| [NoteCheckBox](../com.aspose.note/notecheckbox) | 완료와 미완료 상태를 전환할 수 있는 노트 태그를 나타냅니다. |
+| [NoteTag](../com.aspose.note/notetag) | 노트 태그를 나타냅니다. |
+| [NoteTask](../com.aspose.note/notetask) | 노트 작업을 나타냅니다. |
+| [Notebook](../com.aspose.note/notebook) | Aspose.Note 노트북을 나타냅니다. |
+| [NotebookImageSaveOptions](../com.aspose.note/notebookimagesaveoptions) | 노트북 페이지를 이미지로 렌더링할 때 추가 옵션을 지정할 수 있습니다. |
+| [NotebookLoadOptions](../com.aspose.note/notebookloadoptions) | 노트북을 로드하는 데 사용되는 옵션입니다. |
+| [NotebookOneSaveOptions](../com.aspose.note/notebookonesaveoptions) | 노트북을 OneNote 형식으로 저장할 때 추가 옵션을 지정할 수 있습니다. |
+| [NotebookPdfSaveOptions](../com.aspose.note/notebookpdfsaveoptions) | 노트북 페이지를 PDF로 렌더링할 때 추가 옵션을 지정할 수 있습니다. |
+| [NotebookSaveOptions](../com.aspose.note/notebooksaveoptions) | 특정 형식에 대한 노트북 저장 옵션을 나타내는 추상 기본 클래스입니다. |
+| [NotebookSaveOptionsGeneric&lt;TDocumentSaveOptions&gt;](../com.aspose.note/notebooksaveoptionsgeneric) | 특정 형식에 대한 노트북 저장 옵션을 나타내고 모든 문서 하위 노드에 대한 공통 저장 옵션을 제공하는 추상 기본 클래스입니다. |
+| [NumberFormat](../com.aspose.note/numberformat) | 자동 번호 매기기된 객체 그룹에 사용할 수 있는 번호 매기기 형식을 지정합니다. |
+| [NumberList](../com.aspose.note/numberlist) | 번호 매기기 또는 글머리표 목록을 나타냅니다. |
+| [OneSaveOptions](../com.aspose.note/onesaveoptions) | 문서를 OneNote 형식으로 저장할 때 추가 옵션을 지정할 수 있습니다. |
+| [Outline](../com.aspose.note/outline) | 개요를 나타냅니다. |
+| [OutlineElement](../com.aspose.note/outlineelement) | OutlineElement를 나타냅니다. |
+| [OutlineGroup](../com.aspose.note/outlinegroup) | OutlineGroup를 나타냅니다. |
+| [Page](../com.aspose.note/page) | 페이지를 나타냅니다. |
+| [PageHistory](../com.aspose.note/pagehistory) | 페이지 기록을 나타냅니다. |
+| [PageSavingArgs](../com.aspose.note/pagesavingargs) | PageSaving 이벤트에 대한 데이터를 제공합니다. |
+| [PageSettings](../com.aspose.note/pagesettings) | 페이지에 대한 레이아웃 설정을 나타냅니다. |
+| [PageSizeType](../com.aspose.note/pagesizetype) | 페이지 노드 유형의 크기를 지정합니다. |
+| [PageSplittingAlgorithm](../com.aspose.note/pagesplittingalgorithm) | 원본 페이지에 맞지 않을 경우 객체를 분할하기 위한 기본 클래스입니다. |
+| [ParagraphStyle](../com.aspose.note/paragraphstyle) | 텍스트 스타일 설정은 [RichText.\#getStyles](../com.aspose.note/richtext\#getStyles) 컬렉션에 일치하는 TextStyle 객체가 없거나 이 객체가 필요한 설정을 지정하지 않은 경우에 사용됩니다. |
+| [PdfImageCompression](../com.aspose.note/pdfimagecompression) | PDF 파일의 이미지에 적용되는 압축 유형을 지정합니다. |
+| [PdfSaveOptions](../com.aspose.note/pdfsaveoptions) | 문서 페이지를 PDF로 렌더링할 때 추가 옵션을 지정할 수 있습니다. |
+| [PrintOptions](../com.aspose.note/printoptions) | 문서를 인쇄할 때 사용되는 옵션입니다. |
+| [ResourceExportType](../com.aspose.note/resourceexporttype) |  |
+| [ResourceSavingArgs](../com.aspose.note/resourcesavingargs) | ResourceSaving 이벤트에 대한 데이터를 제공합니다. |
+| [RevisionSummary](../com.aspose.note/revisionsummary) | 노드 수정에 대한 요약을 나타냅니다. |
+| [RichText](../com.aspose.note/richtext) | 리치 텍스트를 나타냅니다. |
+| [SaveFormat](../com.aspose.note/saveformat) | 문서가 저장되는 형식을 나타냅니다. |
+| [SaveFormatConverter](../com.aspose.note/saveformatconverter) | 저장 형식 변환기입니다. |
+| [SaveOptions](../com.aspose.note/saveoptions) | 특정 형식에 대한 문서 저장 옵션을 나타내는 추상 기본 클래스입니다. |
+| [Style&lt;T&gt;](../com.aspose.note/style) | 이 클래스는 [ParagraphStyle](../com.aspose.note/paragraphstyle) 및 [TextStyle](../com.aspose.note/textstyle) 클래스의 공통 속성을 포함합니다. |
+| [Table](../com.aspose.note/table) | 표를 나타냅니다. |
+| [TableCell](../com.aspose.note/tablecell) | 표 셀을 나타냅니다. |
+| [TableColumn](../com.aspose.note/tablecolumn) | 표 열을 나타냅니다. |
+| [TableRow](../com.aspose.note/tablerow) | 표 행을 나타냅니다. |
+| [TagStatus](../com.aspose.note/tagstatus) | 노트 태그 노드의 상태를 지정합니다. |
+| [TextRun](../com.aspose.note/textrun) | 연관된 스타일이 있는 텍스트 조각을 나타내는 클래스입니다. |
+| [TextStyle](../com.aspose.note/textstyle) | 텍스트 스타일을 지정합니다. |
+| [TiffCompression](../com.aspose.note/tiffcompression) | TIFF 형식으로 문서를 저장할 때 사용할 압축 유형을 지정합니다. |
+| [Title](../com.aspose.note/title) | 제목을 나타냅니다. |
+
+## 인터페이스
+
+| 인터페이스 | 설명 |
+| --- | --- |
+| [ICompositeNode](../com.aspose.note/icompositenode) | 다른 노드를 포함할 수 있는 노드용 인터페이스입니다. |
+| [ICompositeNodeT&lt;T&gt;](../com.aspose.note/icompositenodet) | 다른 노드를 포함할 수 있는 노드용 인터페이스입니다. |
+| [ICssSavingCallback](../com.aspose.note/icsssavingcallback) | HTML로 문서를 저장할 때 Aspose.Note가 CSS(스타일시트)를 저장하는 방식을 제어하려면 이 인터페이스를 구현하십시오. |
+| [IFontSavingCallback](../com.aspose.note/ifontsavingcallback) | HTML로 문서를 저장할 때 Aspose.Note가 글꼴을 저장하는 방식을 제어하려면 이 인터페이스를 구현하십시오. |
+| [IImageSavingCallback](../com.aspose.note/iimagesavingcallback) | HTML로 문서를 저장할 때 Aspose.Note가 이미지를 저장하는 방식을 제어하려면 이 인터페이스를 구현하십시오. |
+| [IIndentatedNode](../com.aspose.note/iindentatednode) | 자식 노드에 대한 상대 들여쓰기를 가진 노드용 인터페이스입니다. |
+| [INode](../com.aspose.note/inode) | Aspose.Note 문서의 모든 노드에 대한 인터페이스입니다. |
+| [INoteTag](../com.aspose.note/inotetag) | 노트 태그(i.e.)에 대한 인터페이스. |
+| [INotebookChildNode](../com.aspose.note/inotebookchildnode) | Aspose.Note 노트북의 하위 항목을 나타냅니다. |
+| [IOutlineChildNode](../com.aspose.note/ioutlinechildnode) | 아웃라인 노드의 모든 하위 노드에 대한 인터페이스입니다. |
+| [IOutlineElementChildNode](../com.aspose.note/ioutlineelementchildnode) | 아웃라인 요소 노드의 모든 하위 노드에 대한 인터페이스입니다. |
+| [IPageChildNode](../com.aspose.note/ipagechildnode) | 페이지 노드의 모든 하위 노드에 대한 인터페이스입니다. |
+| [IPageSavingCallback](../com.aspose.note/ipagesavingcallback) | Aspose.Note가 개별 페이지를 저장하는 방식을 제어하려면 이 인터페이스를 구현하십시오. |
+| [ITag](../com.aspose.note/itag) | 모든 종류의 태그에 대한 인터페이스입니다. |
+| [ITaggable](../com.aspose.note/itaggable) | 태그로 표시될 수 있는 노드에 대한 인터페이스입니다. |

--- a/korean/java/com.aspose.note/alwayssplitobjectsalgorithm/_index.md
+++ b/korean/java/com.aspose.note/alwayssplitobjectsalgorithm/_index.md
@@ -1,0 +1,27 @@
+---
+title: "AlwaysSplitObjectsAlgorithm"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "객체가 원본 페이지에 맞지 않을 경우 여러 부분으로 분할합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.note/alwayssplitobjectsalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm)
+```
+public class AlwaysSplitObjectsAlgorithm extends PageSplittingAlgorithm
+```
+
+객체가 원본 페이지에 맞지 않을 경우 여러 부분으로 분할합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [AlwaysSplitObjectsAlgorithm()](#AlwaysSplitObjectsAlgorithm--) |  |
+### AlwaysSplitObjectsAlgorithm() {#AlwaysSplitObjectsAlgorithm--}
+```
+public AlwaysSplitObjectsAlgorithm()
+```
+
+

--- a/korean/java/com.aspose.note/attachedfile/_index.md
+++ b/korean/java/com.aspose.note/attachedfile/_index.md
@@ -1,0 +1,497 @@
+---
+title: "AttachedFile"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "첨부 파일을 나타냅니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.note/attachedfile/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node)
+
+**All Implemented Interfaces:**
+[com.aspose.note.IPageChildNode](../../com.aspose.note/ipagechildnode), [com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode), [com.aspose.note.ITaggable](../../com.aspose.note/itaggable)
+```
+public class AttachedFile extends Node implements IPageChildNode, IOutlineElementChildNode, ITaggable
+```
+
+첨부 파일을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [AttachedFile(String path)](#AttachedFile-java.lang.String-) | 새 `AttachedFile` 클래스 인스턴스를 초기화합니다. |
+| [AttachedFile(String path, InputStream icon, System.Drawing.Imaging.ImageFormat iconFormat)](#AttachedFile-java.lang.String-java.io.InputStream-com.aspose.ms.System.Drawing.Imaging.ImageFormat-) | 새 `AttachedFile` 클래스 인스턴스를 초기화합니다. |
+| [AttachedFile(String fileName, InputStream attachedFileStream)](#AttachedFile-java.lang.String-java.io.InputStream-) | 새 `AttachedFile` 클래스 인스턴스를 초기화합니다. |
+| [AttachedFile(String fileName, InputStream attachedFileStream, InputStream icon, System.Drawing.Imaging.ImageFormat iconFormat)](#AttachedFile-java.lang.String-java.io.InputStream-java.io.InputStream-com.aspose.ms.System.Drawing.Imaging.ImageFormat-) | 새 `AttachedFile` 클래스 인스턴스를 초기화합니다. |
+| [AttachedFile()](#AttachedFile--) | 새 `AttachedFile` 클래스 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | 노드의 방문자를 수락합니다. |
+| [getAlignment()](#getAlignment--) | 정렬을 가져옵니다. |
+| [getAlternativeTextDescription()](#getAlternativeTextDescription--) | 첨부 파일 아이콘에 대한 본문 대체 텍스트를 가져오거나 설정합니다. |
+| [getAlternativeTextTitle()](#getAlternativeTextTitle--) | 첨부 파일 아이콘에 대한 대체 텍스트의 제목을 가져오거나 설정합니다. |
+| [getBytes()](#getBytes--) | 임베드된 파일의 바이너리 데이터를 가져옵니다. |
+| [getExtension()](#getExtension--) | 임베드된 파일의 확장자를 가져옵니다. |
+| [getFileName()](#getFileName--) | 임베드된 파일의 이름을 가져옵니다. |
+| [getFilePath()](#getFilePath--) | 원본 파일의 경로를 가져옵니다. |
+| [getHeight()](#getHeight--) | 임베드된 파일 아이콘의 원본 높이를 가져옵니다. |
+| [getHorizontalOffset()](#getHorizontalOffset--) | 수평 오프셋을 가져옵니다. |
+| [getIcon()](#getIcon--) | 임베드된 파일과 연결된 아이콘의 바이너리 데이터를 가져옵니다. |
+| [getIconExtension()](#getIconExtension--) | 아이콘의 확장자를 가져옵니다. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 마지막 수정 시간을 가져옵니다. |
+| [getMaxHeight()](#getMaxHeight--) | 삽입된 파일 아이콘을 표시하기 위한 최대 높이를 가져옵니다. |
+| [getMaxWidth()](#getMaxWidth--) | 삽입된 파일 아이콘을 표시하기 위한 최대 너비를 가져옵니다. |
+| [getParsingErrorInfo()](#getParsingErrorInfo--) | 파일에 접근하는 동안 발생한 오류에 대한 데이터를 가져옵니다. |
+| [getTags()](#getTags--) | 첨부된 파일의 태그 목록을 가져옵니다. |
+| [getText()](#getText--) | 삽입된 파일의 텍스트 표현을 가져옵니다. |
+| [getVerticalOffset()](#getVerticalOffset--) | 수직 오프셋을 가져옵니다. |
+| [getWidth()](#getWidth--) | 삽입된 파일 아이콘의 원래 너비를 가져옵니다. |
+| [isPrintout()](#isPrintout--) | 파일 보기 방식이 인쇄물인지 여부를 나타내는 값을 가져옵니다. |
+| [isSizeSetByUser()](#isSizeSetByUser--) | 아이콘 크기 값이 사용자가 명시적으로 업데이트했는지 여부를 나타내는 값을 가져옵니다. |
+| [setAlignment(int value)](#setAlignment-int-) | 정렬을 설정합니다. |
+| [setAlternativeTextDescription(String value)](#setAlternativeTextDescription-java.lang.String-) | 첨부 파일 아이콘에 대한 본문 대체 텍스트를 가져오거나 설정합니다. |
+| [setAlternativeTextTitle(String value)](#setAlternativeTextTitle-java.lang.String-) | 첨부 파일 아이콘에 대한 대체 텍스트의 제목을 가져오거나 설정합니다. |
+| [setHorizontalOffset(float value)](#setHorizontalOffset-float-) | 수평 오프셋을 설정합니다. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 마지막 수정 시간을 설정합니다. |
+| [setMaxHeight(float value)](#setMaxHeight-float-) | 삽입된 파일 아이콘을 표시하기 위한 최대 높이를 설정합니다. |
+| [setMaxWidth(float value)](#setMaxWidth-float-) | 삽입된 파일 아이콘을 표시하기 위한 최대 너비를 설정합니다. |
+| [setPrintout(boolean value)](#setPrintout-boolean-) | 파일 보기 방식이 인쇄물인지 여부를 나타내는 값을 설정합니다. |
+| [setSizeSetByUser(boolean value)](#setSizeSetByUser-boolean-) | 아이콘 크기 값이 사용자가 명시적으로 업데이트했는지 여부를 나타내는 값을 설정합니다. |
+| [setText(String value)](#setText-java.lang.String-) | 삽입된 파일의 텍스트 표현을 설정합니다. |
+| [setVerticalOffset(float value)](#setVerticalOffset-float-) | 수직 오프셋을 설정합니다. |
+### AttachedFile(String path) {#AttachedFile-java.lang.String-}
+```
+public AttachedFile(String path)
+```
+
+
+새 `AttachedFile` 클래스 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 경로 | java.lang.String | `AttachedFile`을 생성할 파일의 경로를 포함하는 문자열입니다. |
+
+### AttachedFile(String path, InputStream icon, System.Drawing.Imaging.ImageFormat iconFormat) {#AttachedFile-java.lang.String-java.io.InputStream-com.aspose.ms.System.Drawing.Imaging.ImageFormat-}
+```
+public AttachedFile(String path, InputStream icon, System.Drawing.Imaging.ImageFormat iconFormat)
+```
+
+
+새 `AttachedFile` 클래스 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 경로 | java.lang.String | `AttachedFile`을 생성할 파일의 경로를 포함하는 문자열입니다. |
+| 아이콘 | java.io.InputStream | 첨부된 파일에 대한 아이콘입니다. |
+| 아이콘형식 | com.aspose.ms.System.Drawing.Imaging.ImageFormat |  |
+
+### AttachedFile(String fileName, InputStream attachedFileStream) {#AttachedFile-java.lang.String-java.io.InputStream-}
+```
+public AttachedFile(String fileName, InputStream attachedFileStream)
+```
+
+
+새 `AttachedFile` 클래스 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 파일이름 | java.lang.String | 첨부된 파일의 이름. |
+| attachedFileStream | java.io.InputStream | 첨부된 파일 바이트를 포함하는 스트림. |
+
+### AttachedFile(String fileName, InputStream attachedFileStream, InputStream icon, System.Drawing.Imaging.ImageFormat iconFormat) {#AttachedFile-java.lang.String-java.io.InputStream-java.io.InputStream-com.aspose.ms.System.Drawing.Imaging.ImageFormat-}
+```
+public AttachedFile(String fileName, InputStream attachedFileStream, InputStream icon, System.Drawing.Imaging.ImageFormat iconFormat)
+```
+
+
+새 `AttachedFile` 클래스 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 파일이름 | java.lang.String | 첨부된 파일의 이름. |
+| attachedFileStream | java.io.InputStream | 첨부된 파일 바이트를 포함하는 스트림. |
+| 아이콘 | java.io.InputStream | 첨부된 파일에 대한 아이콘입니다. |
+| 아이콘형식 | com.aspose.ms.System.Drawing.Imaging.ImageFormat | 첨부된 파일 아이콘의 형식. |
+
+### AttachedFile() {#AttachedFile--}
+```
+public AttachedFile()
+```
+
+
+새 `AttachedFile` 클래스 인스턴스를 초기화합니다.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+노드의 방문자를 수락합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor`에서 파생된 클래스의 객체. |
+
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+정렬을 가져옵니다.
+
+**Returns:**
+int
+### getAlternativeTextDescription() {#getAlternativeTextDescription--}
+```
+public final String getAlternativeTextDescription()
+```
+
+
+첨부 파일 아이콘에 대한 본문 대체 텍스트를 가져오거나 설정합니다.
+
+**Returns:**
+java.lang.String
+### getAlternativeTextTitle() {#getAlternativeTextTitle--}
+```
+public final String getAlternativeTextTitle()
+```
+
+
+첨부 파일 아이콘에 대한 대체 텍스트의 제목을 가져오거나 설정합니다.
+
+**Returns:**
+java.lang.String
+### getBytes() {#getBytes--}
+```
+public byte[] getBytes()
+```
+
+
+임베드된 파일의 바이너리 데이터를 가져옵니다.
+
+**Returns:**
+byte[]
+### getExtension() {#getExtension--}
+```
+public String getExtension()
+```
+
+
+임베드된 파일의 확장자를 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+임베드된 파일의 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getFilePath() {#getFilePath--}
+```
+public String getFilePath()
+```
+
+
+원본 파일의 경로를 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public float getHeight()
+```
+
+
+임베드된 파일 아이콘의 원본 높이를 가져옵니다.
+
+**Returns:**
+float
+### getHorizontalOffset() {#getHorizontalOffset--}
+```
+public float getHorizontalOffset()
+```
+
+
+수평 오프셋을 가져옵니다.
+
+**Returns:**
+float
+### getIcon() {#getIcon--}
+```
+public byte[] getIcon()
+```
+
+
+임베드된 파일과 연결된 아이콘의 바이너리 데이터를 가져옵니다.
+
+**Returns:**
+byte[]
+### getIconExtension() {#getIconExtension--}
+```
+public String getIconExtension()
+```
+
+
+아이콘의 확장자를 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+마지막 수정 시간을 가져옵니다.
+
+**Returns:**
+java.util.Date
+### getMaxHeight() {#getMaxHeight--}
+```
+public float getMaxHeight()
+```
+
+
+삽입된 파일 아이콘을 표시하기 위한 최대 높이를 가져옵니다.
+
+**Returns:**
+float
+### getMaxWidth() {#getMaxWidth--}
+```
+public float getMaxWidth()
+```
+
+
+삽입된 파일 아이콘을 표시하기 위한 최대 너비를 가져옵니다.
+
+**Returns:**
+float
+### getParsingErrorInfo() {#getParsingErrorInfo--}
+```
+public final ParsingErrorInfo getParsingErrorInfo()
+```
+
+
+파일에 접근하는 동안 발생한 오류에 대한 데이터를 가져옵니다.
+
+**Returns:**
+[ParsingErrorInfo](../../com.aspose.note.infrastructure/parsingerrorinfo)
+### getTags() {#getTags--}
+```
+public final System.Collections.Generic.List<ITag> getTags()
+```
+
+
+첨부된 파일의 태그 목록을 가져옵니다.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List&lt;com.aspose.note.ITag&gt;
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+임베드된 파일의 텍스트 표현을 가져옵니다. 문자열은 값 10(줄 바꿈) 또는 13(캐리지 리턴)의 문자를 절대 포함해서는 안 됩니다.
+
+**Returns:**
+java.lang.String
+### getVerticalOffset() {#getVerticalOffset--}
+```
+public float getVerticalOffset()
+```
+
+
+수직 오프셋을 가져옵니다.
+
+**Returns:**
+float
+### getWidth() {#getWidth--}
+```
+public float getWidth()
+```
+
+
+삽입된 파일 아이콘의 원래 너비를 가져옵니다.
+
+**Returns:**
+float
+### isPrintout() {#isPrintout--}
+```
+public boolean isPrintout()
+```
+
+
+파일 보기 방식이 인쇄물인지 여부를 나타내는 값을 가져옵니다.
+
+**Returns:**
+boolean
+### isSizeSetByUser() {#isSizeSetByUser--}
+```
+public boolean isSizeSetByUser()
+```
+
+
+아이콘 크기 값이 사용자가 명시적으로 업데이트했는지 여부를 나타내는 값을 가져옵니다.
+
+**Returns:**
+boolean
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+정렬을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | Alignment의 값. |
+
+### setAlternativeTextDescription(String value) {#setAlternativeTextDescription-java.lang.String-}
+```
+public final void setAlternativeTextDescription(String value)
+```
+
+
+첨부 파일 아이콘에 대한 본문 대체 텍스트를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setAlternativeTextTitle(String value) {#setAlternativeTextTitle-java.lang.String-}
+```
+public final void setAlternativeTextTitle(String value)
+```
+
+
+첨부 파일 아이콘에 대한 대체 텍스트의 제목을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setHorizontalOffset(float value) {#setHorizontalOffset-float-}
+```
+public void setHorizontalOffset(float value)
+```
+
+
+수평 오프셋을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | Offsets의 값. |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+마지막 수정 시간을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Date | Date의 값. |
+
+### setMaxHeight(float value) {#setMaxHeight-float-}
+```
+public void setMaxHeight(float value)
+```
+
+
+삽입된 파일 아이콘을 표시하기 위한 최대 높이를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | Maximum height의 값. |
+
+### setMaxWidth(float value) {#setMaxWidth-float-}
+```
+public void setMaxWidth(float value)
+```
+
+
+삽입된 파일 아이콘을 표시하기 위한 최대 너비를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | Maximum width의 값. |
+
+### setPrintout(boolean value) {#setPrintout-boolean-}
+```
+public void setPrintout(boolean value)
+```
+
+
+파일 보기 방식이 인쇄물인지 여부를 나타내는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 새 값. |
+
+### setSizeSetByUser(boolean value) {#setSizeSetByUser-boolean-}
+```
+public void setSizeSetByUser(boolean value)
+```
+
+
+아이콘 크기 값이 사용자가 명시적으로 업데이트했는지 여부를 나타내는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 새 값. |
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public void setText(String value)
+```
+
+
+임베드된 파일의 텍스트 표현을 설정합니다. 문자열은 값 10(줄 바꿈) 또는 13(캐리지 리턴)의 문자를 절대 포함해서는 안 됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | Text의 값. |
+
+### setVerticalOffset(float value) {#setVerticalOffset-float-}
+```
+public void setVerticalOffset(float value)
+```
+
+
+수직 오프셋을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | Offset의 값. |
+

--- a/korean/java/com.aspose.note/binarizationmethod/_index.md
+++ b/korean/java/com.aspose.note/binarizationmethod/_index.md
@@ -1,0 +1,38 @@
+---
+title: "BinarizationMethod"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "이미지에 대한 이진화 방법을 지정합니다."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.note/binarizationmethod/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class BinarizationMethod extends System.Enum
+```
+
+이미지에 대한 이진화 방법을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [FixedThreshold](#FixedThreshold) | 이미지의 이진화는 지정된 고정 임계값을 사용하여 수행됩니다. |
+| [Otsu](#Otsu) | 이미지의 이진화는 Otsu 방법을 사용하여 임계값을 평가하며 적응적으로 수행됩니다. |
+### FixedThreshold {#FixedThreshold}
+```
+public static final int FixedThreshold
+```
+
+
+이미지의 이진화는 지정된 고정 임계값을 사용하여 수행됩니다.
+
+### Otsu {#Otsu}
+```
+public static final int Otsu
+```
+
+
+이미지의 이진화는 Otsu 방법을 사용하여 임계값을 평가하며 적응적으로 수행됩니다.
+

--- a/korean/java/com.aspose.note/checkbox/_index.md
+++ b/korean/java/com.aspose.note/checkbox/_index.md
@@ -1,0 +1,131 @@
+---
+title: "CheckBox"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "완료와 미완료 상태를 전환할 수 있는 태그의 기본 클래스입니다."
+type: docs
+weight: 13
+url: /ko/java/com.aspose.note/checkbox/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.note.TagExtended
+```
+public abstract class CheckBox extends TagExtended
+```
+
+완료와 미완료 상태를 전환할 수 있는 태그의 기본 클래스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getChecked()](#getChecked--) | CheckBox가 선택된 상태인지 여부를 나타내는 값을 가져옵니다. |
+| [getCompletedTime()](#getCompletedTime--) | 완료 시간을 가져오거나 설정합니다. |
+| [getCreationTime()](#getCreationTime--) | 생성 시간을 가져오거나 설정합니다. |
+| [getIcon()](#getIcon--) | 아이콘을 가져오거나 설정합니다. |
+| [getStatus()](#getStatus--) | 상태를 가져오거나 설정합니다. |
+| [setCompleted()](#setCompleted--) | 현재 시간을 완료 시간으로 사용하여 태그를 완료 상태로 설정합니다. |
+| [setCompleted(Date completedTime)](#setCompleted-java.util.Date-) | 태그를 완료 상태로 설정합니다. |
+| [setCreationTime(Date value)](#setCreationTime-java.util.Date-) | 생성 시간을 가져오거나 설정합니다. |
+| [setOpen()](#setOpen--) | 태그를 열림 상태로 설정합니다. |
+### getChecked() {#getChecked--}
+```
+public final boolean getChecked()
+```
+
+
+CheckBox가 선택된 상태인지 여부를 나타내는 값을 가져옵니다.
+
+**Returns:**
+boolean
+### getCompletedTime() {#getCompletedTime--}
+```
+public final Date getCompletedTime()
+```
+
+
+완료 시간을 가져오거나 설정합니다.
+
+값: `Nullable{DateTime}`.
+
+**Returns:**
+java.util.Date
+### getCreationTime() {#getCreationTime--}
+```
+public final Date getCreationTime()
+```
+
+
+생성 시간을 가져오거나 설정합니다.
+
+값: java.util.Date입니다.
+
+**Returns:**
+java.util.Date
+### getIcon() {#getIcon--}
+```
+public abstract int getIcon()
+```
+
+
+아이콘을 가져오거나 설정합니다.
+
+값: [TagIcon](../../com.aspose.note.infrastructure/tagicon)입니다.
+
+**Returns:**
+int
+### getStatus() {#getStatus--}
+```
+public final int getStatus()
+```
+
+
+상태를 가져오거나 설정합니다.
+
+값: [TagStatus](../../com.aspose.note/tagstatus)입니다.
+
+**Returns:**
+int
+### setCompleted() {#setCompleted--}
+```
+public final void setCompleted()
+```
+
+
+현재 시간을 완료 시간으로 사용하여 태그를 완료 상태로 설정합니다.
+
+### setCompleted(Date completedTime) {#setCompleted-java.util.Date-}
+```
+public final void setCompleted(Date completedTime)
+```
+
+
+태그를 완료 상태로 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| completedTime | java.util.Date | 완료 시간입니다. |
+
+### setCreationTime(Date value) {#setCreationTime-java.util.Date-}
+```
+public final void setCreationTime(Date value)
+```
+
+
+생성 시간을 가져오거나 설정합니다.
+
+값: java.util.Date입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Date |  |
+
+### setOpen() {#setOpen--}
+```
+public void setOpen()
+```
+
+
+태그를 열림 상태로 설정합니다.
+

--- a/korean/java/com.aspose.note/colormode/_index.md
+++ b/korean/java/com.aspose.note/colormode/_index.md
@@ -1,0 +1,47 @@
+---
+title: "ColorMode"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "이미지의 색상 모드입니다."
+type: docs
+weight: 14
+url: /ko/java/com.aspose.note/colormode/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class ColorMode extends System.Enum
+```
+
+이미지의 색상 모드입니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BlackAndWhite](#BlackAndWhite) | 이진 이미지: 검은색과 흰색만 사용됩니다. |
+| [GrayScale](#GrayScale) | 그레이스케일 이미지 |
+| [Normal](#Normal) | 전체 색상 이미지 |
+### BlackAndWhite {#BlackAndWhite}
+```
+public static final int BlackAndWhite
+```
+
+
+이진 이미지: 검은색과 흰색만 사용됩니다.
+
+### GrayScale {#GrayScale}
+```
+public static final int GrayScale
+```
+
+
+그레이스케일 이미지
+
+### Normal {#Normal}
+```
+public static final int Normal
+```
+
+
+전체 색상 이미지
+

--- a/korean/java/com.aspose.note/compositenode/_index.md
+++ b/korean/java/com.aspose.note/compositenode/_index.md
@@ -1,0 +1,198 @@
+---
+title: "CompositeNode"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "다른 노드를 포함할 수 있는 노드의 기본 제네릭 클래스입니다."
+type: docs
+weight: 15
+url: /ko/java/com.aspose.note/compositenode/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase)
+
+**All Implemented Interfaces:**
+com.aspose.note.ICompositeNodeT
+```
+public abstract class CompositeNode<T> extends CompositeNodeBase implements ICompositeNodeT<T>
+```
+
+다른 노드를 포함할 수 있는 노드의 기본 제네릭 클래스입니다.
+
+`T`: 복합 노드의 요소 유형.
+
+T :
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [&lt;T1&gt;appendChildFirst(T1 newChild)](#-T1-appendChildFirst-T1-) | 이 노드의 자식 노드 목록 앞에 노드를 추가합니다. |
+| [&lt;T1&gt;appendChildLast(T1 newChild)](#-T1-appendChildLast-T1-) | 이 노드의 자식 노드 목록 끝에 노드를 추가합니다. |
+| [&lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass)](#-T1-getChildNodes-java.lang.Class-T1--) | 노드 유형별로 모든 자식 노드를 가져옵니다. |
+| [&lt;T1&gt;insertChild(int i, T1 newChild)](#-T1-insertChild-int-T1-) | 이 노드의 자식 노드 목록에서 지정된 위치에 노드를 삽입합니다. |
+| [&lt;T1&gt;removeChild(T1 oldChild)](#-T1-removeChild-T1-) | 자식 노드를 제거합니다. |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | 노드의 방문자를 수락합니다. |
+| [getFirstChild()](#getFirstChild--) | 이 노드의 첫 번째 자식 노드를 가져옵니다. |
+| [getLastChild()](#getLastChild--) | 이 노드의 마지막 자식 노드를 가져옵니다. |
+| [insertChildrenRange(int i, T[] newChildren)](#insertChildrenRange-int-T...-) | 이 노드의 자식 노드 목록에서 지정된 위치부터 노드 시퀀스를 삽입합니다. |
+| [insertChildrenRange(int i, Iterable&lt;T&gt; newChildren)](#insertChildrenRange-int-java.lang.Iterable-T--) | 이 노드의 자식 노드 목록에서 지정된 위치부터 노드 시퀀스를 삽입합니다. |
+| [isComposite()](#isComposite--) | 노드가 복합인지 확인합니다. |
+| [iterator()](#iterator--) | `CompositeNode\\{T\\}` 의 자식 노드를 반복하는 열거자를 반환합니다. |
+### &lt;T1&gt;appendChildFirst(T1 newChild) {#-T1-appendChildFirst-T1-}
+```
+public T1 <T1>appendChildFirst(T1 newChild)
+```
+
+
+이 노드의 자식 노드 목록 앞에 노드를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| newChild | T1 | 추가할 노드입니다. |
+
+**Returns:**
+T1 - 추가된 노드.
+### &lt;T1&gt;appendChildLast(T1 newChild) {#-T1-appendChildLast-T1-}
+```
+public T1 <T1>appendChildLast(T1 newChild)
+```
+
+
+이 노드의 자식 노드 목록 끝에 노드를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| newChild | T1 | 추가할 노드입니다. |
+
+**Returns:**
+T1 - 추가된 노드.
+### &lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass) {#-T1-getChildNodes-java.lang.Class-T1--}
+```
+public List<T1> <T1>getChildNodes(Class<T1> typeParameterClass)
+```
+
+
+노드 유형별로 모든 자식 노드를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| typeParameterClass | java.lang.Class&lt;T1&gt; |  |
+
+**Returns:**
+java.util.List&lt;T1&gt; - 자식 노드의 목록입니다.
+
+`T1`: 반환된 목록에 있는 요소의 유형입니다.
+### &lt;T1&gt;insertChild(int i, T1 newChild) {#-T1-insertChild-int-T1-}
+```
+public T1 <T1>insertChild(int i, T1 newChild)
+```
+
+
+이 노드의 자식 노드 목록에서 지정된 위치에 노드를 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| i | int | 삽입 위치 |
+| newChild | T1 | 삽입할 노드입니다. |
+
+**Returns:**
+T1 - 추가된 노드.
+### &lt;T1&gt;removeChild(T1 oldChild) {#-T1-removeChild-T1-}
+```
+public T1 <T1>removeChild(T1 oldChild)
+```
+
+
+자식 노드를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| oldChild | T1 | 제거할 노드입니다. |
+
+**Returns:**
+T1 - 제거된 노드.
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+노드의 방문자를 수락합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor`에서 파생된 클래스의 객체. |
+
+### getFirstChild() {#getFirstChild--}
+```
+public T getFirstChild()
+```
+
+
+이 노드의 첫 번째 자식 노드를 가져옵니다.
+
+**Returns:**
+T
+### getLastChild() {#getLastChild--}
+```
+public T getLastChild()
+```
+
+
+이 노드의 마지막 자식 노드를 가져옵니다.
+
+**Returns:**
+T
+### insertChildrenRange(int i, T[] newChildren) {#insertChildrenRange-int-T...-}
+```
+public final void insertChildrenRange(int i, T[] newChildren)
+```
+
+
+이 노드의 자식 노드 목록에서 지정된 위치부터 노드 시퀀스를 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| i | int | 삽입 위치 |
+| newChildren | T[] | 삽입될 노드 시퀀스입니다. |
+
+### insertChildrenRange(int i, Iterable&lt;T&gt; newChildren) {#insertChildrenRange-int-java.lang.Iterable-T--}
+```
+public final void insertChildrenRange(int i, Iterable<T> newChildren)
+```
+
+
+이 노드의 자식 노드 목록에서 지정된 위치부터 노드 시퀀스를 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| i | int | 삽입 위치 |
+| newChildren | java.lang.Iterable&lt;T&gt; | 삽입될 노드 시퀀스입니다. |
+
+### isComposite() {#isComposite--}
+```
+public final boolean isComposite()
+```
+
+
+노드가 복합인지 확인합니다. true인 경우 노드가 자식 노드를 가질 수 있습니다.
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public System.Collections.Generic.IGenericEnumerator<T> iterator()
+```
+
+
+`CompositeNode\\{T\\}` 의 자식 노드를 반복하는 열거자를 반환합니다.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;T&gt; - `CompositeNode\{T\}`에 대한 `T:IEnumerator`1`.

--- a/korean/java/com.aspose.note/compositenodebase/_index.md
+++ b/korean/java/com.aspose.note/compositenodebase/_index.md
@@ -1,0 +1,19 @@
+---
+title: "CompositeNodeBase"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "다른 노드를 포함할 수 있는 노드의 비제네릭 클래스입니다."
+type: docs
+weight: 16
+url: /ko/java/com.aspose.note/compositenodebase/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node)
+
+**All Implemented Interfaces:**
+[com.aspose.note.ICompositeNode](../../com.aspose.note/icompositenode)
+```
+public abstract class CompositeNodeBase extends Node implements ICompositeNode
+```
+
+다른 노드를 포함할 수 있는 노드의 비제네릭 클래스입니다.

--- a/korean/java/com.aspose.note/csssavingargs/_index.md
+++ b/korean/java/com.aspose.note/csssavingargs/_index.md
@@ -1,0 +1,16 @@
+---
+title: "CssSavingArgs"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "CssSaving 이벤트에 대한 데이터를 제공합니다."
+type: docs
+weight: 17
+url: /ko/java/com.aspose.note/csssavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ResourceSavingArgs](../../com.aspose.note/resourcesavingargs)
+```
+public class CssSavingArgs extends ResourceSavingArgs
+```
+
+CssSaving 이벤트에 대한 데이터를 제공합니다.

--- a/korean/java/com.aspose.note/defaultmsonenotevaluesaccessor/_index.md
+++ b/korean/java/com.aspose.note/defaultmsonenotevaluesaccessor/_index.md
@@ -1,0 +1,62 @@
+---
+title: "DefaultMsOneNoteValuesAccessor"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: 
+type: docs
+weight: 18
+url: /ko/java/com.aspose.note/defaultmsonenotevaluesaccessor/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.internals.Accessor](../../com.aspose.note.internals/accessor)
+```
+public class DefaultMsOneNoteValuesAccessor extends Accessor
+```
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DefaultMsOneNoteValuesAccessor()](#DefaultMsOneNoteValuesAccessor--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getDefaultFontColor()](#getDefaultFontColor--) |  |
+| [getDefaultFontFamily()](#getDefaultFontFamily--) |  |
+| [getDefaultFontSizeInPoints()](#getDefaultFontSizeInPoints--) |  |
+### DefaultMsOneNoteValuesAccessor() {#DefaultMsOneNoteValuesAccessor--}
+```
+public DefaultMsOneNoteValuesAccessor()
+```
+
+
+### getDefaultFontColor() {#getDefaultFontColor--}
+```
+public static System.Drawing.Color getDefaultFontColor()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Drawing.Color
+### getDefaultFontFamily() {#getDefaultFontFamily--}
+```
+public static String getDefaultFontFamily()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getDefaultFontSizeInPoints() {#getDefaultFontSizeInPoints--}
+```
+public static int getDefaultFontSizeInPoints()
+```
+
+
+
+
+**Returns:**
+int

--- a/korean/java/com.aspose.note/displayunitsconverter/_index.md
+++ b/korean/java/com.aspose.note/displayunitsconverter/_index.md
@@ -1,0 +1,118 @@
+---
+title: "DisplayUnitsConverter"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "이 클래스는 값 변환 메서드를 포함합니다."
+type: docs
+weight: 19
+url: /ko/java/com.aspose.note/displayunitsconverter/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DisplayUnitsConverter
+```
+
+이 클래스는 값 변환 메서드를 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [inchToPoint(float inches)](#inchToPoint-float-) | 인치를 포인트로 변환합니다. |
+| [millimeterToInch(float mm)](#millimeterToInch-float-) | 밀리미터를 인치로 변환합니다. |
+| [millimeterToPoint(float mm)](#millimeterToPoint-float-) | 밀리미터를 포인트로 변환합니다. |
+| [pixelToPoint(int pixels, float dpi)](#pixelToPoint-int-float-) | 지정된 픽셀 해상도에서 픽셀을 포인트로 변환합니다. |
+| [pointToInch(float points)](#pointToInch-float-) | 포인트를 인치로 변환합니다. |
+| [pointToPixel(float points, float dpi)](#pointToPixel-float-float-) | 지정된 픽셀 해상도에서 포인트를 픽셀로 변환합니다. |
+### inchToPoint(float inches) {#inchToPoint-float-}
+```
+public static float inchToPoint(float inches)
+```
+
+
+인치를 포인트로 변환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인치 | float | 인치 단위로 변환할 값입니다. |
+
+**Returns:**
+float - `float` 값.
+### millimeterToInch(float mm) {#millimeterToInch-float-}
+```
+public static float millimeterToInch(float mm)
+```
+
+
+밀리미터를 인치로 변환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| mm | float | 밀리미터 단위로 변환할 값입니다. |
+
+**Returns:**
+float - `float` 값.
+### millimeterToPoint(float mm) {#millimeterToPoint-float-}
+```
+public static float millimeterToPoint(float mm)
+```
+
+
+밀리미터를 포인트로 변환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| mm | float | 밀리미터 단위로 변환할 값입니다. |
+
+**Returns:**
+float - `float` 값.
+### pixelToPoint(int pixels, float dpi) {#pixelToPoint-int-float-}
+```
+public static float pixelToPoint(int pixels, float dpi)
+```
+
+
+지정된 픽셀 해상도에서 픽셀을 포인트로 변환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 픽셀 | int | 픽셀 단위로 변환할 값입니다. |
+| dpi | float | 화면 해상도. |
+
+**Returns:**
+float - `int` 값.
+### pointToInch(float points) {#pointToInch-float-}
+```
+public static float pointToInch(float points)
+```
+
+
+포인트를 인치로 변환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 포인트 | float | 포인트 단위로 변환할 값입니다. |
+
+**Returns:**
+float - `float` 값.
+### pointToPixel(float points, float dpi) {#pointToPixel-float-float-}
+```
+public static int pointToPixel(float points, float dpi)
+```
+
+
+지정된 픽셀 해상도에서 포인트를 픽셀로 변환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 포인트 | float | 포인트 단위로 변환할 값입니다. |
+| dpi | float | 화면 해상도. |
+
+**Returns:**
+int - `int`입니다.

--- a/korean/java/com.aspose.note/document/_index.md
+++ b/korean/java/com.aspose.note/document/_index.md
@@ -1,0 +1,511 @@
+---
+title: "Document"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "Aspose.Note 문서를 나타냅니다."
+type: docs
+weight: 20
+url: /ko/java/com.aspose.note/document/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode
+
+**All Implemented Interfaces:**
+[com.aspose.note.INotebookChildNode](../../com.aspose.note/inotebookchildnode)
+```
+public class Document extends CompositeNode<Page> implements INotebookChildNode
+```
+
+Aspose.Note 문서를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Document()](#Document--) | 새 인스턴스를 초기화합니다 `Document` 클래스. |
+| [Document(String filePath)](#Document-java.lang.String-) | 새 인스턴스를 초기화합니다 `Document` 클래스. |
+| [Document(String filePath, LoadOptions loadOptions)](#Document-java.lang.String-com.aspose.note.LoadOptions-) | 새 인스턴스를 초기화합니다 `Document` 클래스. |
+| [Document(InputStream inStream)](#Document-java.io.InputStream-) | 새 인스턴스를 초기화합니다 `Document` 클래스. |
+| [Document(InputStream inStream, LoadOptions loadOptions)](#Document-java.io.InputStream-com.aspose.note.LoadOptions-) | 새 인스턴스를 초기화합니다 `Document` 클래스. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | 노드의 방문자를 수락합니다. |
+| [detectLayoutChanges()](#detectLayoutChanges--) | 이전 `DetectLayoutChanges` 호출 이후 문서 레이아웃에 발생한 모든 변경 사항을 감지합니다. |
+| [getAutomaticLayoutChangesDetectionEnabled()](#getAutomaticLayoutChangesDetectionEnabled--) | Aspose.Note가 레이아웃 변경 감지를 자동으로 수행하는지 여부를 나타내는 값을 가져옵니다. |
+| [getColor()](#getColor--) | 색상을 가져옵니다. |
+| [getCreationTime()](#getCreationTime--) | 생성 시간을 가져옵니다. |
+| [getDisplayName()](#getDisplayName--) | 표시 이름을 가져옵니다. |
+| [getFileFormat()](#getFileFormat--) | 파일 형식을 가져옵니다 (OneNote 2010, OneNote Online). |
+| [getGuid()](#getGuid--) | 객체의 전역 고유 ID를 가져옵니다. |
+| [getGuidInternal()](#getGuidInternal--) |  |
+| [getPageHistory(Page page)](#getPageHistory-com.aspose.note.Page-) | `PageHistory`를 가져옵니다. 이 객체는 문서에 표시된 각 페이지에 대한 전체 기록을 포함합니다(가장 오래된 것이 인덱스 0에 있습니다). |
+| [isEncrypted(InputStream stream, Document[] document)](#isEncrypted-java.io.InputStream-com.aspose.note.Document---) | 스트림에서 가져온 문서가 암호화되었는지 확인합니다. |
+| [isEncrypted(InputStream stream, LoadOptions options, Document[] document)](#isEncrypted-java.io.InputStream-com.aspose.note.LoadOptions-com.aspose.note.Document---) | 스트림에서 가져온 문서가 암호화되었는지 확인합니다. |
+| [isEncrypted(InputStream stream, String password, Document[] document)](#isEncrypted-java.io.InputStream-java.lang.String-com.aspose.note.Document---) | 스트림에서 가져온 문서가 암호화되었는지 확인합니다. |
+| [isEncrypted(String filePath, Document[] document)](#isEncrypted-java.lang.String-com.aspose.note.Document---) | 파일에서 가져온 문서가 암호화되었는지 확인합니다. |
+| [isEncrypted(String filePath, LoadOptions options, Document[] document)](#isEncrypted-java.lang.String-com.aspose.note.LoadOptions-com.aspose.note.Document---) | 파일에서 가져온 문서가 암호화되었는지 확인합니다. |
+| [isEncrypted(String filePath, String password, Document[] document)](#isEncrypted-java.lang.String-java.lang.String-com.aspose.note.Document---) | 파일에서 가져온 문서가 암호화되었는지 확인합니다. |
+| [print()](#print--) | 기본 프린터를 사용하여 문서를 인쇄합니다. |
+| [print(PrintOptions options)](#print-com.aspose.note.PrintOptions-) | 기본 프린터를 사용하여 문서를 인쇄합니다. |
+| [print(String printerName)](#print-java.lang.String-) | 기본 프린터를 사용하여 문서를 인쇄합니다. |
+| [print(AttributeSet printSettings)](#print-javax.print.attribute.AttributeSet-) | 기본 프린터를 사용하여 문서를 인쇄합니다. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | OneNote 문서를 스트림에 저장합니다. |
+| [save(OutputStream stream, SaveOptions options)](#save-java.io.OutputStream-com.aspose.note.SaveOptions-) | 지정된 저장 옵션을 사용하여 OneNote 문서를 스트림에 저장합니다. |
+| [save(OutputStream stream, int format)](#save-java.io.OutputStream-int-) | 지정된 형식으로 OneNote 문서를 스트림에 저장합니다. |
+| [save(String fileName)](#save-java.lang.String-) | OneNote 문서를 파일에 저장합니다. |
+| [save(String fileName, SaveOptions options)](#save-java.lang.String-com.aspose.note.SaveOptions-) | 지정된 저장 옵션을 사용하여 OneNote 문서를 파일에 저장합니다. |
+| [save(String fileName, int format)](#save-java.lang.String-int-) | 지정된 형식으로 OneNote 문서를 파일에 저장합니다. |
+| [setAutomaticLayoutChangesDetectionEnabled(boolean value)](#setAutomaticLayoutChangesDetectionEnabled-boolean-) | Aspose.Note가 레이아웃 변경을 자동으로 감지할지 여부를 나타내는 값을 설정합니다. |
+| [setColor(Color value)](#setColor-java.awt.Color-) | 색상을 설정합니다. |
+| [setCreationTime(Date value)](#setCreationTime-java.util.Date-) | 생성 시간을 설정합니다. |
+| [setDisplayName(String value)](#setDisplayName-java.lang.String-) | 표시 이름을 설정합니다. |
+### Document() {#Document--}
+```
+public Document()
+```
+
+
+`Document` 클래스의 새 인스턴스를 초기화합니다. 빈 OneNote 문서를 생성합니다.
+
+### Document(String filePath) {#Document-java.lang.String-}
+```
+public Document(String filePath)
+```
+
+
+`Document` 클래스의 새 인스턴스를 초기화합니다. 파일에서 기존 OneNote 문서를 엽니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| filePath | java.lang.String | 파일 경로. |
+
+### Document(String filePath, LoadOptions loadOptions) {#Document-java.lang.String-com.aspose.note.LoadOptions-}
+```
+public Document(String filePath, LoadOptions loadOptions)
+```
+
+
+`Document` 클래스의 새 인스턴스를 초기화합니다. 파일에서 기존 OneNote 문서를 엽니다. 암호화 비밀번호와 같은 추가 옵션을 지정할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| filePath | java.lang.String | 파일 경로. |
+| loadOptions | [LoadOptions](../../com.aspose.note/loadoptions) | 문서를 로드하는 데 사용되는 옵션입니다. null일 수 있습니다. |
+
+### Document(InputStream inStream) {#Document-java.io.InputStream-}
+```
+public Document(InputStream inStream)
+```
+
+
+`Document` 클래스의 새 인스턴스를 초기화합니다. 스트림에서 기존 OneNote 문서를 엽니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| inStream | java.io.InputStream | 스트림입니다. |
+
+### Document(InputStream inStream, LoadOptions loadOptions) {#Document-java.io.InputStream-com.aspose.note.LoadOptions-}
+```
+public Document(InputStream inStream, LoadOptions loadOptions)
+```
+
+
+`Document` 클래스의 새 인스턴스를 초기화합니다. 스트림에서 기존 OneNote 문서를 엽니다. 암호화 비밀번호와 같은 추가 옵션을 지정할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| inStream | java.io.InputStream | 스트림입니다. |
+| loadOptions | [LoadOptions](../../com.aspose.note/loadoptions) | 문서를 로드하는 데 사용되는 옵션입니다. null일 수 있습니다. |
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+노드의 방문자를 수락합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor`에서 파생된 클래스의 객체. |
+
+### detectLayoutChanges() {#detectLayoutChanges--}
+```
+public void detectLayoutChanges()
+```
+
+
+이전 `DetectLayoutChanges` 호출 이후 문서 레이아웃에 발생한 모든 변경 사항을 감지합니다. `AutomaticLayoutChangesDetectionEnabled`가 true로 설정된 경우, 문서 내보내기 시작 시 자동으로 사용됩니다.
+
+### getAutomaticLayoutChangesDetectionEnabled() {#getAutomaticLayoutChangesDetectionEnabled--}
+```
+public boolean getAutomaticLayoutChangesDetectionEnabled()
+```
+
+
+Aspose.Note가 레이아웃 변경을 자동으로 감지할지 여부를 나타내는 값을 가져옵니다. 기본값은 `true`입니다.
+
+**Returns:**
+boolean
+### getColor() {#getColor--}
+```
+public Color getColor()
+```
+
+
+색상을 가져옵니다.
+
+**Returns:**
+java.awt.Color
+### getCreationTime() {#getCreationTime--}
+```
+public Date getCreationTime()
+```
+
+
+생성 시간을 가져옵니다.
+
+**Returns:**
+java.util.Date
+### getDisplayName() {#getDisplayName--}
+```
+public String getDisplayName()
+```
+
+
+표시 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getFileFormat() {#getFileFormat--}
+```
+public int getFileFormat()
+```
+
+
+파일 형식을 가져옵니다 (OneNote 2010, OneNote Online).
+
+**Returns:**
+int
+### getGuid() {#getGuid--}
+```
+public UUID getGuid()
+```
+
+
+객체의 전역 고유 ID를 가져옵니다.
+
+**Returns:**
+java.util.UUID
+### getGuidInternal() {#getGuidInternal--}
+```
+public System.Guid getGuidInternal()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Guid
+### getPageHistory(Page page) {#getPageHistory-com.aspose.note.Page-}
+```
+public PageHistory getPageHistory(Page page)
+```
+
+
+`PageHistory`를 가져옵니다. 이 객체는 문서에 표시된 각 페이지에 대한 전체 기록을 포함합니다(가장 오래된 것이 인덱스 0에 있습니다). 현재 페이지 리비전은 `PageHistory.current`로 접근할 수 있으며, 과거 버전 컬렉션과 별도로 포함됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.note/page) | 페이지의 현재 리비전입니다. |
+
+**Returns:**
+[PageHistory](../../com.aspose.note/pagehistory) - The `PageHistory`.
+### isEncrypted(InputStream stream, Document[] document) {#isEncrypted-java.io.InputStream-com.aspose.note.Document---}
+```
+public static boolean isEncrypted(InputStream stream, Document[] document)
+```
+
+
+스트림에서 가져온 문서가 암호화되었는지 확인합니다. 확인하려면 문서를 완전히 로드해야 합니다. 따라서 이 메서드는 성능 저하를 초래할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.InputStream | 스트림입니다. |
+| document | [Document\[\]](../../com.aspose.note/document) | 로드된 문서입니다. |
+
+**Returns:**
+boolean - 문서가 암호화된 경우 true를 반환하고, 그렇지 않으면 false를 반환합니다.
+### isEncrypted(InputStream stream, LoadOptions options, Document[] document) {#isEncrypted-java.io.InputStream-com.aspose.note.LoadOptions-com.aspose.note.Document---}
+```
+public static boolean isEncrypted(InputStream stream, LoadOptions options, Document[] document)
+```
+
+
+스트림에서 가져온 문서가 암호화되었는지 확인합니다. 확인하려면 문서를 완전히 로드해야 합니다. 따라서 이 메서드는 성능 저하를 초래할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.InputStream | 스트림입니다. |
+| options | [LoadOptions](../../com.aspose.note/loadoptions) | 로드 옵션입니다. |
+| document | [Document\[\]](../../com.aspose.note/document) | 로드된 문서입니다. |
+
+**Returns:**
+boolean - 문서가 암호화된 경우 true를 반환하고, 그렇지 않으면 false를 반환합니다.
+### isEncrypted(InputStream stream, String password, Document[] document) {#isEncrypted-java.io.InputStream-java.lang.String-com.aspose.note.Document---}
+```
+public static boolean isEncrypted(InputStream stream, String password, Document[] document)
+```
+
+
+스트림에서 가져온 문서가 암호화되었는지 확인합니다. 확인하려면 문서를 완전히 로드해야 합니다. 따라서 이 메서드는 성능 저하를 초래할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.InputStream | 스트림입니다. |
+| password | java.lang.String | 문서를 복호화하기 위한 비밀번호입니다. |
+| document | [Document\[\]](../../com.aspose.note/document) | 로드된 문서입니다. |
+
+**Returns:**
+boolean - 문서가 암호화된 경우 true를 반환하고, 그렇지 않으면 false를 반환합니다.
+### isEncrypted(String filePath, Document[] document) {#isEncrypted-java.lang.String-com.aspose.note.Document---}
+```
+public static boolean isEncrypted(String filePath, Document[] document)
+```
+
+
+파일에서 가져온 문서가 암호화되었는지 확인합니다. 확인하려면 문서를 완전히 로드해야 합니다. 따라서 이 메서드는 성능 저하를 초래할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| filePath | java.lang.String | 파일 경로. |
+| document | [Document\[\]](../../com.aspose.note/document) | 로드된 문서입니다. |
+
+**Returns:**
+boolean - 문서가 암호화된 경우 true를 반환하고, 그렇지 않으면 false를 반환합니다.
+### isEncrypted(String filePath, LoadOptions options, Document[] document) {#isEncrypted-java.lang.String-com.aspose.note.LoadOptions-com.aspose.note.Document---}
+```
+public static boolean isEncrypted(String filePath, LoadOptions options, Document[] document)
+```
+
+
+파일에서 가져온 문서가 암호화되었는지 확인합니다. 확인하려면 문서를 완전히 로드해야 합니다. 따라서 이 메서드는 성능 저하를 초래할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| filePath | java.lang.String | 파일 경로. |
+| options | [LoadOptions](../../com.aspose.note/loadoptions) | 로드 옵션입니다. |
+| document | [Document\[\]](../../com.aspose.note/document) | 로드된 문서입니다. |
+
+**Returns:**
+boolean - 문서가 암호화된 경우 true를 반환하고, 그렇지 않으면 false를 반환합니다.
+### isEncrypted(String filePath, String password, Document[] document) {#isEncrypted-java.lang.String-java.lang.String-com.aspose.note.Document---}
+```
+public static boolean isEncrypted(String filePath, String password, Document[] document)
+```
+
+
+파일에서 가져온 문서가 암호화되었는지 확인합니다. 확인하려면 문서를 완전히 로드해야 합니다. 따라서 이 메서드는 성능 저하를 초래할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| filePath | java.lang.String | 파일 경로. |
+| password | java.lang.String | 문서를 복호화하기 위한 비밀번호입니다. |
+| document | [Document\[\]](../../com.aspose.note/document) | 로드된 문서입니다. |
+
+**Returns:**
+boolean - 문서가 암호화된 경우 true를 반환하고, 그렇지 않으면 false를 반환합니다.
+### print() {#print--}
+```
+public void print()
+```
+
+
+기본 프린터를 사용하여 문서를 인쇄합니다.
+
+### print(PrintOptions options) {#print-com.aspose.note.PrintOptions-}
+```
+public void print(PrintOptions options)
+```
+
+
+기본 프린터를 사용하여 문서를 인쇄합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [PrintOptions](../../com.aspose.note/printoptions) | 문서를 인쇄하는 데 사용되는 옵션입니다. null일 수 있습니다. |
+
+### print(String printerName) {#print-java.lang.String-}
+```
+public void print(String printerName)
+```
+
+
+기본 프린터를 사용하여 문서를 인쇄합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| printerName | java.lang.String |  |
+
+### print(AttributeSet printSettings) {#print-javax.print.attribute.AttributeSet-}
+```
+public void print(AttributeSet printSettings)
+```
+
+
+기본 프린터를 사용하여 문서를 인쇄합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| printSettings | javax.print.attribute.AttributeSet |  |
+
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+OneNote 문서를 스트림에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.OutputStream | 문서가 저장될 System.iO.stream입니다. |
+
+### save(OutputStream stream, SaveOptions options) {#save-java.io.OutputStream-com.aspose.note.SaveOptions-}
+```
+public void save(OutputStream stream, SaveOptions options)
+```
+
+
+지정된 저장 옵션을 사용하여 OneNote 문서를 스트림에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.OutputStream | 문서가 저장될 System.iO.stream입니다. |
+| options | [SaveOptions](../../com.aspose.note/saveoptions) | 문서가 스트림에 저장되는 방식을 지정하는 옵션입니다. |
+
+### save(OutputStream stream, int format) {#save-java.io.OutputStream-int-}
+```
+public void save(OutputStream stream, int format)
+```
+
+
+지정된 형식으로 OneNote 문서를 스트림에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.OutputStream | 문서가 저장될 System.iO.stream입니다. |
+| format | int | 문서를 저장할 형식. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+OneNote 문서를 파일에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 파일이름 | java.lang.String | 파일의 전체 이름입니다. 지정된 전체 이름을 가진 파일이 이미 존재하면 기존 파일이 덮어쓰기됩니다. |
+
+### save(String fileName, SaveOptions options) {#save-java.lang.String-com.aspose.note.SaveOptions-}
+```
+public void save(String fileName, SaveOptions options)
+```
+
+
+지정된 저장 옵션을 사용하여 OneNote 문서를 파일에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 파일이름 | java.lang.String | 파일의 전체 이름입니다. 지정된 전체 이름을 가진 파일이 이미 존재하면 기존 파일이 덮어쓰기됩니다. |
+| options | [SaveOptions](../../com.aspose.note/saveoptions) | 문서가 파일에 저장되는 옵션을 지정합니다. |
+
+### save(String fileName, int format) {#save-java.lang.String-int-}
+```
+public void save(String fileName, int format)
+```
+
+
+지정된 형식으로 OneNote 문서를 파일에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 파일이름 | java.lang.String | 파일의 전체 이름입니다. 지정된 전체 이름을 가진 파일이 이미 존재하면 기존 파일이 덮어쓰기됩니다. |
+| format | int | 문서를 저장할 형식. |
+
+### setAutomaticLayoutChangesDetectionEnabled(boolean value) {#setAutomaticLayoutChangesDetectionEnabled-boolean-}
+```
+public void setAutomaticLayoutChangesDetectionEnabled(boolean value)
+```
+
+
+Aspose.Note가 레이아웃 변경을 자동으로 감지할지 여부를 나타내는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 새 값입니다. null일 수 있습니다. |
+
+### setColor(Color value) {#setColor-java.awt.Color-}
+```
+public void setColor(Color value)
+```
+
+
+색상을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.Color | Color의 값입니다. |
+
+### setCreationTime(Date value) {#setCreationTime-java.util.Date-}
+```
+public void setCreationTime(Date value)
+```
+
+
+생성 시간을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Date | DateTime의 값입니다. |
+
+### setDisplayName(String value) {#setDisplayName-java.lang.String-}
+```
+public void setDisplayName(String value)
+```
+
+
+표시 이름을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | DateTime의 값입니다. |
+

--- a/korean/java/com.aspose.note/documentprintattributeset/_index.md
+++ b/korean/java/com.aspose.note/documentprintattributeset/_index.md
@@ -1,0 +1,223 @@
+---
+title: "DocumentPrintAttributeSet"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "AttributeSet과 함께 사용자 친화적인 인터페이스를 제공하는 도우미 클래스를 나타냅니다."
+type: docs
+weight: 21
+url: /ko/java/com.aspose.note/documentprintattributeset/
+---
+
+**Inheritance:**
+java.lang.Object, javax.print.attribute.HashAttributeSet
+```
+public final class DocumentPrintAttributeSet extends HashAttributeSet
+```
+
+AttributeSet과 함께 사용자 친화적인 인터페이스를 제공하는 도우미 클래스를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentPrintAttributeSet(int copies)](#DocumentPrintAttributeSet-int-) | 새 인스턴스 `DocumentPrintAttributeSet`를 초기화합니다. |
+| [DocumentPrintAttributeSet(String printerName, int copies)](#DocumentPrintAttributeSet-java.lang.String-int-) | 새 인스턴스 `DocumentPrintAttributeSet`를 초기화합니다. |
+| [DocumentPrintAttributeSet(String printerName)](#DocumentPrintAttributeSet-java.lang.String-) | 새 인스턴스 `DocumentPrintAttributeSet`를 초기화합니다. |
+| [DocumentPrintAttributeSet()](#DocumentPrintAttributeSet--) | 새 인스턴스 `DocumentPrintAttributeSet`를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getCopies()](#getCopies--) |  |
+| [getLandscape()](#getLandscape--) |  |
+| [getPrinterName()](#getPrinterName--) |  |
+| [setCollate(boolean value)](#setCollate-boolean-) | 문서가 정렬되는지 여부를 나타내는 값을 설정합니다. |
+| [setCopies(int value)](#setCopies-int-) | 인쇄할 복사본 수를 설정합니다. |
+| [setDuplex(boolean value)](#setDuplex-boolean-) | 양면 인쇄를 위한 프린터 설정을 설정합니다. |
+| [setLandscape(boolean value)](#setLandscape-boolean-) | 페이지 방향을 설정합니다. |
+| [setPrintRange(int page)](#setPrintRange-int-) | 인쇄할 단일 페이지를 설정합니다. |
+| [setPrintRange(int from, int to)](#setPrintRange-int-int-) | 인쇄할 페이지 범위를 설정합니다. |
+| [setPrinterName(String printerName)](#setPrinterName-java.lang.String-) | 사용할 프린터의 이름입니다. |
+| [setPrinterName(String printerName, Locale locale)](#setPrinterName-java.lang.String-java.util.Locale-) | 사용할 프린터의 이름입니다. |
+### DocumentPrintAttributeSet(int copies) {#DocumentPrintAttributeSet-int-}
+```
+public DocumentPrintAttributeSet(int copies)
+```
+
+
+새 인스턴스 `DocumentPrintAttributeSet`를 초기화합니다. 기본적으로 문서의 모든 페이지가 인쇄됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 복사본 | int | 인쇄할 문서 복사본 수입니다. |
+
+### DocumentPrintAttributeSet(String printerName, int copies) {#DocumentPrintAttributeSet-java.lang.String-int-}
+```
+public DocumentPrintAttributeSet(String printerName, int copies)
+```
+
+
+새 인스턴스 `DocumentPrintAttributeSet`를 초기화합니다. 기본적으로 문서의 모든 페이지가 인쇄됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| printerName | java.lang.String | 프린터 이름입니다. |
+| 복사본 | int | 인쇄할 문서 복사본 수입니다. |
+
+### DocumentPrintAttributeSet(String printerName) {#DocumentPrintAttributeSet-java.lang.String-}
+```
+public DocumentPrintAttributeSet(String printerName)
+```
+
+
+새 인스턴스 `DocumentPrintAttributeSet`를 초기화합니다. 기본적으로 각 페이지당 한 부만 인쇄됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| printerName | java.lang.String | 프린터 이름입니다. |
+
+### DocumentPrintAttributeSet() {#DocumentPrintAttributeSet--}
+```
+public DocumentPrintAttributeSet()
+```
+
+
+새 인스턴스 `DocumentPrintAttributeSet`를 초기화합니다. 기본적으로 각 페이지당 한 부만 인쇄됩니다.
+
+### getCopies() {#getCopies--}
+```
+public int getCopies()
+```
+
+
+
+
+**Returns:**
+int
+### getLandscape() {#getLandscape--}
+```
+public boolean getLandscape()
+```
+
+
+
+
+**Returns:**
+boolean
+### getPrinterName() {#getPrinterName--}
+```
+public String getPrinterName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### setCollate(boolean value) {#setCollate-boolean-}
+```
+public void setCollate(boolean value)
+```
+
+
+문서가 정렬되는지 여부를 나타내는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | true는 SheetCollate.COLLATED 설정과 동일하고 false는 SheetCollate.UNCOLLATED 설정과 동일합니다. |
+
+### setCopies(int value) {#setCopies-int-}
+```
+public void setCopies(int value)
+```
+
+
+인쇄할 복사본 수를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 인쇄할 복사본 수입니다. |
+
+### setDuplex(boolean value) {#setDuplex-boolean-}
+```
+public void setDuplex(boolean value)
+```
+
+
+양면 인쇄를 위한 프린터 설정을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | true는 Sides.DUPLEX 설정과 동일하고 false는 Sides.ONE\_SIDED 설정과 동일합니다. |
+
+### setLandscape(boolean value) {#setLandscape-boolean-}
+```
+public void setLandscape(boolean value)
+```
+
+
+페이지 방향을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | true는 OrientationRequested.LANDSCAPE 설정과 동일하고 false는 OrientationRequested.PORTRAIT 설정과 동일합니다. |
+
+### setPrintRange(int page) {#setPrintRange-int-}
+```
+public void setPrintRange(int page)
+```
+
+
+인쇄할 단일 페이지를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 페이지 | int | 인쇄할 페이지입니다. |
+
+### setPrintRange(int from, int to) {#setPrintRange-int-int-}
+```
+public void setPrintRange(int from, int to)
+```
+
+
+인쇄할 페이지 범위를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 부터 | int | 첫 번째 페이지입니다. |
+| 까지 | int | 마지막 페이지. |
+
+### setPrinterName(String printerName) {#setPrinterName-java.lang.String-}
+```
+public void setPrinterName(String printerName)
+```
+
+
+사용할 프린터의 이름입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| printerName | java.lang.String | 프린터 이름입니다. |
+
+### setPrinterName(String printerName, Locale locale) {#setPrinterName-java.lang.String-java.util.Locale-}
+```
+public void setPrinterName(String printerName, Locale locale)
+```
+
+
+사용할 프린터의 이름입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| printerName | java.lang.String | 프린터 이름입니다. |
+| locale | java.util.Locale | printerName의 로케일. |
+

--- a/korean/java/com.aspose.note/documentvisitor/_index.md
+++ b/korean/java/com.aspose.note/documentvisitor/_index.md
@@ -1,0 +1,479 @@
+---
+title: "DocumentVisitor"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "지정된 노드를 루트로 하는 서브트리를 순회하기 위한 추상 클래스입니다."
+type: docs
+weight: 22
+url: /ko/java/com.aspose.note/documentvisitor/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class DocumentVisitor
+```
+
+지정된 노드를 루트로 하는 서브트리를 순회하기 위한 추상 클래스입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentVisitor()](#DocumentVisitor--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [visitAttachedFileEnd(AttachedFile attachedFile)](#visitAttachedFileEnd-com.aspose.note.AttachedFile-) | `AttachedFile` 노드 방문을 종료합니다. |
+| [visitAttachedFileStart(AttachedFile attachedFile)](#visitAttachedFileStart-com.aspose.note.AttachedFile-) | `AttachedFile` 노드 방문을 시작합니다. |
+| [visitDocumentEnd(Document document)](#visitDocumentEnd-com.aspose.note.Document-) | `Document` 노드 방문을 종료합니다. |
+| [visitDocumentStart(Document document)](#visitDocumentStart-com.aspose.note.Document-) | `Document` 노드 방문을 시작합니다. |
+| [visitImageEnd(Image image)](#visitImageEnd-com.aspose.note.Image-) | `Image` 노드 방문을 종료합니다. |
+| [visitImageStart(Image image)](#visitImageStart-com.aspose.note.Image-) | `Image` 노드 방문을 시작합니다. |
+| [visitInkDrawingEnd(InkDrawing inkDrawing)](#visitInkDrawingEnd-com.aspose.note.InkDrawing-) | [InkDrawing](../../com.aspose.note/inkdrawing) 노드 방문을 종료합니다. |
+| [visitInkDrawingStart(InkDrawing inkDrawing)](#visitInkDrawingStart-com.aspose.note.InkDrawing-) | [InkDrawing](../../com.aspose.note/inkdrawing) 노드 방문을 시작합니다. |
+| [visitInkParagraphEnd(InkParagraph inkParagraph)](#visitInkParagraphEnd-com.aspose.note.InkParagraph-) | [InkParagraph](../../com.aspose.note/inkparagraph) 노드 방문을 종료합니다. |
+| [visitInkParagraphStart(InkParagraph inkParagraph)](#visitInkParagraphStart-com.aspose.note.InkParagraph-) | [InkParagraph](../../com.aspose.note/inkparagraph) 노드 방문을 시작합니다. |
+| [visitInkWordEnd(InkWord inkWord)](#visitInkWordEnd-com.aspose.note.InkWord-) | [InkWord](../../com.aspose.note/inkword) 노드 방문을 종료합니다. |
+| [visitInkWordStart(InkWord inkWord)](#visitInkWordStart-com.aspose.note.InkWord-) | [InkWord](../../com.aspose.note/inkword) 노드 방문을 시작합니다. |
+| [visitLoopEnd(Loop loop)](#visitLoopEnd-com.aspose.note.Loop-) | [Loop](../../com.aspose.note/loop) 노드 방문을 종료합니다. |
+| [visitLoopStart(Loop loop)](#visitLoopStart-com.aspose.note.Loop-) | [Loop](../../com.aspose.note/loop) 노드 방문을 시작합니다. |
+| [visitOutlineElementEnd(OutlineElement outlineElement)](#visitOutlineElementEnd-com.aspose.note.OutlineElement-) | `OutlineElement` 노드 방문을 종료합니다. |
+| [visitOutlineElementStart(OutlineElement outlineElement)](#visitOutlineElementStart-com.aspose.note.OutlineElement-) | `OutlineElement` 노드 방문을 시작합니다. |
+| [visitOutlineEnd(Outline outline)](#visitOutlineEnd-com.aspose.note.Outline-) | `Outline` 노드 방문을 종료합니다. |
+| [visitOutlineGroupEnd(OutlineGroup outlineGroup)](#visitOutlineGroupEnd-com.aspose.note.OutlineGroup-) | `OutlineGroup` 노드 방문을 종료합니다. |
+| [visitOutlineGroupStart(OutlineGroup outlineGroup)](#visitOutlineGroupStart-com.aspose.note.OutlineGroup-) | `OutlineGroup` 노드 방문을 시작합니다. |
+| [visitOutlineStart(Outline outline)](#visitOutlineStart-com.aspose.note.Outline-) | `Outline` 노드 방문을 시작합니다. |
+| [visitPageEnd(Page page)](#visitPageEnd-com.aspose.note.Page-) | `Page` 노드 방문을 종료합니다. |
+| [visitPageStart(Page page)](#visitPageStart-com.aspose.note.Page-) | `Page` 노드 방문을 시작합니다. |
+| [visitRichTextEnd(RichText richText)](#visitRichTextEnd-com.aspose.note.RichText-) | `RichText` 노드 방문을 종료합니다. |
+| [visitRichTextStart(RichText richText)](#visitRichTextStart-com.aspose.note.RichText-) | `RichText` 노드 방문을 시작합니다. |
+| [visitTableCellEnd(TableCell tableCell)](#visitTableCellEnd-com.aspose.note.TableCell-) | `TableCell` 노드 방문을 종료합니다. |
+| [visitTableCellStart(TableCell tableCell)](#visitTableCellStart-com.aspose.note.TableCell-) | `TableCell` 노드 방문을 시작합니다. |
+| [visitTableEnd(Table table)](#visitTableEnd-com.aspose.note.Table-) | `Table` 노드 방문을 종료합니다. |
+| [visitTableRowEnd(TableRow tableRow)](#visitTableRowEnd-com.aspose.note.TableRow-) | `TableRow` 노드 방문을 종료합니다. |
+| [visitTableRowStart(TableRow tableRow)](#visitTableRowStart-com.aspose.note.TableRow-) | `TableRow` 노드 방문을 시작합니다. |
+| [visitTableStart(Table table)](#visitTableStart-com.aspose.note.Table-) | `Table` 노드 방문을 시작합니다. |
+| [visitTitleEnd(Title title)](#visitTitleEnd-com.aspose.note.Title-) | `Title` 노드 방문을 종료합니다. |
+| [visitTitleStart(Title title)](#visitTitleStart-com.aspose.note.Title-) | `Title` 노드 방문을 시작합니다. |
+### DocumentVisitor() {#DocumentVisitor--}
+```
+public DocumentVisitor()
+```
+
+
+### visitAttachedFileEnd(AttachedFile attachedFile) {#visitAttachedFileEnd-com.aspose.note.AttachedFile-}
+```
+public void visitAttachedFileEnd(AttachedFile attachedFile)
+```
+
+
+`AttachedFile` 노드 방문을 종료합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| attachedFile | [AttachedFile](../../com.aspose.note/attachedfile) | `AttachedFile` 노드. |
+
+### visitAttachedFileStart(AttachedFile attachedFile) {#visitAttachedFileStart-com.aspose.note.AttachedFile-}
+```
+public void visitAttachedFileStart(AttachedFile attachedFile)
+```
+
+
+`AttachedFile` 노드 방문을 시작합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| attachedFile | [AttachedFile](../../com.aspose.note/attachedfile) | `AttachedFile` 노드. |
+
+### visitDocumentEnd(Document document) {#visitDocumentEnd-com.aspose.note.Document-}
+```
+public void visitDocumentEnd(Document document)
+```
+
+
+`Document` 노드 방문을 종료합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| document | [Document](../../com.aspose.note/document) | `Document` 노드. |
+
+### visitDocumentStart(Document document) {#visitDocumentStart-com.aspose.note.Document-}
+```
+public void visitDocumentStart(Document document)
+```
+
+
+`Document` 노드 방문을 시작합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| document | [Document](../../com.aspose.note/document) | `Document` 노드. |
+
+### visitImageEnd(Image image) {#visitImageEnd-com.aspose.note.Image-}
+```
+public void visitImageEnd(Image image)
+```
+
+
+`Image` 노드 방문을 종료합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| image | [Image](../../com.aspose.note/image) | `Image` 노드. |
+
+### visitImageStart(Image image) {#visitImageStart-com.aspose.note.Image-}
+```
+public void visitImageStart(Image image)
+```
+
+
+`Image` 노드 방문을 시작합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| image | [Image](../../com.aspose.note/image) | `Image` 노드. |
+
+### visitInkDrawingEnd(InkDrawing inkDrawing) {#visitInkDrawingEnd-com.aspose.note.InkDrawing-}
+```
+public void visitInkDrawingEnd(InkDrawing inkDrawing)
+```
+
+
+[InkDrawing](../../com.aspose.note/inkdrawing) 노드 방문을 종료합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| inkDrawing | [InkDrawing](../../com.aspose.note/inkdrawing) | [InkDrawing](../../com.aspose.note/inkdrawing) 노드. |
+
+### visitInkDrawingStart(InkDrawing inkDrawing) {#visitInkDrawingStart-com.aspose.note.InkDrawing-}
+```
+public void visitInkDrawingStart(InkDrawing inkDrawing)
+```
+
+
+[InkDrawing](../../com.aspose.note/inkdrawing) 노드 방문을 시작합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| inkDrawing | [InkDrawing](../../com.aspose.note/inkdrawing) | [InkDrawing](../../com.aspose.note/inkdrawing) 노드. |
+
+### visitInkParagraphEnd(InkParagraph inkParagraph) {#visitInkParagraphEnd-com.aspose.note.InkParagraph-}
+```
+public void visitInkParagraphEnd(InkParagraph inkParagraph)
+```
+
+
+[InkParagraph](../../com.aspose.note/inkparagraph) 노드 방문을 종료합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| inkParagraph | [InkParagraph](../../com.aspose.note/inkparagraph) | [InkParagraph](../../com.aspose.note/inkparagraph) 노드. |
+
+### visitInkParagraphStart(InkParagraph inkParagraph) {#visitInkParagraphStart-com.aspose.note.InkParagraph-}
+```
+public void visitInkParagraphStart(InkParagraph inkParagraph)
+```
+
+
+[InkParagraph](../../com.aspose.note/inkparagraph) 노드 방문을 시작합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| inkParagraph | [InkParagraph](../../com.aspose.note/inkparagraph) | [InkParagraph](../../com.aspose.note/inkparagraph) 노드. |
+
+### visitInkWordEnd(InkWord inkWord) {#visitInkWordEnd-com.aspose.note.InkWord-}
+```
+public void visitInkWordEnd(InkWord inkWord)
+```
+
+
+[InkWord](../../com.aspose.note/inkword) 노드 방문을 종료합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| inkWord | [InkWord](../../com.aspose.note/inkword) | [InkWord](../../com.aspose.note/inkword) 노드. |
+
+### visitInkWordStart(InkWord inkWord) {#visitInkWordStart-com.aspose.note.InkWord-}
+```
+public void visitInkWordStart(InkWord inkWord)
+```
+
+
+[InkWord](../../com.aspose.note/inkword) 노드 방문을 시작합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| inkWord | [InkWord](../../com.aspose.note/inkword) | [InkWord](../../com.aspose.note/inkword) 노드. |
+
+### visitLoopEnd(Loop loop) {#visitLoopEnd-com.aspose.note.Loop-}
+```
+public void visitLoopEnd(Loop loop)
+```
+
+
+[Loop](../../com.aspose.note/loop) 노드 방문을 종료합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| loop | [Loop](../../com.aspose.note/loop) | [Loop](../../com.aspose.note/loop) 노드. |
+
+### visitLoopStart(Loop loop) {#visitLoopStart-com.aspose.note.Loop-}
+```
+public void visitLoopStart(Loop loop)
+```
+
+
+[Loop](../../com.aspose.note/loop) 노드 방문을 시작합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| loop | [Loop](../../com.aspose.note/loop) | [Loop](../../com.aspose.note/loop) 노드. |
+
+### visitOutlineElementEnd(OutlineElement outlineElement) {#visitOutlineElementEnd-com.aspose.note.OutlineElement-}
+```
+public void visitOutlineElementEnd(OutlineElement outlineElement)
+```
+
+
+`OutlineElement` 노드 방문을 종료합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| outlineElement | [OutlineElement](../../com.aspose.note/outlineelement) | `OutlineElement` 노드. |
+
+### visitOutlineElementStart(OutlineElement outlineElement) {#visitOutlineElementStart-com.aspose.note.OutlineElement-}
+```
+public void visitOutlineElementStart(OutlineElement outlineElement)
+```
+
+
+`OutlineElement` 노드 방문을 시작합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| outlineElement | [OutlineElement](../../com.aspose.note/outlineelement) | `OutlineElement` 노드. |
+
+### visitOutlineEnd(Outline outline) {#visitOutlineEnd-com.aspose.note.Outline-}
+```
+public void visitOutlineEnd(Outline outline)
+```
+
+
+`Outline` 노드 방문을 종료합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| outline | [Outline](../../com.aspose.note/outline) | `Outline` 노드. |
+
+### visitOutlineGroupEnd(OutlineGroup outlineGroup) {#visitOutlineGroupEnd-com.aspose.note.OutlineGroup-}
+```
+public void visitOutlineGroupEnd(OutlineGroup outlineGroup)
+```
+
+
+`OutlineGroup` 노드 방문을 종료합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| outlineGroup | [OutlineGroup](../../com.aspose.note/outlinegroup) | `OutlineGroup` 노드. |
+
+### visitOutlineGroupStart(OutlineGroup outlineGroup) {#visitOutlineGroupStart-com.aspose.note.OutlineGroup-}
+```
+public void visitOutlineGroupStart(OutlineGroup outlineGroup)
+```
+
+
+`OutlineGroup` 노드 방문을 시작합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| outlineGroup | [OutlineGroup](../../com.aspose.note/outlinegroup) | `OutlineGroup` 노드. |
+
+### visitOutlineStart(Outline outline) {#visitOutlineStart-com.aspose.note.Outline-}
+```
+public void visitOutlineStart(Outline outline)
+```
+
+
+`Outline` 노드 방문을 시작합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| outline | [Outline](../../com.aspose.note/outline) | `Outline` 노드. |
+
+### visitPageEnd(Page page) {#visitPageEnd-com.aspose.note.Page-}
+```
+public void visitPageEnd(Page page)
+```
+
+
+`Page` 노드 방문을 종료합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.note/page) | `Page` 노드. |
+
+### visitPageStart(Page page) {#visitPageStart-com.aspose.note.Page-}
+```
+public void visitPageStart(Page page)
+```
+
+
+`Page` 노드 방문을 시작합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.note/page) | `Page` 노드. |
+
+### visitRichTextEnd(RichText richText) {#visitRichTextEnd-com.aspose.note.RichText-}
+```
+public void visitRichTextEnd(RichText richText)
+```
+
+
+`RichText` 노드 방문을 종료합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| richText | [RichText](../../com.aspose.note/richtext) | `RichText` 노드. |
+
+### visitRichTextStart(RichText richText) {#visitRichTextStart-com.aspose.note.RichText-}
+```
+public void visitRichTextStart(RichText richText)
+```
+
+
+`RichText` 노드 방문을 시작합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| richText | [RichText](../../com.aspose.note/richtext) | `RichText` 노드. |
+
+### visitTableCellEnd(TableCell tableCell) {#visitTableCellEnd-com.aspose.note.TableCell-}
+```
+public void visitTableCellEnd(TableCell tableCell)
+```
+
+
+`TableCell` 노드 방문을 종료합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| tableCell | [TableCell](../../com.aspose.note/tablecell) | `TableCell` 노드. |
+
+### visitTableCellStart(TableCell tableCell) {#visitTableCellStart-com.aspose.note.TableCell-}
+```
+public void visitTableCellStart(TableCell tableCell)
+```
+
+
+`TableCell` 노드 방문을 시작합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| tableCell | [TableCell](../../com.aspose.note/tablecell) | `TableCell` 노드. |
+
+### visitTableEnd(Table table) {#visitTableEnd-com.aspose.note.Table-}
+```
+public void visitTableEnd(Table table)
+```
+
+
+`Table` 노드 방문을 종료합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| table | [Table](../../com.aspose.note/table) | `Table` 노드. |
+
+### visitTableRowEnd(TableRow tableRow) {#visitTableRowEnd-com.aspose.note.TableRow-}
+```
+public void visitTableRowEnd(TableRow tableRow)
+```
+
+
+`TableRow` 노드 방문을 종료합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| tableRow | [TableRow](../../com.aspose.note/tablerow) | `TableRow` 노드. |
+
+### visitTableRowStart(TableRow tableRow) {#visitTableRowStart-com.aspose.note.TableRow-}
+```
+public void visitTableRowStart(TableRow tableRow)
+```
+
+
+`TableRow` 노드 방문을 시작합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| tableRow | [TableRow](../../com.aspose.note/tablerow) | `TableRow` 노드. |
+
+### visitTableStart(Table table) {#visitTableStart-com.aspose.note.Table-}
+```
+public void visitTableStart(Table table)
+```
+
+
+`Table` 노드 방문을 시작합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| table | [Table](../../com.aspose.note/table) | `Table` 노드. |
+
+### visitTitleEnd(Title title) {#visitTitleEnd-com.aspose.note.Title-}
+```
+public void visitTitleEnd(Title title)
+```
+
+
+`Title` 노드 방문을 종료합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| title | [Title](../../com.aspose.note/title) | `Title` 노드. |
+
+### visitTitleStart(Title title) {#visitTitleStart-com.aspose.note.Title-}
+```
+public void visitTitleStart(Title title)
+```
+
+
+`Title` 노드 방문을 시작합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| title | [Title](../../com.aspose.note/title) | `Title` 노드. |
+

--- a/korean/java/com.aspose.note/extendedapsdocument/_index.md
+++ b/korean/java/com.aspose.note/extendedapsdocument/_index.md
@@ -1,0 +1,97 @@
+---
+title: "ExtendedApsDocument"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "전체 one-note 문서를 나타내며, 페이지를 페이지 세트로 변환한 것입니다."
+type: docs
+weight: 23
+url: /ko/java/com.aspose.note/extendedapsdocument/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.foundation.rendering.ApsNode
+
+**All Implemented Interfaces:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerable
+```
+public class ExtendedApsDocument extends ApsNode implements System.Collections.Generic.IGenericEnumerable<ApsPage>
+```
+
+전체 OneNote 문서를 나타내며, 페이지를 페이지 세트로 변환하여 구성됩니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ExtendedApsDocument()](#ExtendedApsDocument--) | 새로운 `ExtendedApsDocument` 클래스 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [accept(ApsDocumentVisitor visitor)](#accept-com.aspose.foundation.rendering.ApsDocumentVisitor-) | 이 요소에 ApsDocumentVisitor를 수락합니다. |
+| [addPage(ApsPage page)](#addPage-com.aspose.foundation.rendering.ApsPage-) | 문서에 페이지 세트를 추가합니다. |
+| [getPageList()](#getPageList--) | 페이지 세트 목록을 가져옵니다. |
+| [iterator()](#iterator--) | 열거자를 반환합니다. |
+| [iterator_Rename_Namesake()](#iterator-Rename-Namesake--) |  |
+### ExtendedApsDocument() {#ExtendedApsDocument--}
+```
+public ExtendedApsDocument()
+```
+
+
+새로운 `ExtendedApsDocument` 클래스 인스턴스를 초기화합니다.
+
+### accept(ApsDocumentVisitor visitor) {#accept-com.aspose.foundation.rendering.ApsDocumentVisitor-}
+```
+public void accept(ApsDocumentVisitor visitor)
+```
+
+
+이 요소에 ApsDocumentVisitor를 수락합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 방문자 | com.aspose.foundation.rendering.ApsDocumentVisitor | 방문자. |
+
+### addPage(ApsPage page) {#addPage-com.aspose.foundation.rendering.ApsPage-}
+```
+public void addPage(ApsPage page)
+```
+
+
+문서에 페이지 세트를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 페이지 | com.aspose.foundation.rendering.ApsPage | 페이지 세트. |
+
+### getPageList() {#getPageList--}
+```
+public System.Collections.Generic.List<ApsPage> getPageList()
+```
+
+
+페이지 세트 목록을 가져옵니다.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List&lt;com.aspose.foundation.rendering.ApsPage&gt;
+### iterator() {#iterator--}
+```
+public System.Collections.Generic.IGenericEnumerator<ApsPage> iterator()
+```
+
+
+열거자를 반환합니다.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;com.aspose.foundation.rendering.ApsPage&gt;
+### iterator_Rename_Namesake() {#iterator-Rename-Namesake--}
+```
+public System.Collections.IEnumerator iterator_Rename_Namesake()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Collections.IEnumerator

--- a/korean/java/com.aspose.note/extendedapsglyphs/_index.md
+++ b/korean/java/com.aspose.note/extendedapsglyphs/_index.md
@@ -1,0 +1,135 @@
+---
+title: "ExtendedApsGlyphs"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "표준 ApsGlyphs에 대한 래퍼를 나타내며, 일부 그리기 동작을 확장합니다."
+type: docs
+weight: 24
+url: /ko/java/com.aspose.note/extendedapsglyphs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ExtendedApsNode](../../com.aspose.note/extendedapsnode)
+```
+public class ExtendedApsGlyphs extends ExtendedApsNode
+```
+
+표준 ApsGlyphs에 대한 래퍼를 나타내며, 일부 그리기 동작을 확장합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ExtendedApsGlyphs(ApsGlyphs internalGlyphs)](#ExtendedApsGlyphs-com.aspose.foundation.rendering.ApsGlyphs-) | 새 `ExtendedApsGlyphs` 클래스 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [addToCompositeNode(ApsCompositeNode compositeNode)](#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-) | 주어진 `compositeNode`에 이 노드를 추가합니다. |
+| [applyPlaneTransform(System.Drawing.PointF transformVector)](#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-) | 평면 변환을 적용하여 노드를 x 및 y 평면으로 이동시킵니다. |
+| [applyScaleTransform(float scaleTransform)](#applyScaleTransform-float-) | 글리프에 스케일링을 적용합니다. |
+| [getBottom()](#getBottom--) | 글리프의 하단을 가져옵니다. |
+| [getCopy()](#getCopy--) | 글리프의 복사본을 가져옵니다. |
+| [getOrigin()](#getOrigin--) | 원점을 가져옵니다. |
+| [getSize()](#getSize--) | 크기를 가져옵니다. |
+| [getTop()](#getTop--) | 상단을 가져옵니다. |
+### ExtendedApsGlyphs(ApsGlyphs internalGlyphs) {#ExtendedApsGlyphs-com.aspose.foundation.rendering.ApsGlyphs-}
+```
+public ExtendedApsGlyphs(ApsGlyphs internalGlyphs)
+```
+
+
+새 `ExtendedApsGlyphs` 클래스 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| internalGlyphs | com.aspose.foundation.rendering.ApsGlyphs | 원본 aps 글리프입니다. |
+
+### addToCompositeNode(ApsCompositeNode compositeNode) {#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-}
+```
+public void addToCompositeNode(ApsCompositeNode compositeNode)
+```
+
+
+주어진 `compositeNode`에 이 노드를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| compositeNode | com.aspose.foundation.rendering.ApsCompositeNode |  |
+
+### applyPlaneTransform(System.Drawing.PointF transformVector) {#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-}
+```
+public void applyPlaneTransform(System.Drawing.PointF transformVector)
+```
+
+
+평면 변환을 적용하여 노드를 x 및 y 평면으로 이동시킵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| transformVector | com.aspose.ms.System.Drawing.PointF |  |
+
+### applyScaleTransform(float scaleTransform) {#applyScaleTransform-float-}
+```
+public void applyScaleTransform(float scaleTransform)
+```
+
+
+글리프에 스케일링을 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| scaleTransform | float | 변환에 대한 스케일 계수입니다. |
+
+### getBottom() {#getBottom--}
+```
+public float getBottom()
+```
+
+
+글리프의 하단을 가져옵니다.
+
+**Returns:**
+float
+### getCopy() {#getCopy--}
+```
+public ExtendedApsNode getCopy()
+```
+
+
+글리프의 복사본을 가져옵니다.
+
+**Returns:**
+[ExtendedApsNode](../../com.aspose.note/extendedapsnode) - The `IExtendedApsNode`.
+### getOrigin() {#getOrigin--}
+```
+public System.Drawing.PointF getOrigin()
+```
+
+
+원점을 가져옵니다.
+
+**Returns:**
+com.aspose.ms.System.Drawing.PointF
+### getSize() {#getSize--}
+```
+public System.Drawing.SizeF getSize()
+```
+
+
+크기를 가져옵니다.
+
+**Returns:**
+com.aspose.ms.System.Drawing.SizeF
+### getTop() {#getTop--}
+```
+public float getTop()
+```
+
+
+상단을 가져옵니다.
+
+**Returns:**
+float

--- a/korean/java/com.aspose.note/extendedapsimage/_index.md
+++ b/korean/java/com.aspose.note/extendedapsimage/_index.md
@@ -1,0 +1,146 @@
+---
+title: "ExtendedApsImage"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "표준 ApsImage를 래핑하며 일부 그리기 동작을 확장하는 래퍼를 나타냅니다."
+type: docs
+weight: 25
+url: /ko/java/com.aspose.note/extendedapsimage/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ExtendedApsNode](../../com.aspose.note/extendedapsnode)
+```
+public class ExtendedApsImage extends ExtendedApsNode
+```
+
+표준 ApsImage에 대한 래퍼를 나타내며, 일부 그리기 동작을 확장합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ExtendedApsImage(ApsImage internalImage)](#ExtendedApsImage-com.aspose.foundation.rendering.ApsImage-) | `ExtendedApsImage` 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [addToCompositeNode(ApsCompositeNode compositeNode)](#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-) | 주어진 `compositeNode`에 이 노드를 추가합니다. |
+| [applyPlaneTransform(System.Drawing.PointF transformVector)](#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-) | 평면 변환을 적용하여 노드를 x 및 y 평면으로 이동시킵니다. |
+| [applyScaleTransform(float scaleTransform)](#applyScaleTransform-float-) | 이미지에 스케일링을 적용합니다. |
+| [getBottom()](#getBottom--) | 하단 값을 가져옵니다. |
+| [getCopy()](#getCopy--) | 이 노드의 전체 복사본을 생성합니다. |
+| [getOrigin()](#getOrigin--) | 원점을 가져옵니다. |
+| [getSize()](#getSize--) | 크기를 가져옵니다. |
+| [getTop()](#getTop--) | 상단을 가져옵니다. |
+| [isBackground()](#isBackground--) | 이미지가 배경 이미지인지 여부를 가져옵니다. |
+### ExtendedApsImage(ApsImage internalImage) {#ExtendedApsImage-com.aspose.foundation.rendering.ApsImage-}
+```
+public ExtendedApsImage(ApsImage internalImage)
+```
+
+
+`ExtendedApsImage` 클래스의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| internalImage | com.aspose.foundation.rendering.ApsImage | 이미지. |
+
+### addToCompositeNode(ApsCompositeNode compositeNode) {#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-}
+```
+public void addToCompositeNode(ApsCompositeNode compositeNode)
+```
+
+
+주어진 `compositeNode`에 이 노드를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| compositeNode | com.aspose.foundation.rendering.ApsCompositeNode |  |
+
+### applyPlaneTransform(System.Drawing.PointF transformVector) {#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-}
+```
+public void applyPlaneTransform(System.Drawing.PointF transformVector)
+```
+
+
+평면 변환을 적용하여 노드를 x 및 y 평면으로 이동시킵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| transformVector | com.aspose.ms.System.Drawing.PointF |  |
+
+### applyScaleTransform(float scaleTransform) {#applyScaleTransform-float-}
+```
+public void applyScaleTransform(float scaleTransform)
+```
+
+
+이미지에 스케일링을 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| scaleTransform | float | 변환에 대한 스케일 계수입니다. |
+
+### getBottom() {#getBottom--}
+```
+public float getBottom()
+```
+
+
+하단 값을 가져옵니다.
+
+**Returns:**
+float
+### getCopy() {#getCopy--}
+```
+public ExtendedApsNode getCopy()
+```
+
+
+이 노드의 전체 복사본을 생성합니다.
+
+**Returns:**
+[ExtendedApsNode](../../com.aspose.note/extendedapsnode) - The `IExtendedApsNode`.
+### getOrigin() {#getOrigin--}
+```
+public System.Drawing.PointF getOrigin()
+```
+
+
+원점을 가져옵니다.
+
+**Returns:**
+com.aspose.ms.System.Drawing.PointF
+### getSize() {#getSize--}
+```
+public System.Drawing.SizeF getSize()
+```
+
+
+크기를 가져옵니다.
+
+**Returns:**
+com.aspose.ms.System.Drawing.SizeF
+### getTop() {#getTop--}
+```
+public float getTop()
+```
+
+
+상단을 가져옵니다.
+
+**Returns:**
+float
+### isBackground() {#isBackground--}
+```
+public final boolean isBackground()
+```
+
+
+이미지가 배경 이미지인지 여부를 가져옵니다.
+
+**Returns:**
+boolean

--- a/korean/java/com.aspose.note/extendedapsnode/_index.md
+++ b/korean/java/com.aspose.note/extendedapsnode/_index.md
@@ -1,0 +1,158 @@
+---
+title: "ExtendedApsNode"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "표준 ApsNode의 래퍼를 나타내며, 일부 그리기 동작을 확장합니다."
+type: docs
+weight: 26
+url: /ko/java/com.aspose.note/extendedapsnode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class ExtendedApsNode
+```
+
+표준 ApsNode에 대한 래퍼를 나타내며, 일부 그리기 동작을 확장합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ExtendedApsNode()](#ExtendedApsNode--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [addToCompositeNode(ApsCompositeNode compositeNode)](#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-) | 주어진 `compositeNode`에 이 노드를 추가합니다. |
+| [applyPlaneTransform(System.Drawing.PointF transformVector)](#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-) | 평면 변환을 적용하여 노드를 x 및 y 평면으로 이동시킵니다. |
+| [applyScaleTransform(float scaleTransform)](#applyScaleTransform-float-) | 노드에 스케일링을 적용합니다. |
+| [copyAttributes(ApsNode src, ApsNode dst)](#copyAttributes-com.aspose.foundation.rendering.ApsNode-com.aspose.foundation.rendering.ApsNode-) |  |
+| [copyAttributes(ApsNodeAttributes src, ApsNodeAttributes dst)](#copyAttributes-com.aspose.foundation.rendering.ApsNodeAttributes-com.aspose.foundation.rendering.ApsNodeAttributes-) |  |
+| [getBottom()](#getBottom--) | 노드 하단의 y 좌표를 가져오거나 설정합니다. |
+| [getCopy()](#getCopy--) | 이 노드의 전체 복사본을 생성합니다. |
+| [getOrigin()](#getOrigin--) | 노드의 원점을 가져오거나 설정합니다. |
+| [getSize()](#getSize--) | 노드의 크기를 가져오거나 설정합니다. |
+| [getTop()](#getTop--) | 노드 상단의 y 좌표를 가져오거나 설정합니다. |
+### ExtendedApsNode() {#ExtendedApsNode--}
+```
+public ExtendedApsNode()
+```
+
+
+### addToCompositeNode(ApsCompositeNode compositeNode) {#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-}
+```
+public abstract void addToCompositeNode(ApsCompositeNode compositeNode)
+```
+
+
+주어진 `compositeNode`에 이 노드를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| compositeNode | com.aspose.foundation.rendering.ApsCompositeNode |  |
+
+### applyPlaneTransform(System.Drawing.PointF transformVector) {#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-}
+```
+public abstract void applyPlaneTransform(System.Drawing.PointF transformVector)
+```
+
+
+평면 변환을 적용하여 노드를 x 및 y 평면으로 이동시킵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| transformVector | com.aspose.ms.System.Drawing.PointF |  |
+
+### applyScaleTransform(float scaleTransform) {#applyScaleTransform-float-}
+```
+public abstract void applyScaleTransform(float scaleTransform)
+```
+
+
+노드에 스케일링을 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| scaleTransform | float | 변환에 대한 스케일 계수입니다. |
+
+### copyAttributes(ApsNode src, ApsNode dst) {#copyAttributes-com.aspose.foundation.rendering.ApsNode-com.aspose.foundation.rendering.ApsNode-}
+```
+public static void copyAttributes(ApsNode src, ApsNode dst)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| src | com.aspose.foundation.rendering.ApsNode |  |
+| dst | com.aspose.foundation.rendering.ApsNode |  |
+
+### copyAttributes(ApsNodeAttributes src, ApsNodeAttributes dst) {#copyAttributes-com.aspose.foundation.rendering.ApsNodeAttributes-com.aspose.foundation.rendering.ApsNodeAttributes-}
+```
+public static void copyAttributes(ApsNodeAttributes src, ApsNodeAttributes dst)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| src | com.aspose.foundation.rendering.ApsNodeAttributes |  |
+| dst | com.aspose.foundation.rendering.ApsNodeAttributes |  |
+
+### getBottom() {#getBottom--}
+```
+public float getBottom()
+```
+
+
+노드 하단의 y 좌표를 가져오거나 설정합니다.
+
+**Returns:**
+float
+### getCopy() {#getCopy--}
+```
+public abstract ExtendedApsNode getCopy()
+```
+
+
+이 노드의 전체 복사본을 생성합니다.
+
+**Returns:**
+[ExtendedApsNode](../../com.aspose.note/extendedapsnode) - The `!:ExtendedApsNode`.
+### getOrigin() {#getOrigin--}
+```
+public System.Drawing.PointF getOrigin()
+```
+
+
+노드의 원점을 가져오거나 설정합니다.
+
+**Returns:**
+com.aspose.ms.System.Drawing.PointF
+### getSize() {#getSize--}
+```
+public System.Drawing.SizeF getSize()
+```
+
+
+노드의 크기를 가져오거나 설정합니다.
+
+**Returns:**
+com.aspose.ms.System.Drawing.SizeF
+### getTop() {#getTop--}
+```
+public float getTop()
+```
+
+
+노드 상단의 y 좌표를 가져오거나 설정합니다.
+
+**Returns:**
+float

--- a/korean/java/com.aspose.note/extendedapspage/_index.md
+++ b/korean/java/com.aspose.note/extendedapspage/_index.md
@@ -1,0 +1,120 @@
+---
+title: "ExtendedApsPage"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "표준 ApsGlyphs에 대한 래퍼를 나타내며, 일부 그리기 동작을 확장합니다."
+type: docs
+weight: 27
+url: /ko/java/com.aspose.note/extendedapspage/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.foundation.rendering.ApsNode, com.aspose.foundation.rendering.ApsCompositeNode, com.aspose.foundation.rendering.ApsPage
+
+**All Implemented Interfaces:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerable
+```
+public class ExtendedApsPage extends ApsPage implements System.Collections.Generic.IGenericEnumerable<ApsNode>
+```
+
+표준 ApsGlyphs에 대한 래퍼를 나타내며, 일부 그리기 동작을 확장합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ExtendedApsPage(System.Drawing.SizeF pageSize, float pageStartInNotePage, Margin margin)](#ExtendedApsPage-com.aspose.ms.System.Drawing.SizeF-float-com.aspose.foundation.layout.Margin-) | 새 `ExtendedApsPage` 클래스 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getContentSize()](#getContentSize--) | 여백을 제외한 페이지 크기를 가져옵니다. |
+| [getMargin()](#getMargin--) | 이 페이지의 여백을 가져옵니다. |
+| [getPageEndInNotePage()](#getPageEndInNotePage--) | MS OneNote 페이지가 여러 aps 페이지로 분할될 때, MS OneNote 페이지에서 페이지 끝 위치를 가져옵니다. |
+| [getPageSize()](#getPageSize--) | 최종 페이지 크기를 가져옵니다. |
+| [getPageStartInNotePage()](#getPageStartInNotePage--) | MS OneNote 페이지가 여러 aps 페이지로 분할될 때, MS OneNote 페이지에서 페이지 시작 위치를 가져옵니다. |
+| [iterator()](#iterator--) | 이 페이지의 모든 노드를 순회하는 열거자를 반환합니다. |
+| [iterator_Rename_Namesake()](#iterator-Rename-Namesake--) | 열거자를 가져옵니다. |
+### ExtendedApsPage(System.Drawing.SizeF pageSize, float pageStartInNotePage, Margin margin) {#ExtendedApsPage-com.aspose.ms.System.Drawing.SizeF-float-com.aspose.foundation.layout.Margin-}
+```
+public ExtendedApsPage(System.Drawing.SizeF pageSize, float pageStartInNotePage, Margin margin)
+```
+
+
+새 `ExtendedApsPage` 클래스 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| pageSize | com.aspose.ms.System.Drawing.SizeF | 페이지 크기입니다. |
+| pageStartInNotePage | float | 원본 MS OneNote 페이지에서 페이지 시작 위치입니다. |
+| margin | com.aspose.foundation.layout.Margin | 확장된 페이지 여백. |
+
+### getContentSize() {#getContentSize--}
+```
+public System.Drawing.SizeF getContentSize()
+```
+
+
+여백을 제외한 페이지 크기를 가져옵니다.
+
+**Returns:**
+com.aspose.ms.System.Drawing.SizeF
+### getMargin() {#getMargin--}
+```
+public Margin getMargin()
+```
+
+
+이 페이지의 여백을 가져옵니다.
+
+**Returns:**
+com.aspose.foundation.layout.Margin
+### getPageEndInNotePage() {#getPageEndInNotePage--}
+```
+public float getPageEndInNotePage()
+```
+
+
+MS OneNote 페이지가 여러 aps 페이지로 분할될 때, MS OneNote 페이지에서 페이지 끝 위치를 가져옵니다.
+
+**Returns:**
+float
+### getPageSize() {#getPageSize--}
+```
+public System.Drawing.SizeF getPageSize()
+```
+
+
+최종 페이지 크기를 가져옵니다.
+
+**Returns:**
+com.aspose.ms.System.Drawing.SizeF
+### getPageStartInNotePage() {#getPageStartInNotePage--}
+```
+public float getPageStartInNotePage()
+```
+
+
+MS OneNote 페이지가 여러 aps 페이지로 분할될 때, MS OneNote 페이지에서 페이지 시작 위치를 가져옵니다.
+
+**Returns:**
+float
+### iterator() {#iterator--}
+```
+public System.Collections.Generic.IGenericEnumerator<ApsNode> iterator()
+```
+
+
+이 페이지의 모든 노드를 순회하는 열거자를 반환합니다.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;com.aspose.foundation.rendering.ApsNode&gt; - 해당 `IEnumerator`.
+### iterator_Rename_Namesake() {#iterator-Rename-Namesake--}
+```
+public System.Collections.IEnumerator iterator_Rename_Namesake()
+```
+
+
+열거자를 가져옵니다.
+
+**Returns:**
+com.aspose.ms.System.Collections.IEnumerator - 해당 `IEnumerator`.

--- a/korean/java/com.aspose.note/extendedapspath/_index.md
+++ b/korean/java/com.aspose.note/extendedapspath/_index.md
@@ -1,0 +1,113 @@
+---
+title: "ExtendedApsPath"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "표준 ApsPath에 대한 래퍼를 나타내며, 일부 그리기 동작을 확장합니다."
+type: docs
+weight: 28
+url: /ko/java/com.aspose.note/extendedapspath/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ExtendedApsNode](../../com.aspose.note/extendedapsnode)
+```
+public class ExtendedApsPath extends ExtendedApsNode
+```
+
+표준 ApsPath에 대한 래퍼를 나타내며, 일부 그리기 동작을 확장합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ExtendedApsPath(ApsPath internalApsPath)](#ExtendedApsPath-com.aspose.foundation.rendering.ApsPath-) | `ExtendedApsPath` 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [addToCompositeNode(ApsCompositeNode compositeNode)](#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-) | 주어진 `compositeNode`에 이 노드를 추가합니다. |
+| [applyPlaneTransform(System.Drawing.PointF transformVector)](#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-) | 평면 변환을 적용하여 노드를 x 및 y 평면으로 이동시킵니다. |
+| [applyScaleTransform(float scaleTransform)](#applyScaleTransform-float-) | 노드에 스케일링을 적용합니다. |
+| [getBottom()](#getBottom--) | 하단 값을 가져옵니다. |
+| [getCopy()](#getCopy--) | 이 노드의 전체 복사본을 생성합니다. |
+| [getTop()](#getTop--) | 상단을 가져옵니다. |
+### ExtendedApsPath(ApsPath internalApsPath) {#ExtendedApsPath-com.aspose.foundation.rendering.ApsPath-}
+```
+public ExtendedApsPath(ApsPath internalApsPath)
+```
+
+
+`ExtendedApsPath` 클래스의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| internalApsPath | com.aspose.foundation.rendering.ApsPath | Aps 경로입니다. |
+
+### addToCompositeNode(ApsCompositeNode compositeNode) {#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-}
+```
+public void addToCompositeNode(ApsCompositeNode compositeNode)
+```
+
+
+주어진 `compositeNode`에 이 노드를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| compositeNode | com.aspose.foundation.rendering.ApsCompositeNode |  |
+
+### applyPlaneTransform(System.Drawing.PointF transformVector) {#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-}
+```
+public void applyPlaneTransform(System.Drawing.PointF transformVector)
+```
+
+
+평면 변환을 적용하여 노드를 x 및 y 평면으로 이동시킵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| transformVector | com.aspose.ms.System.Drawing.PointF |  |
+
+### applyScaleTransform(float scaleTransform) {#applyScaleTransform-float-}
+```
+public void applyScaleTransform(float scaleTransform)
+```
+
+
+노드에 스케일링을 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| scaleTransform | float | 변환에 대한 스케일 계수입니다. |
+
+### getBottom() {#getBottom--}
+```
+public float getBottom()
+```
+
+
+하단 값을 가져옵니다.
+
+**Returns:**
+float
+### getCopy() {#getCopy--}
+```
+public ExtendedApsNode getCopy()
+```
+
+
+이 노드의 전체 복사본을 생성합니다.
+
+**Returns:**
+[ExtendedApsNode](../../com.aspose.note/extendedapsnode) - The `IExtendedApsNode`.
+### getTop() {#getTop--}
+```
+public float getTop()
+```
+
+
+상단을 가져옵니다.
+
+**Returns:**
+float

--- a/korean/java/com.aspose.note/extendedcompositenode/_index.md
+++ b/korean/java/com.aspose.note/extendedcompositenode/_index.md
@@ -1,0 +1,111 @@
+---
+title: "ExtendedCompositeNode"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "여러 IExtendedApsNode 인스턴스를 결합합니다."
+type: docs
+weight: 29
+url: /ko/java/com.aspose.note/extendedcompositenode/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ExtendedApsNode](../../com.aspose.note/extendedapsnode)
+```
+public class ExtendedCompositeNode extends ExtendedApsNode
+```
+
+`IExtendedApsNode` 인스턴스를 여러 개 결합합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ExtendedCompositeNode()](#ExtendedCompositeNode--) | 새 `ExtendedCompositeNode` 클래스 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(ExtendedApsNode extendedApsNode)](#add-com.aspose.note.ExtendedApsNode-) | `extendedApsNode`를 내부 노드 목록에 추가합니다. |
+| [addToCompositeNode(ApsCompositeNode compositeNode)](#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-) | 주어진 `compositeNode`에 이 노드를 추가합니다. |
+| [applyPlaneTransform(System.Drawing.PointF transformVector)](#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-) | 평면 변환을 적용하여 노드를 x 및 y 평면으로 이동시킵니다. |
+| [applyScaleTransform(float scaleTransform)](#applyScaleTransform-float-) | 노드에 스케일링을 적용합니다. |
+| [getApsNodes()](#getApsNodes--) | 이 `ExtendedCompositeNode`에 결합된 모든 `IExtendedApsNode` 인스턴스를 가져옵니다. |
+| [getCopy()](#getCopy--) | 이 노드의 전체 복사본을 생성합니다. |
+### ExtendedCompositeNode() {#ExtendedCompositeNode--}
+```
+public ExtendedCompositeNode()
+```
+
+
+새 `ExtendedCompositeNode` 클래스 인스턴스를 초기화합니다.
+
+### add(ExtendedApsNode extendedApsNode) {#add-com.aspose.note.ExtendedApsNode-}
+```
+public final void add(ExtendedApsNode extendedApsNode)
+```
+
+
+`extendedApsNode`를 내부 노드 목록에 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| extendedApsNode | [ExtendedApsNode](../../com.aspose.note/extendedapsnode) |  |
+
+### addToCompositeNode(ApsCompositeNode compositeNode) {#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-}
+```
+public void addToCompositeNode(ApsCompositeNode compositeNode)
+```
+
+
+주어진 `compositeNode`에 이 노드를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| compositeNode | com.aspose.foundation.rendering.ApsCompositeNode |  |
+
+### applyPlaneTransform(System.Drawing.PointF transformVector) {#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-}
+```
+public void applyPlaneTransform(System.Drawing.PointF transformVector)
+```
+
+
+평면 변환을 적용하여 노드를 x 및 y 평면으로 이동시킵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| transformVector | com.aspose.ms.System.Drawing.PointF |  |
+
+### applyScaleTransform(float scaleTransform) {#applyScaleTransform-float-}
+```
+public void applyScaleTransform(float scaleTransform)
+```
+
+
+노드에 스케일링을 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| scaleTransform | float | 변환에 대한 스케일 계수입니다. |
+
+### getApsNodes() {#getApsNodes--}
+```
+public final System.Collections.Generic.IGenericCollection<ExtendedApsNode> getApsNodes()
+```
+
+
+이 `ExtendedCompositeNode`에 결합된 모든 `IExtendedApsNode` 인스턴스를 가져옵니다.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericCollection&lt;com.aspose.note.ExtendedApsNode&gt;
+### getCopy() {#getCopy--}
+```
+public ExtendedApsNode getCopy()
+```
+
+
+이 노드의 전체 복사본을 생성합니다.
+
+**Returns:**
+[ExtendedApsNode](../../com.aspose.note/extendedapsnode) - The `IExtendedApsNode`.

--- a/korean/java/com.aspose.note/fileformat/_index.md
+++ b/korean/java/com.aspose.note/fileformat/_index.md
@@ -1,0 +1,56 @@
+---
+title: "FileFormat"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "OneNote 파일 형식을 나타냅니다."
+type: docs
+weight: 30
+url: /ko/java/com.aspose.note/fileformat/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class FileFormat extends System.Enum
+```
+
+OneNote 파일 형식을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [OneNote2007](#OneNote2007) | OneNote 2010. |
+| [OneNote2010](#OneNote2010) | OneNote 2010. |
+| [OneNoteOnline](#OneNoteOnline) | OneNote Online. |
+| [Unknown](#Unknown) | 알 수 없는 파일 형식. |
+### OneNote2007 {#OneNote2007}
+```
+public static final int OneNote2007
+```
+
+
+OneNote 2010.
+
+### OneNote2010 {#OneNote2010}
+```
+public static final int OneNote2010
+```
+
+
+OneNote 2010.
+
+### OneNoteOnline {#OneNoteOnline}
+```
+public static final int OneNoteOnline
+```
+
+
+OneNote Online.
+
+### Unknown {#Unknown}
+```
+public static final int Unknown
+```
+
+
+알 수 없는 파일 형식.
+

--- a/korean/java/com.aspose.note/fontsavingargs/_index.md
+++ b/korean/java/com.aspose.note/fontsavingargs/_index.md
@@ -1,0 +1,53 @@
+---
+title: "FontSavingArgs"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "FontSaving 이벤트에 대한 데이터를 제공합니다."
+type: docs
+weight: 31
+url: /ko/java/com.aspose.note/fontsavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ResourceSavingArgs](../../com.aspose.note/resourcesavingargs)
+```
+public class FontSavingArgs extends ResourceSavingArgs
+```
+
+FontSaving 이벤트에 대한 데이터를 제공합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getFontFamilyName()](#getFontFamilyName--) | 저장될 글꼴의 패밀리 이름을 가져옵니다. |
+| [isBold()](#isBold--) | 저장 중인 글꼴이 굵게인지 여부를 나타내는 값을 가져옵니다. |
+| [isItalic()](#isItalic--) | 저장 중인 글꼴이 이탤릭인지 여부를 나타내는 값을 가져옵니다. |
+### getFontFamilyName() {#getFontFamilyName--}
+```
+public final String getFontFamilyName()
+```
+
+
+저장될 글꼴의 패밀리 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### isBold() {#isBold--}
+```
+public final boolean isBold()
+```
+
+
+저장 중인 글꼴이 굵게인지 여부를 나타내는 값을 가져옵니다.
+
+**Returns:**
+boolean
+### isItalic() {#isItalic--}
+```
+public final boolean isItalic()
+```
+
+
+저장 중인 글꼴이 이탤릭인지 여부를 나타내는 값을 가져옵니다.
+
+**Returns:**
+boolean

--- a/korean/java/com.aspose.note/htmlsaveoptions/_index.md
+++ b/korean/java/com.aspose.note/htmlsaveoptions/_index.md
@@ -1,0 +1,287 @@
+---
+title: "HtmlSaveOptions"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "문서를 HTML 형식으로 저장할 때 추가 옵션을 지정할 수 있습니다."
+type: docs
+weight: 32
+url: /ko/java/com.aspose.note/htmlsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.SaveOptions](../../com.aspose.note/saveoptions)
+```
+public class HtmlSaveOptions extends SaveOptions
+```
+
+문서를 HTML 형식으로 저장할 때 추가 옵션을 지정할 수 있습니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [HtmlSaveOptions()](#HtmlSaveOptions--) | 새 인스턴스를 초기화합니다 [HtmlSaveOptions](../../com.aspose.note/htmlsaveoptions) 클래스. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getCssPerPageGeneration()](#getCssPerPageGeneration--) | 각 새 페이지마다 StyleSheet 파일을 별도로 생성할지 여부를 가져오거나 설정합니다. |
+| [getCssSavingCallback()](#getCssSavingCallback--) | CSS를 저장할 리소스를 생성하기 위해 호출되는 콜백을 가져오거나 설정합니다. |
+| [getDocumentPerPageGeneration()](#getDocumentPerPageGeneration--) | 문서 페이지당 생성이 활성화되어 있는지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [getExportCss()](#getExportCss--) | css가 내보내지는 방식을 가져오거나 설정합니다. |
+| [getExportFonts()](#getExportFonts--) | 글꼴이 내보내지는 방식을 가져오거나 설정합니다. |
+| [getExportImages()](#getExportImages--) | 이미지가 내보내지는 방식을 가져오거나 설정합니다. |
+| [getFontFaceTypes()](#getFontFaceTypes--) | 글꼴 얼굴 유형을 가져오거나 설정합니다. |
+| [getFontSavingCallback()](#getFontSavingCallback--) | 글꼴을 저장할 리소스를 생성하기 위해 호출되는 콜백을 가져오거나 설정합니다. |
+| [getImageSavingCallback()](#getImageSavingCallback--) | 이미지를 저장할 리소스를 생성하기 위해 호출되는 콜백을 가져오거나 설정합니다. |
+| [getPageSavingCallback()](#getPageSavingCallback--) | 페이지를 저장할 리소스를 생성하기 위해 호출되는 콜백을 가져오거나 설정합니다. |
+| [setCssPerPageGeneration(boolean value)](#setCssPerPageGeneration-boolean-) | 각 새 페이지마다 StyleSheet 파일을 별도로 생성할지 여부를 가져오거나 설정합니다. |
+| [setCssSavingCallback(ICssSavingCallback value)](#setCssSavingCallback-com.aspose.note.ICssSavingCallback-) | CSS를 저장할 리소스를 생성하기 위해 호출되는 콜백을 가져오거나 설정합니다. |
+| [setDocumentPerPageGeneration(boolean value)](#setDocumentPerPageGeneration-boolean-) | 문서 페이지당 생성이 활성화되어 있는지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [setExportCss(int value)](#setExportCss-int-) | css가 내보내지는 방식을 가져오거나 설정합니다. |
+| [setExportFonts(int value)](#setExportFonts-int-) | 글꼴이 내보내지는 방식을 가져오거나 설정합니다. |
+| [setExportImages(int value)](#setExportImages-int-) | 이미지가 내보내지는 방식을 가져오거나 설정합니다. |
+| [setFontFaceTypes(int value)](#setFontFaceTypes-int-) | 글꼴 얼굴 유형을 가져오거나 설정합니다. |
+| [setFontSavingCallback(IFontSavingCallback value)](#setFontSavingCallback-com.aspose.note.IFontSavingCallback-) | 글꼴을 저장할 리소스를 생성하기 위해 호출되는 콜백을 가져오거나 설정합니다. |
+| [setImageSavingCallback(IImageSavingCallback value)](#setImageSavingCallback-com.aspose.note.IImageSavingCallback-) | 이미지를 저장할 리소스를 생성하기 위해 호출되는 콜백을 가져오거나 설정합니다. |
+| [setPageSavingCallback(IPageSavingCallback value)](#setPageSavingCallback-com.aspose.note.IPageSavingCallback-) | 페이지를 저장할 리소스를 생성하기 위해 호출되는 콜백을 가져오거나 설정합니다. |
+### HtmlSaveOptions() {#HtmlSaveOptions--}
+```
+public HtmlSaveOptions()
+```
+
+
+새 인스턴스를 초기화합니다 [HtmlSaveOptions](../../com.aspose.note/htmlsaveoptions) 클래스.
+
+### getCssPerPageGeneration() {#getCssPerPageGeneration--}
+```
+public final boolean getCssPerPageGeneration()
+```
+
+
+각 새 페이지마다 StyleSheet 파일을 별도로 생성할지 여부를 가져오거나 설정합니다.
+
+**Returns:**
+boolean
+### getCssSavingCallback() {#getCssSavingCallback--}
+```
+public final ICssSavingCallback getCssSavingCallback()
+```
+
+
+CSS를 저장할 리소스를 생성하기 위해 호출되는 콜백을 가져오거나 설정합니다.
+
+**Returns:**
+[ICssSavingCallback](../../com.aspose.note/icsssavingcallback)
+### getDocumentPerPageGeneration() {#getDocumentPerPageGeneration--}
+```
+public final boolean getDocumentPerPageGeneration()
+```
+
+
+문서 페이지당 생성이 활성화되어 있는지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Returns:**
+boolean
+### getExportCss() {#getExportCss--}
+```
+public final int getExportCss()
+```
+
+
+css가 내보내지는 방식을 가져오거나 설정합니다.
+
+**Returns:**
+int
+### getExportFonts() {#getExportFonts--}
+```
+public final int getExportFonts()
+```
+
+
+글꼴이 내보내지는 방식을 가져오거나 설정합니다.
+
+**Returns:**
+int
+### getExportImages() {#getExportImages--}
+```
+public final int getExportImages()
+```
+
+
+이미지가 내보내지는 방식을 가져오거나 설정합니다.
+
+**Returns:**
+int
+### getFontFaceTypes() {#getFontFaceTypes--}
+```
+public final int getFontFaceTypes()
+```
+
+
+글꼴 얼굴 유형을 가져오거나 설정합니다.
+
+값: 글꼴 얼굴 유형.
+
+**Returns:**
+int
+### getFontSavingCallback() {#getFontSavingCallback--}
+```
+public final IFontSavingCallback getFontSavingCallback()
+```
+
+
+글꼴을 저장할 리소스를 생성하기 위해 호출되는 콜백을 가져오거나 설정합니다.
+
+**Returns:**
+[IFontSavingCallback](../../com.aspose.note/ifontsavingcallback)
+### getImageSavingCallback() {#getImageSavingCallback--}
+```
+public final IImageSavingCallback getImageSavingCallback()
+```
+
+
+이미지를 저장할 리소스를 생성하기 위해 호출되는 콜백을 가져오거나 설정합니다.
+
+**Returns:**
+[IImageSavingCallback](../../com.aspose.note/iimagesavingcallback)
+### getPageSavingCallback() {#getPageSavingCallback--}
+```
+public final IPageSavingCallback getPageSavingCallback()
+```
+
+
+페이지를 저장할 리소스를 생성하기 위해 호출되는 콜백을 가져오거나 설정합니다.
+
+**Returns:**
+[IPageSavingCallback](../../com.aspose.note/ipagesavingcallback)
+### setCssPerPageGeneration(boolean value) {#setCssPerPageGeneration-boolean-}
+```
+public final void setCssPerPageGeneration(boolean value)
+```
+
+
+각 새 페이지마다 StyleSheet 파일을 별도로 생성할지 여부를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setCssSavingCallback(ICssSavingCallback value) {#setCssSavingCallback-com.aspose.note.ICssSavingCallback-}
+```
+public final void setCssSavingCallback(ICssSavingCallback value)
+```
+
+
+CSS를 저장할 리소스를 생성하기 위해 호출되는 콜백을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [ICssSavingCallback](../../com.aspose.note/icsssavingcallback) |  |
+
+### setDocumentPerPageGeneration(boolean value) {#setDocumentPerPageGeneration-boolean-}
+```
+public final void setDocumentPerPageGeneration(boolean value)
+```
+
+
+문서 페이지당 생성이 활성화되어 있는지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setExportCss(int value) {#setExportCss-int-}
+```
+public final void setExportCss(int value)
+```
+
+
+css가 내보내지는 방식을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setExportFonts(int value) {#setExportFonts-int-}
+```
+public final void setExportFonts(int value)
+```
+
+
+글꼴이 내보내지는 방식을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setExportImages(int value) {#setExportImages-int-}
+```
+public final void setExportImages(int value)
+```
+
+
+이미지가 내보내지는 방식을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setFontFaceTypes(int value) {#setFontFaceTypes-int-}
+```
+public final void setFontFaceTypes(int value)
+```
+
+
+글꼴 얼굴 유형을 가져오거나 설정합니다.
+
+값: 글꼴 얼굴 유형.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setFontSavingCallback(IFontSavingCallback value) {#setFontSavingCallback-com.aspose.note.IFontSavingCallback-}
+```
+public final void setFontSavingCallback(IFontSavingCallback value)
+```
+
+
+글꼴을 저장할 리소스를 생성하기 위해 호출되는 콜백을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [IFontSavingCallback](../../com.aspose.note/ifontsavingcallback) |  |
+
+### setImageSavingCallback(IImageSavingCallback value) {#setImageSavingCallback-com.aspose.note.IImageSavingCallback-}
+```
+public final void setImageSavingCallback(IImageSavingCallback value)
+```
+
+
+이미지를 저장할 리소스를 생성하기 위해 호출되는 콜백을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [IImageSavingCallback](../../com.aspose.note/iimagesavingcallback) |  |
+
+### setPageSavingCallback(IPageSavingCallback value) {#setPageSavingCallback-com.aspose.note.IPageSavingCallback-}
+```
+public final void setPageSavingCallback(IPageSavingCallback value)
+```
+
+
+페이지를 저장할 리소스를 생성하기 위해 호출되는 콜백을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [IPageSavingCallback](../../com.aspose.note/ipagesavingcallback) |  |
+

--- a/korean/java/com.aspose.note/icompositenode/_index.md
+++ b/korean/java/com.aspose.note/icompositenode/_index.md
@@ -1,0 +1,33 @@
+---
+title: "ICompositeNode"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "다른 노드를 포함할 수 있는 노드용 인터페이스입니다."
+type: docs
+weight: 96
+url: /ko/java/com.aspose.note/icompositenode/
+---
+```
+public interface ICompositeNode
+```
+
+다른 노드를 포함할 수 있는 노드용 인터페이스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [&lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass)](#-T1-getChildNodes-java.lang.Class-T1--) |  |
+### &lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass) {#-T1-getChildNodes-java.lang.Class-T1--}
+```
+public abstract List<T1> <T1>getChildNodes(Class<T1> typeParameterClass)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| typeParameterClass | java.lang.Class&lt;T1&gt; |  |
+
+**Returns:**
+java.util.List&lt;T1&gt;

--- a/korean/java/com.aspose.note/icompositenodet/_index.md
+++ b/korean/java/com.aspose.note/icompositenodet/_index.md
@@ -1,0 +1,20 @@
+---
+title: "ICompositeNodeT"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "다른 노드를 포함할 수 있는 노드용 인터페이스입니다."
+type: docs
+weight: 97
+url: /ko/java/com.aspose.note/icompositenodet/
+---
+
+**All Implemented Interfaces:**
+[com.aspose.note.ICompositeNode](../../com.aspose.note/icompositenode), com.aspose.ms.System.Collections.Generic.IGenericEnumerable
+```
+public interface ICompositeNodeT<T> extends ICompositeNode, System.Collections.Generic.IGenericEnumerable<T>
+```
+
+다른 노드를 포함할 수 있는 노드용 인터페이스입니다.
+
+`T`: 자식 노드의 유형
+
+T :

--- a/korean/java/com.aspose.note/icsssavingcallback/_index.md
+++ b/korean/java/com.aspose.note/icsssavingcallback/_index.md
@@ -1,0 +1,31 @@
+---
+title: "ICssSavingCallback"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "Aspose.Note가 문서를 HTML로 저장할 때 CSS(계단식 스타일 시트)를 저장하는 방식을 제어하려면 이 인터페이스를 구현하십시오."
+type: docs
+weight: 98
+url: /ko/java/com.aspose.note/icsssavingcallback/
+---
+```
+public interface ICssSavingCallback
+```
+
+HTML로 문서를 저장할 때 Aspose.Note가 CSS(스타일시트)를 저장하는 방식을 제어하려면 이 인터페이스를 구현하십시오.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [cssSaving(CssSavingArgs args)](#cssSaving-com.aspose.note.CssSavingArgs-) | Aspose.Note가 CSS(계단식 스타일 시트)를 저장할 때 호출됩니다. |
+### cssSaving(CssSavingArgs args) {#cssSaving-com.aspose.note.CssSavingArgs-}
+```
+public abstract void cssSaving(CssSavingArgs args)
+```
+
+
+Aspose.Note가 CSS(계단식 스타일 시트)를 저장할 때 호출됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| args | [CssSavingArgs](../../com.aspose.note/csssavingargs) | 저장 매개변수입니다. |
+

--- a/korean/java/com.aspose.note/ifontsavingcallback/_index.md
+++ b/korean/java/com.aspose.note/ifontsavingcallback/_index.md
@@ -1,0 +1,31 @@
+---
+title: "IFontSavingCallback"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "HTML로 문서를 저장할 때 Aspose.Note가 글꼴을 저장하는 방식을 제어하려면 이 인터페이스를 구현하십시오."
+type: docs
+weight: 99
+url: /ko/java/com.aspose.note/ifontsavingcallback/
+---
+```
+public interface IFontSavingCallback
+```
+
+HTML로 문서를 저장할 때 Aspose.Note가 글꼴을 저장하는 방식을 제어하려면 이 인터페이스를 구현하십시오.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [fontSaving(FontSavingArgs args)](#fontSaving-com.aspose.note.FontSavingArgs-) | Aspose.Note가 글꼴을 저장할 때 호출됩니다. |
+### fontSaving(FontSavingArgs args) {#fontSaving-com.aspose.note.FontSavingArgs-}
+```
+public abstract void fontSaving(FontSavingArgs args)
+```
+
+
+Aspose.Note가 글꼴을 저장할 때 호출됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| args | [FontSavingArgs](../../com.aspose.note/fontsavingargs) | 저장 매개변수입니다. |
+

--- a/korean/java/com.aspose.note/iimagesavingcallback/_index.md
+++ b/korean/java/com.aspose.note/iimagesavingcallback/_index.md
@@ -1,0 +1,31 @@
+---
+title: "IImageSavingCallback"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "HTML로 문서를 저장할 때 Aspose.Note가 이미지를 저장하는 방식을 제어하려면 이 인터페이스를 구현하십시오."
+type: docs
+weight: 100
+url: /ko/java/com.aspose.note/iimagesavingcallback/
+---
+```
+public interface IImageSavingCallback
+```
+
+HTML로 문서를 저장할 때 Aspose.Note가 이미지를 저장하는 방식을 제어하려면 이 인터페이스를 구현하십시오.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [imageSaving(ImageSavingArgs args)](#imageSaving-com.aspose.note.ImageSavingArgs-) | Aspose.Note가 이미지를 저장할 때 호출됩니다. |
+### imageSaving(ImageSavingArgs args) {#imageSaving-com.aspose.note.ImageSavingArgs-}
+```
+public abstract void imageSaving(ImageSavingArgs args)
+```
+
+
+Aspose.Note가 이미지를 저장할 때 호출됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| args | [ImageSavingArgs](../../com.aspose.note/imagesavingargs) | 저장 매개변수입니다. |
+

--- a/korean/java/com.aspose.note/iindentatednode/_index.md
+++ b/korean/java/com.aspose.note/iindentatednode/_index.md
@@ -1,0 +1,60 @@
+---
+title: "IIndentatedNode"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "자식 노드에 대한 상대 들여쓰기를 가진 노드용 인터페이스입니다."
+type: docs
+weight: 101
+url: /ko/java/com.aspose.note/iindentatednode/
+---
+```
+public interface IIndentatedNode
+```
+
+자식 노드에 대한 상대 들여쓰기를 가진 노드용 인터페이스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [&lt;T&gt;setIndentPosition(byte value)](#-T-setIndentPosition-byte-) | 들여쓰기 위치를 가져오거나 설정합니다. |
+| [&lt;T&gt;setIndentPosition(int value)](#-T-setIndentPosition-int-) | 들여쓰기 위치를 가져오거나 설정합니다. |
+| [getIndentPosition()](#getIndentPosition--) | 들여쓰기 위치를 가져오거나 설정합니다. |
+### &lt;T&gt;setIndentPosition(byte value) {#-T-setIndentPosition-byte-}
+```
+public abstract T <T>setIndentPosition(byte value)
+```
+
+
+들여쓰기 위치를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | byte |  |
+
+**Returns:**
+T
+### &lt;T&gt;setIndentPosition(int value) {#-T-setIndentPosition-int-}
+```
+public abstract T <T>setIndentPosition(int value)
+```
+
+
+들여쓰기 위치를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+**Returns:**
+T
+### getIndentPosition() {#getIndentPosition--}
+```
+public abstract byte getIndentPosition()
+```
+
+
+들여쓰기 위치를 가져오거나 설정합니다.
+
+**Returns:**
+byte

--- a/korean/java/com.aspose.note/image/_index.md
+++ b/korean/java/com.aspose.note/image/_index.md
@@ -1,0 +1,420 @@
+---
+title: "이미지"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "이미지를 나타냅니다."
+type: docs
+weight: 33
+url: /ko/java/com.aspose.note/image/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode
+
+**All Implemented Interfaces:**
+[com.aspose.note.IPageChildNode](../../com.aspose.note/ipagechildnode), [com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode), [com.aspose.note.ITaggable](../../com.aspose.note/itaggable)
+```
+public final class Image extends CompositeNode<Loop> implements IPageChildNode, IOutlineElementChildNode, ITaggable
+```
+
+이미지를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Image(String path)](#Image-java.lang.String-) | `Image` 클래스의 새 인스턴스를 초기화합니다. |
+| [Image(String fileName, InputStream imageStream)](#Image-java.lang.String-java.io.InputStream-) | `Image` 클래스의 새 인스턴스를 초기화합니다. |
+| [Image()](#Image--) | `Image` 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | 노드의 방문자를 수락합니다. |
+| [getAlignment()](#getAlignment--) | 정렬을 가져옵니다. |
+| [getAlternativeTextDescription()](#getAlternativeTextDescription--) | 이미지에 대한 본문 대체 텍스트를 가져옵니다. |
+| [getAlternativeTextTitle()](#getAlternativeTextTitle--) | 이미지에 대한 대체 텍스트의 제목을 가져옵니다. |
+| [getBytes()](#getBytes--) | 이미지 데이터 저장소를 가져옵니다. |
+| [getFileName()](#getFileName--) | 파일 이름을 가져옵니다. |
+| [getFilePath()](#getFilePath--) | 이미지 파일 경로를 가져옵니다. |
+| [getFormat()](#getFormat--) | 이미지 형식을 가져옵니다. |
+| [getHeight()](#getHeight--) | 높이를 가져옵니다. |
+| [getHorizontalOffset()](#getHorizontalOffset--) | 수평 오프셋을 가져옵니다. |
+| [getHyperlinkUrl()](#getHyperlinkUrl--) | 이미지와 연결된 하이퍼링크를 가져옵니다. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 마지막 수정 시간을 가져옵니다. |
+| [getOriginalHeight()](#getOriginalHeight--) | 원본 높이를 가져옵니다. |
+| [getOriginalWidth()](#getOriginalWidth--) | 원본 너비를 가져옵니다. |
+| [getTags()](#getTags--) | 이미지의 모든 태그 목록을 가져옵니다. |
+| [getVerticalOffset()](#getVerticalOffset--) | 수직 오프셋을 가져옵니다. |
+| [getWidth()](#getWidth--) | 너비를 가져옵니다. |
+| [isBackground()](#isBackground--) | 이미지가 배경 이미지인지 여부를 가져옵니다. |
+| [replace(Image newImage)](#replace-com.aspose.note.Image-) | 제공된 Image 객체의 데이터로 현재 이미지 데이터를 교체합니다. |
+| [setAlignment(int value)](#setAlignment-int-) | 정렬을 설정합니다. |
+| [setAlternativeTextDescription(String value)](#setAlternativeTextDescription-java.lang.String-) | 이미지에 대한 본문 대체 텍스트를 설정합니다. |
+| [setAlternativeTextTitle(String value)](#setAlternativeTextTitle-java.lang.String-) | 이미지에 대한 대체 텍스트의 제목을 설정합니다. |
+| [setBackground(boolean value)](#setBackground-boolean-) | 이미지가 배경 이미지인지 여부를 가져옵니다. |
+| [setHeight(float value)](#setHeight-float-) | 높이를 설정합니다. |
+| [setHorizontalOffset(float value)](#setHorizontalOffset-float-) | 수평 오프셋을 설정합니다. |
+| [setHyperlinkUrl(String value)](#setHyperlinkUrl-java.lang.String-) | 이미지와 연결된 하이퍼링크를 설정합니다. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 마지막 수정 시간을 설정합니다. |
+| [setVerticalOffset(float value)](#setVerticalOffset-float-) | 수직 오프셋을 설정합니다. |
+| [setWidth(float value)](#setWidth-float-) | 너비를 설정합니다. |
+### Image(String path) {#Image-java.lang.String-}
+```
+public Image(String path)
+```
+
+
+`Image` 클래스의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 경로 | java.lang.String | `Image`를 생성할 파일의 경로를 포함하는 문자열입니다. |
+
+### Image(String fileName, InputStream imageStream) {#Image-java.lang.String-java.io.InputStream-}
+```
+public Image(String fileName, InputStream imageStream)
+```
+
+
+`Image` 클래스의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 파일이름 | java.lang.String | 이미지의 이름입니다. |
+| imageStream | java.io.InputStream | 이미지를 포함하는 스트림입니다. |
+
+### Image() {#Image--}
+```
+public Image()
+```
+
+
+`Image` 클래스의 새 인스턴스를 초기화합니다.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+노드의 방문자를 수락합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor`에서 파생된 클래스의 객체. |
+
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+정렬을 가져옵니다.
+
+**Returns:**
+int
+### getAlternativeTextDescription() {#getAlternativeTextDescription--}
+```
+public final String getAlternativeTextDescription()
+```
+
+
+이미지에 대한 본문 대체 텍스트를 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getAlternativeTextTitle() {#getAlternativeTextTitle--}
+```
+public final String getAlternativeTextTitle()
+```
+
+
+이미지에 대한 대체 텍스트의 제목을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getBytes() {#getBytes--}
+```
+public byte[] getBytes()
+```
+
+
+이미지 데이터 저장소를 가져옵니다.
+
+**Returns:**
+byte[]
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+파일 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getFilePath() {#getFilePath--}
+```
+public String getFilePath()
+```
+
+
+이미지 파일 경로를 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getFormat() {#getFormat--}
+```
+public final System.Drawing.Imaging.ImageFormat getFormat()
+```
+
+
+이미지 형식을 가져옵니다.
+
+**Returns:**
+com.aspose.ms.System.Drawing.Imaging.ImageFormat
+### getHeight() {#getHeight--}
+```
+public final float getHeight()
+```
+
+
+높이를 가져옵니다. 이는 MS OneNote 문서에서 이미지의 실제 높이입니다.
+
+**Returns:**
+float
+### getHorizontalOffset() {#getHorizontalOffset--}
+```
+public float getHorizontalOffset()
+```
+
+
+수평 오프셋을 가져옵니다.
+
+**Returns:**
+float
+### getHyperlinkUrl() {#getHyperlinkUrl--}
+```
+public String getHyperlinkUrl()
+```
+
+
+이미지와 연결된 하이퍼링크를 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+마지막 수정 시간을 가져옵니다.
+
+**Returns:**
+java.util.Date
+### getOriginalHeight() {#getOriginalHeight--}
+```
+public float getOriginalHeight()
+```
+
+
+원본 높이를 가져옵니다. 이는 크기 조정 전 이미지의 원본 너비입니다.
+
+**Returns:**
+float
+### getOriginalWidth() {#getOriginalWidth--}
+```
+public float getOriginalWidth()
+```
+
+
+원본 너비를 가져옵니다. 이는 크기 조정 전 이미지의 원본 너비입니다.
+
+**Returns:**
+float
+### getTags() {#getTags--}
+```
+public final System.Collections.Generic.List<ITag> getTags()
+```
+
+
+이미지의 모든 태그 목록을 가져옵니다.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List&lt;com.aspose.note.ITag&gt;
+### getVerticalOffset() {#getVerticalOffset--}
+```
+public float getVerticalOffset()
+```
+
+
+수직 오프셋을 가져옵니다.
+
+**Returns:**
+float
+### getWidth() {#getWidth--}
+```
+public final float getWidth()
+```
+
+
+너비를 가져옵니다. 이는 MS OneNote 문서에서 이미지의 실제 너비입니다.
+
+**Returns:**
+float
+### isBackground() {#isBackground--}
+```
+public final boolean isBackground()
+```
+
+
+이미지가 배경 이미지인지 여부를 가져옵니다.
+
+**Returns:**
+boolean
+### replace(Image newImage) {#replace-com.aspose.note.Image-}
+```
+public void replace(Image newImage)
+```
+
+
+제공된 Image 객체의 데이터로 현재 이미지 데이터를 교체합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| newImage | [Image](../../com.aspose.note/image) |  |
+
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+정렬을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setAlternativeTextDescription(String value) {#setAlternativeTextDescription-java.lang.String-}
+```
+public final void setAlternativeTextDescription(String value)
+```
+
+
+이미지에 대한 본문 대체 텍스트를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setAlternativeTextTitle(String value) {#setAlternativeTextTitle-java.lang.String-}
+```
+public final void setAlternativeTextTitle(String value)
+```
+
+
+이미지에 대한 대체 텍스트의 제목을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setBackground(boolean value) {#setBackground-boolean-}
+```
+public final void setBackground(boolean value)
+```
+
+
+이미지가 배경 이미지인지 여부를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setHeight(float value) {#setHeight-float-}
+```
+public final void setHeight(float value)
+```
+
+
+높이를 설정합니다. 이는 MS OneNote 문서에서 이미지의 실제 높이입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setHorizontalOffset(float value) {#setHorizontalOffset-float-}
+```
+public void setHorizontalOffset(float value)
+```
+
+
+수평 오프셋을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setHyperlinkUrl(String value) {#setHyperlinkUrl-java.lang.String-}
+```
+public void setHyperlinkUrl(String value)
+```
+
+
+이미지와 연결된 하이퍼링크를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+마지막 수정 시간을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Date |  |
+
+### setVerticalOffset(float value) {#setVerticalOffset-float-}
+```
+public void setVerticalOffset(float value)
+```
+
+
+수직 오프셋을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setWidth(float value) {#setWidth-float-}
+```
+public final void setWidth(float value)
+```
+
+
+너비를 설정합니다. 이는 MS OneNote 문서에서 이미지의 실제 너비입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+

--- a/korean/java/com.aspose.note/imagebinarizationoptions/_index.md
+++ b/korean/java/com.aspose.note/imagebinarizationoptions/_index.md
@@ -1,0 +1,83 @@
+---
+title: "ImageBinarizationOptions"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "이미지 이진화 옵션."
+type: docs
+weight: 34
+url: /ko/java/com.aspose.note/imagebinarizationoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ImageBinarizationOptions
+```
+
+이미지 이진화 옵션.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ImageBinarizationOptions()](#ImageBinarizationOptions--) | 새 인스턴스를 초기화합니다 [ImageBinarizationOptions](../../com.aspose.note/imagebinarizationoptions) 클래스. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getBinarizationMethod()](#getBinarizationMethod--) | 이진화 방법을 가져오거나 설정합니다. |
+| [getBinarizationThreshold()](#getBinarizationThreshold--) | 고정 임계값 이진화 방법에 대한 임계값을 가져오거나 설정합니다. |
+| [setBinarizationMethod(int value)](#setBinarizationMethod-int-) | 이진화 방법을 가져오거나 설정합니다. |
+| [setBinarizationThreshold(int value)](#setBinarizationThreshold-int-) | 고정 임계값 이진화 방법에 대한 임계값을 가져오거나 설정합니다. |
+### ImageBinarizationOptions() {#ImageBinarizationOptions--}
+```
+public ImageBinarizationOptions()
+```
+
+
+새 인스턴스를 초기화합니다 [ImageBinarizationOptions](../../com.aspose.note/imagebinarizationoptions) 클래스.
+
+### getBinarizationMethod() {#getBinarizationMethod--}
+```
+public final int getBinarizationMethod()
+```
+
+
+이진화 방법을 가져오거나 설정합니다. 기본값은 [BinarizationMethod.FixedThreshold](../../com.aspose.note/binarizationmethod\#FixedThreshold)입니다.
+
+**Returns:**
+int
+### getBinarizationThreshold() {#getBinarizationThreshold--}
+```
+public final int getBinarizationThreshold()
+```
+
+
+고정 임계값 이진화 방법에 대한 임계값을 가져오거나 설정합니다. 기본값은 128입니다.
+
+**Returns:**
+int
+### setBinarizationMethod(int value) {#setBinarizationMethod-int-}
+```
+public final void setBinarizationMethod(int value)
+```
+
+
+이진화 방법을 가져오거나 설정합니다. 기본값은 [BinarizationMethod.FixedThreshold](../../com.aspose.note/binarizationmethod\#FixedThreshold)입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setBinarizationThreshold(int value) {#setBinarizationThreshold-int-}
+```
+public final void setBinarizationThreshold(int value)
+```
+
+
+고정 임계값 이진화 방법에 대한 임계값을 가져오거나 설정합니다. 기본값은 128입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+

--- a/korean/java/com.aspose.note/imagesaveoptions/_index.md
+++ b/korean/java/com.aspose.note/imagesaveoptions/_index.md
@@ -1,0 +1,179 @@
+---
+title: "ImageSaveOptions"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "문서 페이지를 이미지로 렌더링할 때 추가 옵션을 지정할 수 있습니다."
+type: docs
+weight: 35
+url: /ko/java/com.aspose.note/imagesaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.SaveOptions](../../com.aspose.note/saveoptions)
+```
+public class ImageSaveOptions extends SaveOptions
+```
+
+문서 페이지를 이미지로 렌더링할 때 추가 옵션을 지정할 수 있습니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ImageSaveOptions(int format)](#ImageSaveOptions-int-) | 새 `ImageSaveOptions` 클래스 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getBinarizationOptions()](#getBinarizationOptions--) | 이미지 이진화 옵션을 가져오거나 설정합니다. |
+| [getColorMode()](#getColorMode--) | 출력 이미지에 대한 `ColorMode`([getColorMode](../../com.aspose.note/imagesaveoptions\#getColorMode--)/[setColorMode(int)](../../com.aspose.note/imagesaveoptions\#setColorMode-int-))을 가져오거나 설정합니다. |
+| [getQuality()](#getQuality--) | 저장된 이미지 품질을 결정하는 값을 가져옵니다. |
+| [getResolution()](#getResolution--) | 생성된 이미지의 해상도를 DPI(인치당 도트) 단위로 가져옵니다. |
+| [getTiffCompression()](#getTiffCompression--) | 생성된 이미지를 TIFF 형식으로 저장할 때 사용할 압축 유형을 가져오거나 설정합니다. |
+| [setBinarizationOptions(ImageBinarizationOptions value)](#setBinarizationOptions-com.aspose.note.ImageBinarizationOptions-) | 이미지 이진화 옵션을 가져오거나 설정합니다. |
+| [setColorMode(int value)](#setColorMode-int-) | 출력 이미지에 대한 `ColorMode`([getColorMode](../../com.aspose.note/imagesaveoptions\#getColorMode--)/[setColorMode(int)](../../com.aspose.note/imagesaveoptions\#setColorMode-int-))을 가져오거나 설정합니다. |
+| [setQuality(int value)](#setQuality-int-) | 저장된 이미지의 품질을 결정하는 값을 설정합니다. |
+| [setResolution(float value)](#setResolution-float-) | 생성된 이미지의 해상도를 인치당 도트(dpi) 단위로 설정합니다. |
+| [setTiffCompression(int value)](#setTiffCompression-int-) | 생성된 이미지를 TIFF 형식으로 저장할 때 사용할 압축 유형을 가져오거나 설정합니다. |
+### ImageSaveOptions(int format) {#ImageSaveOptions-int-}
+```
+public ImageSaveOptions(int format)
+```
+
+
+새 `ImageSaveOptions` 클래스 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| format | int | 문서가 저장되는 형식입니다. |
+
+### getBinarizationOptions() {#getBinarizationOptions--}
+```
+public final ImageBinarizationOptions getBinarizationOptions()
+```
+
+
+이미지 이진화 옵션을 가져오거나 설정합니다.
+
+**Returns:**
+[ImageBinarizationOptions](../../com.aspose.note/imagebinarizationoptions)
+### getColorMode() {#getColorMode--}
+```
+public final int getColorMode()
+```
+
+
+출력 이미지에 대한 `ColorMode`([getColorMode](../../com.aspose.note/imagesaveoptions\#getColorMode--)/[setColorMode(int)](../../com.aspose.note/imagesaveoptions\#setColorMode-int-))을 가져오거나 설정합니다.
+
+**Returns:**
+int
+### getQuality() {#getQuality--}
+```
+public final int getQuality()
+```
+
+
+저장된 이미지의 품질을 결정하는 값을 가져옵니다. 이 값은 System.Drawing.Imaging.Encoder.Quality 매개변수로 코덱에 전달됩니다.
+
+--------------------
+
+품질 범주의 유용한 값 범위는 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 그에 따라 이미지 품질이 낮아집니다. 0은 가장 낮은 품질의 이미지를, 100은 가장 높은 품질의 이미지를 제공합니다. 기본값은 90입니다.
+
+**Returns:**
+int
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+생성된 이미지의 해상도를 DPI(인치당 도트) 단위로 가져옵니다.
+
+--------------------
+
+기본값은 96입니다.
+
+**Returns:**
+float
+### getTiffCompression() {#getTiffCompression--}
+```
+public final int getTiffCompression()
+```
+
+
+생성된 이미지를 TIFF 형식으로 저장할 때 사용할 압축 유형을 가져오거나 설정합니다.
+
+**Returns:**
+int
+### setBinarizationOptions(ImageBinarizationOptions value) {#setBinarizationOptions-com.aspose.note.ImageBinarizationOptions-}
+```
+public final void setBinarizationOptions(ImageBinarizationOptions value)
+```
+
+
+이미지 이진화 옵션을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [ImageBinarizationOptions](../../com.aspose.note/imagebinarizationoptions) |  |
+
+### setColorMode(int value) {#setColorMode-int-}
+```
+public final void setColorMode(int value)
+```
+
+
+출력 이미지에 대한 `ColorMode`([getColorMode](../../com.aspose.note/imagesaveoptions\#getColorMode--)/[setColorMode(int)](../../com.aspose.note/imagesaveoptions\#setColorMode-int-))을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setQuality(int value) {#setQuality-int-}
+```
+public final void setQuality(int value)
+```
+
+
+저장된 이미지의 품질을 결정하는 값을 설정합니다. 이 값은 System.Drawing.Imaging.Encoder.Quality 매개변수로 코덱에 전달됩니다.
+
+--------------------
+
+품질 범주의 유용한 값 범위는 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 그에 따라 이미지 품질이 낮아집니다. 0은 가장 낮은 품질의 이미지를, 100은 가장 높은 품질의 이미지를 제공합니다. 기본값은 90입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+생성된 이미지의 해상도를 인치당 도트(dpi) 단위로 설정합니다.
+
+--------------------
+
+기본값은 90입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setTiffCompression(int value) {#setTiffCompression-int-}
+```
+public final void setTiffCompression(int value)
+```
+
+
+생성된 이미지를 TIFF 형식으로 저장할 때 사용할 압축 유형을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+

--- a/korean/java/com.aspose.note/imagesavingargs/_index.md
+++ b/korean/java/com.aspose.note/imagesavingargs/_index.md
@@ -1,0 +1,31 @@
+---
+title: "ImageSavingArgs"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "ImageSaving 이벤트에 대한 데이터를 제공합니다."
+type: docs
+weight: 36
+url: /ko/java/com.aspose.note/imagesavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ResourceSavingArgs](../../com.aspose.note/resourcesavingargs)
+```
+public class ImageSavingArgs extends ResourceSavingArgs
+```
+
+ImageSaving 이벤트에 대한 데이터를 제공합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getImageType()](#getImageType--) | 저장될 이미지 유형을 가져옵니다. |
+### getImageType() {#getImageType--}
+```
+public final int getImageType()
+```
+
+
+저장될 이미지 유형을 가져옵니다.
+
+**Returns:**
+int

--- a/korean/java/com.aspose.note/indentatednode/_index.md
+++ b/korean/java/com.aspose.note/indentatednode/_index.md
@@ -1,0 +1,82 @@
+---
+title: "IndentatedNode"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "자식 노드에 대한 상대 들여쓰기를 가진 노드의 기본 클래스입니다."
+type: docs
+weight: 37
+url: /ko/java/com.aspose.note/indentatednode/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode
+
+**All Implemented Interfaces:**
+com.aspose.note.IIndentatedNodeExtended
+```
+public class IndentatedNode<T,Self> extends CompositeNode<T> implements IIndentatedNodeExtended
+```
+
+자식 노드에 대한 상대 들여쓰기를 가진 노드의 기본 클래스입니다.
+
+`T`: 복합 노드의 요소 유형.
+
+T :
+Self :
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getIndentPosition()](#getIndentPosition--) | 들여쓰기 위치를 가져오거나 설정합니다. |
+| [getInternalIndentPosition()](#getInternalIndentPosition--) | 들여쓰기 크기를 얻기 위해 RgOutlineIndentDistance 배열에서 합산할 항목 수를 가져옵니다. |
+| [setIndentPosition(byte value)](#setIndentPosition-byte-) | 들여쓰기 위치를 가져오거나 설정합니다. |
+| [setIndentPosition(int value)](#setIndentPosition-int-) |  |
+### getIndentPosition() {#getIndentPosition--}
+```
+public final byte getIndentPosition()
+```
+
+
+들여쓰기 위치를 가져오거나 설정합니다.
+
+**Returns:**
+byte
+### getInternalIndentPosition() {#getInternalIndentPosition--}
+```
+public int getInternalIndentPosition()
+```
+
+
+들여쓰기 크기를 얻기 위해 RgOutlineIndentDistance 배열에서 합산할 항목 수를 가져옵니다.
+
+**Returns:**
+int
+### setIndentPosition(byte value) {#setIndentPosition-byte-}
+```
+public final Self setIndentPosition(byte value)
+```
+
+
+들여쓰기 위치를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | byte |  |
+
+**Returns:**
+Self
+### setIndentPosition(int value) {#setIndentPosition-int-}
+```
+public final Self setIndentPosition(int value)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+**Returns:**
+Self

--- a/korean/java/com.aspose.note/inkdrawing/_index.md
+++ b/korean/java/com.aspose.note/inkdrawing/_index.md
@@ -1,0 +1,87 @@
+---
+title: "InkDrawing"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "그려진 콘텐츠를 포함하는 잉크 노드를 나타냅니다."
+type: docs
+weight: 38
+url: /ko/java/com.aspose.note/inkdrawing/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.InkNode](../../com.aspose.note/inknode)
+
+**All Implemented Interfaces:**
+[com.aspose.note.IPageChildNode](../../com.aspose.note/ipagechildnode)
+```
+public final class InkDrawing extends InkNode implements IPageChildNode
+```
+
+그려진 콘텐츠를 포함하는 잉크 노드를 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | 노드의 방문자를 수락합니다. |
+| [getHorizontalOffset()](#getHorizontalOffset--) | 수평 오프셋을 가져옵니다. |
+| [getVerticalOffset()](#getVerticalOffset--) | 수직 오프셋을 가져옵니다. |
+| [setHorizontalOffset(float value)](#setHorizontalOffset-float-) | 수평 오프셋을 설정합니다. |
+| [setVerticalOffset(float value)](#setVerticalOffset-float-) | 수직 오프셋을 설정합니다. |
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+노드의 방문자를 수락합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | 다음으로부터 파생된 클래스인 [DocumentVisitor](../../com.aspose.note/documentvisitor)의 객체. |
+
+### getHorizontalOffset() {#getHorizontalOffset--}
+```
+public final float getHorizontalOffset()
+```
+
+
+수평 오프셋을 가져옵니다.
+
+**Returns:**
+float
+### getVerticalOffset() {#getVerticalOffset--}
+```
+public final float getVerticalOffset()
+```
+
+
+수직 오프셋을 가져옵니다.
+
+**Returns:**
+float
+### setHorizontalOffset(float value) {#setHorizontalOffset-float-}
+```
+public final void setHorizontalOffset(float value)
+```
+
+
+수평 오프셋을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setVerticalOffset(float value) {#setVerticalOffset-float-}
+```
+public final void setVerticalOffset(float value)
+```
+
+
+수직 오프셋을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+

--- a/korean/java/com.aspose.note/inknode/_index.md
+++ b/korean/java/com.aspose.note/inknode/_index.md
@@ -1,0 +1,16 @@
+---
+title: "InkNode"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "모든 잉크 노드에 대한 공통 인터페이스를 나타냅니다."
+type: docs
+weight: 39
+url: /ko/java/com.aspose.note/inknode/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node)
+```
+public abstract class InkNode extends Node
+```
+
+모든 잉크 노드에 대한 공통 인터페이스를 나타냅니다.

--- a/korean/java/com.aspose.note/inkparagraph/_index.md
+++ b/korean/java/com.aspose.note/inkparagraph/_index.md
@@ -1,0 +1,37 @@
+---
+title: "InkParagraph"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "기울어진 필기와 같은 추가 속성을 가진 손글씨 텍스트를 포함하는 잉크 노드를 나타냅니다."
+type: docs
+weight: 40
+url: /ko/java/com.aspose.note/inkparagraph/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.InkNode](../../com.aspose.note/inknode)
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode)
+```
+public final class InkParagraph extends InkNode implements IOutlineElementChildNode
+```
+
+기울어진 필기와 같은 추가 속성을 가진 손글씨 텍스트를 포함하는 잉크 노드를 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | 노드의 방문자를 수락합니다. |
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+노드의 방문자를 수락합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | 다음으로부터 파생된 클래스인 [DocumentVisitor](../../com.aspose.note/documentvisitor)의 객체. |
+

--- a/korean/java/com.aspose.note/inkword/_index.md
+++ b/korean/java/com.aspose.note/inkword/_index.md
@@ -1,0 +1,37 @@
+---
+title: "InkWord"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "손글씨 텍스트를 포함하는 잉크 노드를 나타냅니다."
+type: docs
+weight: 41
+url: /ko/java/com.aspose.note/inkword/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.InkNode](../../com.aspose.note/inknode)
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode)
+```
+public final class InkWord extends InkNode implements IOutlineElementChildNode
+```
+
+손글씨 텍스트를 포함하는 잉크 노드를 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | 노드의 방문자를 수락합니다. |
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+노드의 방문자를 수락합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | 다음으로부터 파생된 클래스인 [DocumentVisitor](../../com.aspose.note/documentvisitor)의 객체. |
+

--- a/korean/java/com.aspose.note/inode/_index.md
+++ b/korean/java/com.aspose.note/inode/_index.md
@@ -1,0 +1,53 @@
+---
+title: "INode"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "Aspose.Note 문서의 모든 노드에 대한 인터페이스입니다."
+type: docs
+weight: 102
+url: /ko/java/com.aspose.note/inode/
+---
+```
+public interface INode
+```
+
+Aspose.Note 문서의 모든 노드에 대한 인터페이스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) |  |
+| [getNextSibling()](#getNextSibling--) |  |
+| [getPreviousSibling()](#getPreviousSibling--) |  |
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public abstract void accept(DocumentVisitor visitor)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) |  |
+
+### getNextSibling() {#getNextSibling--}
+```
+public abstract INode getNextSibling()
+```
+
+
+
+
+**Returns:**
+[INode](../../com.aspose.note/inode)
+### getPreviousSibling() {#getPreviousSibling--}
+```
+public abstract INode getPreviousSibling()
+```
+
+
+
+
+**Returns:**
+[INode](../../com.aspose.note/inode)

--- a/korean/java/com.aspose.note/inotebookchildnode/_index.md
+++ b/korean/java/com.aspose.note/inotebookchildnode/_index.md
@@ -1,0 +1,61 @@
+---
+title: "INotebookChildNode"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "Aspose.Note 노트북의 자식을 나타냅니다."
+type: docs
+weight: 104
+url: /ko/java/com.aspose.note/inotebookchildnode/
+---
+```
+public interface INotebookChildNode
+```
+
+Aspose.Note 노트북의 하위 항목을 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getColor()](#getColor--) |  |
+| [getDisplayName()](#getDisplayName--) |  |
+| [getGuid()](#getGuid--) |  |
+| [getGuidInternal()](#getGuidInternal--) |  |
+### getColor() {#getColor--}
+```
+public abstract Color getColor()
+```
+
+
+
+
+**Returns:**
+java.awt.Color
+### getDisplayName() {#getDisplayName--}
+```
+public abstract String getDisplayName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getGuid() {#getGuid--}
+```
+public abstract UUID getGuid()
+```
+
+
+
+
+**Returns:**
+java.util.UUID
+### getGuidInternal() {#getGuidInternal--}
+```
+public abstract System.Guid getGuidInternal()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Guid

--- a/korean/java/com.aspose.note/inotetag/_index.md
+++ b/korean/java/com.aspose.note/inotetag/_index.md
@@ -1,0 +1,84 @@
+---
+title: "INoteTag"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "노트 태그에 대한 인터페이스입니다(i.e.)."
+type: docs
+weight: 103
+url: /ko/java/com.aspose.note/inotetag/
+---
+
+**All Implemented Interfaces:**
+[com.aspose.note.ITag](../../com.aspose.note/itag)
+```
+public interface INoteTag extends ITag
+```
+
+노트 태그에 대한 인터페이스입니다(i.e. Outlook 작업과 연결되지 않은 태그).
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getFontColor()](#getFontColor--) | 글꼴 색상을 가져옵니다. |
+| [getHighlight()](#getHighlight--) | 하이라이트 색상을 가져옵니다. |
+| [setFontColor(Color value)](#setFontColor-java.awt.Color-) | 글꼴 색상을 설정합니다. |
+| [setHighlight(Color value)](#setHighlight-java.awt.Color-) | 하이라이트 색상을 설정합니다. |
+| [setLabel(String value)](#setLabel-java.lang.String-) | 레이블 텍스트를 설정합니다. |
+### getFontColor() {#getFontColor--}
+```
+public abstract Color getFontColor()
+```
+
+
+글꼴 색상을 가져옵니다.
+
+**Returns:**
+java.awt.Color
+### getHighlight() {#getHighlight--}
+```
+public abstract Color getHighlight()
+```
+
+
+하이라이트 색상을 가져옵니다.
+
+**Returns:**
+java.awt.Color
+### setFontColor(Color value) {#setFontColor-java.awt.Color-}
+```
+public abstract void setFontColor(Color value)
+```
+
+
+글꼴 색상을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.Color |  |
+
+### setHighlight(Color value) {#setHighlight-java.awt.Color-}
+```
+public abstract void setHighlight(Color value)
+```
+
+
+하이라이트 색상을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.Color |  |
+
+### setLabel(String value) {#setLabel-java.lang.String-}
+```
+public abstract void setLabel(String value)
+```
+
+
+레이블 텍스트를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+

--- a/korean/java/com.aspose.note/ioutlinechildnode/_index.md
+++ b/korean/java/com.aspose.note/ioutlinechildnode/_index.md
@@ -1,0 +1,16 @@
+---
+title: "IOutlineChildNode"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "아웃라인 노드의 모든 하위 노드에 대한 인터페이스입니다."
+type: docs
+weight: 105
+url: /ko/java/com.aspose.note/ioutlinechildnode/
+---
+
+**All Implemented Interfaces:**
+[com.aspose.note.INode](../../com.aspose.note/inode)
+```
+public interface IOutlineChildNode extends INode
+```
+
+아웃라인 노드의 모든 하위 노드에 대한 인터페이스입니다.

--- a/korean/java/com.aspose.note/ioutlineelementchildnode/_index.md
+++ b/korean/java/com.aspose.note/ioutlineelementchildnode/_index.md
@@ -1,0 +1,16 @@
+---
+title: "IOutlineElementChildNode"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "아웃라인 요소 노드의 모든 하위 노드에 대한 인터페이스입니다."
+type: docs
+weight: 106
+url: /ko/java/com.aspose.note/ioutlineelementchildnode/
+---
+
+**All Implemented Interfaces:**
+[com.aspose.note.INode](../../com.aspose.note/inode)
+```
+public interface IOutlineElementChildNode extends INode
+```
+
+아웃라인 요소 노드의 모든 하위 노드에 대한 인터페이스입니다.

--- a/korean/java/com.aspose.note/ipagechildnode/_index.md
+++ b/korean/java/com.aspose.note/ipagechildnode/_index.md
@@ -1,0 +1,70 @@
+---
+title: "IPageChildNode"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "페이지 노드의 모든 하위 노드에 대한 인터페이스입니다."
+type: docs
+weight: 107
+url: /ko/java/com.aspose.note/ipagechildnode/
+---
+
+**All Implemented Interfaces:**
+[com.aspose.note.INode](../../com.aspose.note/inode)
+```
+public interface IPageChildNode extends INode
+```
+
+페이지 노드의 모든 하위 노드에 대한 인터페이스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getHorizontalOffset()](#getHorizontalOffset--) | 수평 오프셋을 가져오거나 설정합니다. |
+| [getVerticalOffset()](#getVerticalOffset--) | 수직 오프셋을 가져오거나 설정합니다. |
+| [setHorizontalOffset(float value)](#setHorizontalOffset-float-) | 수평 오프셋을 가져오거나 설정합니다. |
+| [setVerticalOffset(float value)](#setVerticalOffset-float-) | 수직 오프셋을 가져오거나 설정합니다. |
+### getHorizontalOffset() {#getHorizontalOffset--}
+```
+public abstract float getHorizontalOffset()
+```
+
+
+수평 오프셋을 가져오거나 설정합니다.
+
+**Returns:**
+float
+### getVerticalOffset() {#getVerticalOffset--}
+```
+public abstract float getVerticalOffset()
+```
+
+
+수직 오프셋을 가져오거나 설정합니다.
+
+**Returns:**
+float
+### setHorizontalOffset(float value) {#setHorizontalOffset-float-}
+```
+public abstract void setHorizontalOffset(float value)
+```
+
+
+수평 오프셋을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setVerticalOffset(float value) {#setVerticalOffset-float-}
+```
+public abstract void setVerticalOffset(float value)
+```
+
+
+수직 오프셋을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+

--- a/korean/java/com.aspose.note/ipagesavingcallback/_index.md
+++ b/korean/java/com.aspose.note/ipagesavingcallback/_index.md
@@ -1,0 +1,31 @@
+---
+title: "IPageSavingCallback"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "Aspose.Note가 개별 페이지를 저장하는 방식을 제어하려면 이 인터페이스를 구현하십시오."
+type: docs
+weight: 108
+url: /ko/java/com.aspose.note/ipagesavingcallback/
+---
+```
+public interface IPageSavingCallback
+```
+
+Aspose.Note가 개별 페이지를 저장하는 방식을 제어하려면 이 인터페이스를 구현하십시오.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [pageSaving(PageSavingArgs args)](#pageSaving-com.aspose.note.PageSavingArgs-) | Aspose.Note가 별도의 페이지를 저장할 때 호출됩니다. |
+### pageSaving(PageSavingArgs args) {#pageSaving-com.aspose.note.PageSavingArgs-}
+```
+public abstract void pageSaving(PageSavingArgs args)
+```
+
+
+Aspose.Note가 별도의 페이지를 저장할 때 호출됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| args | [PageSavingArgs](../../com.aspose.note/pagesavingargs) | 저장 매개변수입니다. |
+

--- a/korean/java/com.aspose.note/itag/_index.md
+++ b/korean/java/com.aspose.note/itag/_index.md
@@ -1,0 +1,96 @@
+---
+title: "ITag"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "모든 종류의 태그에 대한 인터페이스입니다."
+type: docs
+weight: 109
+url: /ko/java/com.aspose.note/itag/
+---
+```
+public interface ITag
+```
+
+모든 종류의 태그에 대한 인터페이스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getCompletedTime()](#getCompletedTime--) | 완료 시간을 가져옵니다. |
+| [getCreationTime()](#getCreationTime--) | 생성 시간을 가져옵니다. |
+| [getIcon()](#getIcon--) | 아이콘을 가져옵니다. |
+| [getLabel()](#getLabel--) | 레이블 텍스트를 가져옵니다. |
+| [getStatus()](#getStatus--) | 상태를 가져옵니다. |
+| [setCreationTime(Date value)](#setCreationTime-java.util.Date-) | 생성 시간을 설정합니다. |
+### getCompletedTime() {#getCompletedTime--}
+```
+public abstract Date getCompletedTime()
+```
+
+
+완료 시간을 가져옵니다.
+
+값: `Nullable{DateTime}`.
+
+**Returns:**
+java.util.Date
+### getCreationTime() {#getCreationTime--}
+```
+public abstract Date getCreationTime()
+```
+
+
+생성 시간을 가져옵니다.
+
+값: java.util.Date입니다.
+
+**Returns:**
+java.util.Date
+### getIcon() {#getIcon--}
+```
+public abstract int getIcon()
+```
+
+
+아이콘을 가져옵니다.
+
+값: [TagIcon](../../com.aspose.note.infrastructure/tagicon)입니다.
+
+**Returns:**
+int
+### getLabel() {#getLabel--}
+```
+public abstract String getLabel()
+```
+
+
+레이블 텍스트를 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getStatus() {#getStatus--}
+```
+public abstract int getStatus()
+```
+
+
+상태를 가져옵니다.
+
+값: [TagStatus](../../com.aspose.note/tagstatus)입니다.
+
+**Returns:**
+int
+### setCreationTime(Date value) {#setCreationTime-java.util.Date-}
+```
+public abstract void setCreationTime(Date value)
+```
+
+
+생성 시간을 설정합니다.
+
+값: java.util.Date입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Date |  |
+

--- a/korean/java/com.aspose.note/itaggable/_index.md
+++ b/korean/java/com.aspose.note/itaggable/_index.md
@@ -1,0 +1,31 @@
+---
+title: "ITaggable"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "태그로 표시될 수 있는 노드에 대한 인터페이스입니다."
+type: docs
+weight: 110
+url: /ko/java/com.aspose.note/itaggable/
+---
+
+**All Implemented Interfaces:**
+[com.aspose.note.INode](../../com.aspose.note/inode)
+```
+public interface ITaggable extends INode
+```
+
+태그로 표시될 수 있는 노드에 대한 인터페이스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getTags()](#getTags--) | 모든 태그의 목록을 가져옵니다. |
+### getTags() {#getTags--}
+```
+public abstract System.Collections.Generic.List<ITag> getTags()
+```
+
+
+모든 태그의 목록을 가져옵니다.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List&lt;com.aspose.note.ITag&gt;

--- a/korean/java/com.aspose.note/keeppartandclonesolidobjecttonextpagealgorithm/_index.md
+++ b/korean/java/com.aspose.note/keeppartandclonesolidobjecttonextpagealgorithm/_index.md
@@ -1,0 +1,71 @@
+---
+title: "KeepPartAndCloneSolidObjectToNextPageAlgorithm"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "객체의 상단 부분을 페이지 하단에 추가하고, 원본 페이지에 맞지 않을 경우 전체 객체를 다음 페이지에 복제합니다."
+type: docs
+weight: 42
+url: /ko/java/com.aspose.note/keeppartandclonesolidobjecttonextpagealgorithm/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm)
+```
+public class KeepPartAndCloneSolidObjectToNextPageAlgorithm extends PageSplittingAlgorithm
+```
+
+객체의 상단 부분을 페이지 하단에 추가하고, 원본 페이지에 맞지 않을 경우 전체 객체를 다음 페이지에 복제합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [KeepPartAndCloneSolidObjectToNextPageAlgorithm()](#KeepPartAndCloneSolidObjectToNextPageAlgorithm--) | `KeepPartAndCloneSolidObjectToNextPageAlgorithm` 클래스를 새 인스턴스로 초기화하며, 복제된 부분의 기본 높이 제한을 사용합니다. |
+| [KeepPartAndCloneSolidObjectToNextPageAlgorithm(float heightLimitOfClonedPart)](#KeepPartAndCloneSolidObjectToNextPageAlgorithm-float-) | `KeepPartAndCloneSolidObjectToNextPageAlgorithm` 클래스를 새 인스턴스로 초기화하며, 복제된 부분의 특정 높이 제한을 사용합니다. |
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [DEFAULT_HEIGHT_LIMIT_OF_CLONED_PART](#DEFAULT-HEIGHT-LIMIT-OF-CLONED-PART) | 복제된 부분의 기본 최대 크기입니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getHeightLimitOfClonedPart()](#getHeightLimitOfClonedPart--) | 복제된 부분의 높이 제한을 가져옵니다. |
+### KeepPartAndCloneSolidObjectToNextPageAlgorithm() {#KeepPartAndCloneSolidObjectToNextPageAlgorithm--}
+```
+public KeepPartAndCloneSolidObjectToNextPageAlgorithm()
+```
+
+
+`KeepPartAndCloneSolidObjectToNextPageAlgorithm` 클래스를 새 인스턴스로 초기화하며, 복제된 부분의 기본 높이 제한을 사용합니다.
+
+### KeepPartAndCloneSolidObjectToNextPageAlgorithm(float heightLimitOfClonedPart) {#KeepPartAndCloneSolidObjectToNextPageAlgorithm-float-}
+```
+public KeepPartAndCloneSolidObjectToNextPageAlgorithm(float heightLimitOfClonedPart)
+```
+
+
+`KeepPartAndCloneSolidObjectToNextPageAlgorithm` 클래스를 새 인스턴스로 초기화하며, 복제된 부분의 특정 높이 제한을 사용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| heightLimitOfClonedPart | float | 복제된 부분의 최대 높이. |
+
+### DEFAULT_HEIGHT_LIMIT_OF_CLONED_PART {#DEFAULT-HEIGHT-LIMIT-OF-CLONED-PART}
+```
+public static final float DEFAULT_HEIGHT_LIMIT_OF_CLONED_PART
+```
+
+
+복제된 부분의 기본 최대 크기입니다.
+
+### getHeightLimitOfClonedPart() {#getHeightLimitOfClonedPart--}
+```
+public float getHeightLimitOfClonedPart()
+```
+
+
+복제된 부분의 높이 제한을 가져옵니다.
+
+**Returns:**
+float

--- a/korean/java/com.aspose.note/keepsolidobjectsalgorithm/_index.md
+++ b/korean/java/com.aspose.note/keepsolidobjectsalgorithm/_index.md
@@ -1,0 +1,71 @@
+---
+title: "KeepSolidObjectsAlgorithm"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "전체 객체가 원래 페이지에 맞지 않을 경우 다음 페이지로 이동시�니다."
+type: docs
+weight: 43
+url: /ko/java/com.aspose.note/keepsolidobjectsalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm)
+```
+public class KeepSolidObjectsAlgorithm extends PageSplittingAlgorithm
+```
+
+원본 페이지에 맞지 않을 경우 전체 객체를 다음 페이지로 이동시킵니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [KeepSolidObjectsAlgorithm()](#KeepSolidObjectsAlgorithm--) | `KeepSolidObjectsAlgorithm` 클래스를 복제된 부분의 기본 높이 제한을 사용하여 새 인스턴스로 초기화합니다. |
+| [KeepSolidObjectsAlgorithm(float heightLimitOfClonedPart)](#KeepSolidObjectsAlgorithm-float-) | `KeepSolidObjectsAlgorithm` 클래스를 복제된 부분의 특정 높이 제한을 사용하여 새 인스턴스로 초기화합니다. |
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [DEFAULT_HEIGHT_LIMIT_OF_CLONED_PART](#DEFAULT-HEIGHT-LIMIT-OF-CLONED-PART) | 복제된 부분의 기본 최대 크기입니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getHeightLimitOfClonedPart()](#getHeightLimitOfClonedPart--) | 복제된 부분의 높이 제한을 가져옵니다. |
+### KeepSolidObjectsAlgorithm() {#KeepSolidObjectsAlgorithm--}
+```
+public KeepSolidObjectsAlgorithm()
+```
+
+
+`KeepSolidObjectsAlgorithm` 클래스를 복제된 부분의 기본 높이 제한을 사용하여 새 인스턴스로 초기화합니다.
+
+### KeepSolidObjectsAlgorithm(float heightLimitOfClonedPart) {#KeepSolidObjectsAlgorithm-float-}
+```
+public KeepSolidObjectsAlgorithm(float heightLimitOfClonedPart)
+```
+
+
+`KeepSolidObjectsAlgorithm` 클래스를 복제된 부분의 특정 높이 제한을 사용하여 새 인스턴스로 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| heightLimitOfClonedPart | float | 복제된 부분의 최대 높이. |
+
+### DEFAULT_HEIGHT_LIMIT_OF_CLONED_PART {#DEFAULT-HEIGHT-LIMIT-OF-CLONED-PART}
+```
+public static final float DEFAULT_HEIGHT_LIMIT_OF_CLONED_PART
+```
+
+
+복제된 부분의 기본 최대 크기입니다.
+
+### getHeightLimitOfClonedPart() {#getHeightLimitOfClonedPart--}
+```
+public float getHeightLimitOfClonedPart()
+```
+
+
+복제된 부분의 높이 제한을 가져옵니다.
+
+**Returns:**
+float

--- a/korean/java/com.aspose.note/license/_index.md
+++ b/korean/java/com.aspose.note/license/_index.md
@@ -1,0 +1,142 @@
+---
+title: "License"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "구성 요소를 라이선스하는 메서드를 제공합니다."
+type: docs
+weight: 44
+url: /ko/java/com.aspose.note/license/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class License
+```
+
+구성 요소를 라이선스하는 메서드를 제공합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [License()](#License--) | 이 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [resetThreadContext()](#resetThreadContext--) | 현재 스레드에 대한 라이선스 컨텍스트를 재설정합니다. |
+| [setLicense(File licenseFile)](#setLicense-java.io.File-) | 구성 요소에 라이선스를 적용합니다. |
+| [setLicense(InputStream stream)](#setLicense-java.io.InputStream-) | 구성 요소에 라이선스를 적용합니다. |
+| [setLicense(String licenseName)](#setLicense-java.lang.String-) | 구성 요소에 라이선스를 적용합니다. |
+| [setThreadContext(InputStream stream)](#setThreadContext-java.io.InputStream-) | 현재 스레드에 대한 라이선스 컨텍스트를 설정합니다. |
+### License() {#License--}
+```
+public License()
+```
+
+
+이 클래스의 새 인스턴스를 초기화합니다.
+
+### resetThreadContext() {#resetThreadContext--}
+```
+public static void resetThreadContext()
+```
+
+
+현재 스레드에 대한 라이선스 컨텍스트를 재설정합니다.
+
+### setLicense(File licenseFile) {#setLicense-java.io.File-}
+```
+public void setLicense(File licenseFile)
+```
+
+
+구성 요소에 라이선스를 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| licenseFile | java.io.File | 라이선스 파일`System.IO.FileInfo`. |
+
+### setLicense(InputStream stream) {#setLicense-java.io.InputStream-}
+```
+public final void setLicense(InputStream stream)
+```
+
+
+구성 요소에 라이선스를 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+|  | 스트림 | java.io.InputStream | 라이선스를 포함하는 스트림입니다. |
+
+--------------------
+
+`
+
+이 메서드를 사용하여 스트림에서 라이선스를 로드합니다.
+
+`
+
+`void setLicense(java.io.InputStream stream)` |
+
+### setLicense(String licenseName) {#setLicense-java.lang.String-}
+```
+public final void setLicense(String licenseName)
+```
+
+
+구성 요소에 라이선스를 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+|  | licenseName | java.lang.String | 전체 또는 짧은 파일 이름` 또는 포함된 리소스의 이름`이 될 수 있습니다. 평가 모드로 전환하려면 빈 문자열을 사용하십시오. |
+
+--------------------
+
+`
+
+다음 위치에서 라이선스를 찾으려고 시도합니다:
+
+` `
+
+1. 명시적 경로.
+
+` `
+
+2. Aspose 구성 요소 어셈블리를 포함하는 폴더.
+
+3. 클라이언트의 호출 어셈블리를 포함하는 폴더.
+
+4. 엔트리(시작) 어셈블리를 포함하는 폴더.
+
+5. 클라이언트의 호출 어셈블리 내에 포함된 리소스.
+
+**Note:**On the .NET Compact Framework, tries to find the license only in these locations:
+
+1. 명시적 경로.
+
+2. 클라이언트의 호출 어셈블리 내에 포함된 리소스.
+
+` `
+
+2. Aspose 구성 요소 JAR 파일을 포함하는 폴더.
+
+3. 클라이언트의 호출 JAR 파일을 포함하는 폴더.
+
+` |
+
+### setThreadContext(InputStream stream) {#setThreadContext-java.io.InputStream-}
+```
+public static void setThreadContext(InputStream stream)
+```
+
+
+현재 스레드에 대한 라이선스 컨텍스트를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.InputStream | 라이선스를 포함하는 스트림입니다. |
+

--- a/korean/java/com.aspose.note/licenseexceptions/_index.md
+++ b/korean/java/com.aspose.note/licenseexceptions/_index.md
@@ -1,0 +1,145 @@
+---
+title: "LicenseExceptions"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: 
+type: docs
+weight: 45
+url: /ko/java/com.aspose.note/licenseexceptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LicenseExceptions
+```
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [LicenseExceptions()](#LicenseExceptions--) |  |
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BlackListedLicense_ExceptionMessage](#BlackListedLicense-ExceptionMessage) |  |
+| [ExpiredLicense_ExceptionMessage](#ExpiredLicense-ExceptionMessage) |  |
+| [InvalidBlackListResourceName_ExceptionMessage](#InvalidBlackListResourceName-ExceptionMessage) |  |
+| [InvalidEditionType_ExceptionMessage](#InvalidEditionType-ExceptionMessage) |  |
+| [InvalidLicenseSignature_ExceptionMessage](#InvalidLicenseSignature-ExceptionMessage) |  |
+| [InvalidProduct_ExceptionMessage](#InvalidProduct-ExceptionMessage) |  |
+| [InvalidSignatureBlackList_ExceptionMessage](#InvalidSignatureBlackList-ExceptionMessage) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [throwBlackListedLicense()](#throwBlackListedLicense--) |  |
+| [throwExpiredLicense()](#throwExpiredLicense--) |  |
+| [throwInvalidBlackListResourceName()](#throwInvalidBlackListResourceName--) |  |
+| [throwInvalidEditionType()](#throwInvalidEditionType--) |  |
+| [throwInvalidLicense()](#throwInvalidLicense--) |  |
+| [throwInvalidProduct()](#throwInvalidProduct--) |  |
+| [throwInvalidSignatureBlackList()](#throwInvalidSignatureBlackList--) |  |
+### LicenseExceptions() {#LicenseExceptions--}
+```
+public LicenseExceptions()
+```
+
+
+### BlackListedLicense_ExceptionMessage {#BlackListedLicense-ExceptionMessage}
+```
+public static final String BlackListedLicense_ExceptionMessage
+```
+
+
+### ExpiredLicense_ExceptionMessage {#ExpiredLicense-ExceptionMessage}
+```
+public static final String ExpiredLicense_ExceptionMessage
+```
+
+
+### InvalidBlackListResourceName_ExceptionMessage {#InvalidBlackListResourceName-ExceptionMessage}
+```
+public static final String InvalidBlackListResourceName_ExceptionMessage
+```
+
+
+### InvalidEditionType_ExceptionMessage {#InvalidEditionType-ExceptionMessage}
+```
+public static final String InvalidEditionType_ExceptionMessage
+```
+
+
+### InvalidLicenseSignature_ExceptionMessage {#InvalidLicenseSignature-ExceptionMessage}
+```
+public static final String InvalidLicenseSignature_ExceptionMessage
+```
+
+
+### InvalidProduct_ExceptionMessage {#InvalidProduct-ExceptionMessage}
+```
+public static final String InvalidProduct_ExceptionMessage
+```
+
+
+### InvalidSignatureBlackList_ExceptionMessage {#InvalidSignatureBlackList-ExceptionMessage}
+```
+public static final String InvalidSignatureBlackList_ExceptionMessage
+```
+
+
+### throwBlackListedLicense() {#throwBlackListedLicense--}
+```
+public static void throwBlackListedLicense()
+```
+
+
+
+
+### throwExpiredLicense() {#throwExpiredLicense--}
+```
+public static void throwExpiredLicense()
+```
+
+
+
+
+### throwInvalidBlackListResourceName() {#throwInvalidBlackListResourceName--}
+```
+public static void throwInvalidBlackListResourceName()
+```
+
+
+
+
+### throwInvalidEditionType() {#throwInvalidEditionType--}
+```
+public static void throwInvalidEditionType()
+```
+
+
+
+
+### throwInvalidLicense() {#throwInvalidLicense--}
+```
+public static void throwInvalidLicense()
+```
+
+
+
+
+### throwInvalidProduct() {#throwInvalidProduct--}
+```
+public static void throwInvalidProduct()
+```
+
+
+
+
+### throwInvalidSignatureBlackList() {#throwInvalidSignatureBlackList--}
+```
+public static void throwInvalidSignatureBlackList()
+```
+
+
+
+

--- a/korean/java/com.aspose.note/loadoptions/_index.md
+++ b/korean/java/com.aspose.note/loadoptions/_index.md
@@ -1,0 +1,83 @@
+---
+title: "LoadOptions"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "문서를 로드하는 데 사용되는 옵션입니다."
+type: docs
+weight: 46
+url: /ko/java/com.aspose.note/loadoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LoadOptions
+```
+
+문서를 로드하는 데 사용되는 옵션입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [LoadOptions()](#LoadOptions--) | `LoadOptions` 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getDocumentPassword()](#getDocumentPassword--) | 암호화된 문서 내용에 대한 비밀번호를 가져오거나 설정합니다. |
+| [getLoadHistory()](#getLoadHistory--) | 문서 로더가 기록을 무시해야 하는지를 나타내는 값을 가져오거나 설정합니다. |
+| [setDocumentPassword(String value)](#setDocumentPassword-java.lang.String-) | 암호화된 문서 내용에 대한 비밀번호를 가져오거나 설정합니다. |
+| [setLoadHistory(boolean value)](#setLoadHistory-boolean-) | 문서 로더가 기록을 무시해야 하는지를 나타내는 값을 가져오거나 설정합니다. |
+### LoadOptions() {#LoadOptions--}
+```
+public LoadOptions()
+```
+
+
+`LoadOptions` 클래스의 새 인스턴스를 초기화합니다.
+
+### getDocumentPassword() {#getDocumentPassword--}
+```
+public String getDocumentPassword()
+```
+
+
+암호화된 문서 내용에 대한 비밀번호를 가져오거나 설정합니다. 문서가 비밀번호로 보호되지 않은 경우 이 값은 무시됩니다.
+
+**Returns:**
+java.lang.String
+### getLoadHistory() {#getLoadHistory--}
+```
+public boolean getLoadHistory()
+```
+
+
+문서 로더가 기록을 무시해야 하는지를 나타내는 값을 가져오거나 설정합니다. 이 옵션을 사용하면 메모리와 CPU 사용량을 줄일 수 있습니다. 기본값은 `true`입니다.
+
+**Returns:**
+boolean
+### setDocumentPassword(String value) {#setDocumentPassword-java.lang.String-}
+```
+public void setDocumentPassword(String value)
+```
+
+
+암호화된 문서 내용에 대한 비밀번호를 가져오거나 설정합니다. 문서가 비밀번호로 보호되지 않은 경우 이 값은 무시됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setLoadHistory(boolean value) {#setLoadHistory-boolean-}
+```
+public void setLoadHistory(boolean value)
+```
+
+
+문서 로더가 기록을 무시해야 하는지를 나타내는 값을 가져오거나 설정합니다. 이 옵션을 사용하면 메모리와 CPU 사용량을 줄일 수 있습니다. 기본값은 `true`입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+

--- a/korean/java/com.aspose.note/localeoptions/_index.md
+++ b/korean/java/com.aspose.note/localeoptions/_index.md
@@ -1,0 +1,65 @@
+---
+title: "LocaleOptions"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "LocaleOptions 유형은 Aspose.Note에 대한 로케일 구성을 지정합니다."
+type: docs
+weight: 47
+url: /ko/java/com.aspose.note/localeoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LocaleOptions
+```
+
+LocaleOptions 유형은 Aspose.Note에 대한 로케일 구성을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [LocaleOptions()](#LocaleOptions--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clear()](#clear--) | Aspose.Note의 기본 로케일을 지웁니다. |
+| [getLocale()](#getLocale--) | Aspose.Note의 현재 실제 기본 로케일을 가져옵니다 |
+| [setLocale(Locale local)](#setLocale-java.util.Locale-) | Aspose.Note와 관련된 기본 로케일을 설정합니다. |
+### LocaleOptions() {#LocaleOptions--}
+```
+public LocaleOptions()
+```
+
+
+### clear() {#clear--}
+```
+public static void clear()
+```
+
+
+Aspose.Note의 기본 로케일을 지웁니다. Java에 사용할 기본 로케일이 됩니다.
+
+### getLocale() {#getLocale--}
+```
+public static Locale getLocale()
+```
+
+
+Aspose.Note의 현재 실제 기본 로케일을 가져옵니다
+
+**Returns:**
+java.util.Locale - 로케일 인스턴스
+### setLocale(Locale local) {#setLocale-java.util.Locale-}
+```
+public static void setLocale(Locale local)
+```
+
+
+Aspose.Note와 관련된 기본 로케일을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 로컬 | java.util.Locale | 로케일 인스턴스 |
+

--- a/korean/java/com.aspose.note/loop/_index.md
+++ b/korean/java/com.aspose.note/loop/_index.md
@@ -1,0 +1,100 @@
+---
+title: "Loop"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "루프를 나타냅니다."
+type: docs
+weight: 48
+url: /ko/java/com.aspose.note/loop/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node)
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode)
+```
+public class Loop extends Node implements IOutlineElementChildNode
+```
+
+루프를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Loop()](#Loop--) | 새 `Loop` 클래스 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | 노드의 방문자를 수락합니다. |
+| [getHyperlinkUrl()](#getHyperlinkUrl--) | 하이퍼링크를 가져옵니다. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 마지막 수정 시간을 가져옵니다. |
+| [setHyperlinkUrl(String value)](#setHyperlinkUrl-java.lang.String-) | 하이퍼링크를 설정합니다. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 마지막 수정 시간을 설정합니다. |
+### Loop() {#Loop--}
+```
+public Loop()
+```
+
+
+새 `Loop` 클래스 인스턴스를 초기화합니다.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+노드의 방문자를 수락합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor`에서 파생된 클래스의 객체. |
+
+### getHyperlinkUrl() {#getHyperlinkUrl--}
+```
+public String getHyperlinkUrl()
+```
+
+
+하이퍼링크를 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+마지막 수정 시간을 가져옵니다.
+
+**Returns:**
+java.util.Date
+### setHyperlinkUrl(String value) {#setHyperlinkUrl-java.lang.String-}
+```
+public void setHyperlinkUrl(String value)
+```
+
+
+하이퍼링크를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+마지막 수정 시간을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Date |  |
+

--- a/korean/java/com.aspose.note/margins/_index.md
+++ b/korean/java/com.aspose.note/margins/_index.md
@@ -1,0 +1,283 @@
+---
+title: "Margins"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "노드 여백의 크기를 지정합니다."
+type: docs
+weight: 49
+url: /ko/java/com.aspose.note/margins/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.lang.Struct
+
+**All Implemented Interfaces:**
+com.aspose.ms.System.IEquatable
+```
+public class Margins extends Struct<Margins> implements System.IEquatable<Margins>
+```
+
+노드 여백의 크기를 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Margins()](#Margins--) |  |
+| [Margins(float left, float right, float top, float bottom)](#Margins-float-float-float-float-) | 지정된 왼쪽, 오른쪽, 위, 아래 여백을 사용하여 `Margins` 구조체의 새 인스턴스를 초기화합니다. |
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Empty](#Empty) | 빈 여백입니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [Clone()](#Clone--) |  |
+| [CloneTo(Margins that)](#CloneTo-com.aspose.note.Margins-) |  |
+| [clone()](#clone--) |  |
+| [equals(Margins other)](#equals-com.aspose.note.Margins-) |  |
+| [equals(Margins obj1, Margins obj2)](#equals-com.aspose.note.Margins-com.aspose.note.Margins-) |  |
+| [equals(Object obj)](#equals-java.lang.Object-) | 두 `T:Margins` 구조가 같은지 테스트합니다. |
+| [getBottom()](#getBottom--) | 아래쪽 여백 너비를 가져오거나 설정합니다. |
+| [getLeft()](#getLeft--) | 왼쪽 여백 너비를 가져오거나 설정합니다. |
+| [getRight()](#getRight--) | 오른쪽 여백 너비를 가져오거나 설정합니다. |
+| [getTop()](#getTop--) | 위쪽 여백 너비를 가져오거나 설정합니다. |
+| [op_Equality(Margins lhs, Margins rhs)](#op-Equality-com.aspose.note.Margins-com.aspose.note.Margins-) | 두 `T:Margins` 구조가 같은지 테스트합니다. |
+| [op_Inequality(Margins lhs, Margins rhs)](#op-Inequality-com.aspose.note.Margins-com.aspose.note.Margins-) | 두 `T:Margins` 구조가 같지 않은지 테스트합니다. |
+| [setBottom(float value)](#setBottom-float-) | 아래쪽 여백 너비를 가져오거나 설정합니다. |
+| [setLeft(float value)](#setLeft-float-) | 왼쪽 여백 너비를 가져오거나 설정합니다. |
+| [setRight(float value)](#setRight-float-) | 오른쪽 여백 너비를 가져오거나 설정합니다. |
+| [setTop(float value)](#setTop-float-) | 위쪽 여백 너비를 가져오거나 설정합니다. |
+### Margins() {#Margins--}
+```
+public Margins()
+```
+
+
+### Margins(float left, float right, float top, float bottom) {#Margins-float-float-float-float-}
+```
+public Margins(float left, float right, float top, float bottom)
+```
+
+
+지정된 왼쪽, 오른쪽, 위, 아래 여백을 사용하여 `Margins` 구조체의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 왼쪽 | float | 왼쪽 여백 너비입니다. |
+| 오른쪽 | float | 오른쪽 여백 너비입니다. |
+| 위쪽 | float | 위쪽 여백 너비입니다. |
+| 아래쪽 | float | 하단 여백 너비입니다. |
+
+### Empty {#Empty}
+```
+public static final Margins Empty
+```
+
+
+빈 여백입니다.
+
+### Clone() {#Clone--}
+```
+public Margins Clone()
+```
+
+
+
+
+**Returns:**
+[Margins](../../com.aspose.note/margins)
+### CloneTo(Margins that) {#CloneTo-com.aspose.note.Margins-}
+```
+public void CloneTo(Margins that)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| that | [Margins](../../com.aspose.note/margins) |  |
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### equals(Margins other) {#equals-com.aspose.note.Margins-}
+```
+public boolean equals(Margins other)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| other | [Margins](../../com.aspose.note/margins) |  |
+
+**Returns:**
+boolean
+### equals(Margins obj1, Margins obj2) {#equals-com.aspose.note.Margins-com.aspose.note.Margins-}
+```
+public static boolean equals(Margins obj1, Margins obj2)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| obj1 | [Margins](../../com.aspose.note/margins) |  |
+| obj2 | [Margins](../../com.aspose.note/margins) |  |
+
+**Returns:**
+boolean
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+두 `T:Margins` 구조가 같은지 테스트합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | java.lang.Object | 임의 객체. |
+
+**Returns:**
+boolean - `bool`입니다.
+### getBottom() {#getBottom--}
+```
+public float getBottom()
+```
+
+
+아래쪽 여백 너비를 가져오거나 설정합니다.
+
+**Returns:**
+float
+### getLeft() {#getLeft--}
+```
+public float getLeft()
+```
+
+
+왼쪽 여백 너비를 가져오거나 설정합니다.
+
+**Returns:**
+float
+### getRight() {#getRight--}
+```
+public float getRight()
+```
+
+
+오른쪽 여백 너비를 가져오거나 설정합니다.
+
+**Returns:**
+float
+### getTop() {#getTop--}
+```
+public float getTop()
+```
+
+
+위쪽 여백 너비를 가져오거나 설정합니다.
+
+**Returns:**
+float
+### op_Equality(Margins lhs, Margins rhs) {#op-Equality-com.aspose.note.Margins-com.aspose.note.Margins-}
+```
+public static boolean op_Equality(Margins lhs, Margins rhs)
+```
+
+
+두 `T:Margins` 구조가 같은지 테스트합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| lhs | [Margins](../../com.aspose.note/margins) | `T:Margins` 구조체. |
+| rhs | [Margins](../../com.aspose.note/margins) | 비교 대상인 `T:Margins` 구조체. |
+
+**Returns:**
+boolean - `bool`입니다.
+### op_Inequality(Margins lhs, Margins rhs) {#op-Inequality-com.aspose.note.Margins-com.aspose.note.Margins-}
+```
+public static boolean op_Inequality(Margins lhs, Margins rhs)
+```
+
+
+두 `T:Margins` 구조가 같지 않은지 테스트합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| lhs | [Margins](../../com.aspose.note/margins) | `T:Margins` 구조체. |
+| rhs | [Margins](../../com.aspose.note/margins) | 비교 대상인 `T:Margins` 구조체. |
+
+**Returns:**
+boolean - `bool`입니다.
+### setBottom(float value) {#setBottom-float-}
+```
+public void setBottom(float value)
+```
+
+
+아래쪽 여백 너비를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setLeft(float value) {#setLeft-float-}
+```
+public void setLeft(float value)
+```
+
+
+왼쪽 여백 너비를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setRight(float value) {#setRight-float-}
+```
+public void setRight(float value)
+```
+
+
+오른쪽 여백 너비를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setTop(float value) {#setTop-float-}
+```
+public void setTop(float value)
+```
+
+
+위쪽 여백 너비를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+

--- a/korean/java/com.aspose.note/metered/_index.md
+++ b/korean/java/com.aspose.note/metered/_index.md
@@ -1,0 +1,108 @@
+---
+title: "Metered"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "계량 키를 설정하는 메서드를 제공합니다."
+type: docs
+weight: 50
+url: /ko/java/com.aspose.note/metered/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Metered
+```
+
+계량 키를 설정하는 메서드를 제공합니다.
+
+--------------------
+
+&gt; ```
+&gt; 이 예제에서는 metered 공개 키와 개인 키를 설정하려고 시도합니다.
+&gt; ``````
+
+  [C#]
+
+Metered metered = new Metered();
+metered.SetMeteredKey("PublicKey", "PrivateKey");
+  [Visual Basic]
+Dim metered As Metered = New Metered
+metered.SetMeteredKey("PublicKey", "PrivateKey")
+  
+```
+
+the component jar file:
+
+```
+
+Metered metered = new Metered();
+metered.setMeteredKey("PublicKey", "PrivateKey");
+  
+```
+
+
+## Constructors
+
+| Constructor | Description |
+| --- | --- |
+| [Metered()](#Metered--) |  |
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getConsumptionCredit()](#getConsumptionCredit--) | Gets consumption credit. |
+| [getConsumptionQuantity()](#getConsumptionQuantity--) | Gets consumption file size. |
+| [resetMeteredKey()](#resetMeteredKey--) | Removes previously setup license. |
+| [setMeteredKey(String publicKey, String privateKey)](#setMeteredKey-java.lang.String-java.lang.String-) | Sets metered public and private keys. |
+### Metered() {#Metered--}
+```
+public Metered()
+```
+
+
+### getConsumptionCredit() {#getConsumptionCredit--}
+```
+public static BigDecimal getConsumptionCredit()
+```
+
+
+Gets consumption credit.
+
+**Returns:**
+java.math.BigDecimal - Returns the number of consumed credit points.
+### getConsumptionQuantity() {#getConsumptionQuantity--}
+```
+public static BigDecimal getConsumptionQuantity()
+```
+
+
+Gets consumption file size.
+
+**Returns:**
+java.math.BigDecimal - Returns the number of consumed bytes.
+### resetMeteredKey() {#resetMeteredKey--}
+```
+public final void resetMeteredKey()
+```
+
+
+Removes previously setup license.
+
+### setMeteredKey(String publicKey, String privateKey) {#setMeteredKey-java.lang.String-java.lang.String-}
+```
+public final void setMeteredKey(String publicKey, String privateKey)
+```
+
+
+Sets metered public and private keys.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| publicKey | java.lang.String | The public key. |
+| privateKey | java.lang.String | The private key.
+
+--------------------
+
+If you purchase metered license, this API should be called on application startup, normally, this is enough. However, if metered fails to upload consumption data during 24 hours period, the license will be set to evaluation status. To avoid such case, you should regularly check the license status If it is evaluation status, call this API again. |
+

--- a/korean/java/com.aspose.note/node/_index.md
+++ b/korean/java/com.aspose.note/node/_index.md
@@ -1,0 +1,120 @@
+---
+title: "노드"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "Aspose.Note 문서의 모든 노드에 대한 기본 클래스입니다."
+type: docs
+weight: 51
+url: /ko/java/com.aspose.note/node/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.note.INode](../../com.aspose.note/inode)
+```
+public abstract class Node implements INode
+```
+
+Aspose.Note 문서의 모든 노드에 대한 기본 클래스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | 노드의 방문자를 수락합니다. |
+| [getDocument()](#getDocument--) | 노드의 문서를 가져옵니다. |
+| [getNextSibling()](#getNextSibling--) | 같은 노드 트리 레벨에 있는 다음 노드를 가져옵니다. |
+| [getNodeId()](#getNodeId--) | 노드의 ID를 가져옵니다. |
+| [getNodeType()](#getNodeType--) | 노드 유형을 가져옵니다. |
+| [getParentNode()](#getParentNode--) | 부모 노드를 가져옵니다. |
+| [getPreviousSibling()](#getPreviousSibling--) | 같은 노드 트리 레벨에 있는 이전 노드를 가져옵니다. |
+| [isComposite()](#isComposite--) | 이 노드가 복합 노드인지 여부를 나타내는 값을 가져옵니다. |
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public abstract void accept(DocumentVisitor visitor)
+```
+
+
+노드의 방문자를 수락합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor`에서 파생된 클래스의 객체. |
+
+### getDocument() {#getDocument--}
+```
+public Document getDocument()
+```
+
+
+노드의 문서를 가져옵니다.
+
+값: 문서.
+
+**Returns:**
+[Document](../../com.aspose.note/document)
+### getNextSibling() {#getNextSibling--}
+```
+public INode getNextSibling()
+```
+
+
+같은 노드 트리 레벨에 있는 다음 노드를 가져옵니다.
+
+값: 다음 형제.
+
+**Returns:**
+[INode](../../com.aspose.note/inode)
+### getNodeId() {#getNodeId--}
+```
+public ExtendedGuid getNodeId()
+```
+
+
+노드의 ID를 가져옵니다.
+
+**Returns:**
+[ExtendedGuid](../../com.aspose.note.revision.types/extendedguid)
+### getNodeType() {#getNodeType--}
+```
+public int getNodeType()
+```
+
+
+노드 유형을 가져옵니다.
+
+**Returns:**
+int
+### getParentNode() {#getParentNode--}
+```
+public ICompositeNode getParentNode()
+```
+
+
+부모 노드를 가져옵니다.
+
+**Returns:**
+[ICompositeNode](../../com.aspose.note/icompositenode)
+### getPreviousSibling() {#getPreviousSibling--}
+```
+public INode getPreviousSibling()
+```
+
+
+같은 노드 트리 레벨에 있는 이전 노드를 가져옵니다.
+
+값: 이전 형제.
+
+**Returns:**
+[INode](../../com.aspose.note/inode)
+### isComposite() {#isComposite--}
+```
+public boolean isComposite()
+```
+
+
+이 노드가 복합 노드인지 여부를 나타내는 값을 가져옵니다. true인 경우 노드는 자식 노드를 가질 수 있습니다.
+
+**Returns:**
+boolean

--- a/korean/java/com.aspose.note/nodetype/_index.md
+++ b/korean/java/com.aspose.note/nodetype/_index.md
@@ -1,0 +1,182 @@
+---
+title: "NodeType"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "노드의 유형을 지정합니다."
+type: docs
+weight: 52
+url: /ko/java/com.aspose.note/nodetype/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class NodeType extends System.Enum
+```
+
+노드의 유형을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [AttachedFile](#AttachedFile) | 노드가 `AttachedFile`임을 지정합니다. |
+| [Document](#Document) | 노드가 `Document`임을 지정합니다. |
+| [Image](#Image) | 노드가 `Image`임을 지정합니다. |
+| [InkDrawing](#InkDrawing) | 노드가 [InkDrawing](../../com.aspose.note/nodetype\#InkDrawing)임을 지정합니다. |
+| [InkParagraph](#InkParagraph) | 노드가 [InkParagraph](../../com.aspose.note/nodetype\#InkParagraph)임을 지정합니다. |
+| [InkWord](#InkWord) | 노드가 [InkWord](../../com.aspose.note/nodetype\#InkWord)임을 지정합니다. |
+| [Loop](#Loop) | 노드가 [Loop](../../com.aspose.note/nodetype\#Loop)임을 지정합니다. |
+| [Outline](#Outline) | 노드가 `Outline`임을 지정합니다. |
+| [OutlineElement](#OutlineElement) | 노드가 `OutlineElement`임을 지정합니다. |
+| [OutlineGroup](#OutlineGroup) | 노드가 `OutlineGroup`임을 지정합니다. |
+| [Page](#Page) | 노드가 `Page`임을 지정합니다. |
+| [PageSeries](#PageSeries) | 노드가 `PageSeries`임을 지정합니다. |
+| [RichText](#RichText) | 노드가 `RichText`임을 지정합니다. |
+| [Section](#Section) | 노드가 `Section`임을 지정합니다. |
+| [Table](#Table) | 노드가 `Table`임을 지정합니다. |
+| [TableCell](#TableCell) | 노드가 `TableCell`임을 지정합니다. |
+| [TableRow](#TableRow) | 노드가 `TableRow`임을 지정합니다. |
+| [Title](#Title) | 노드가 `Title`임을 지정합니다. |
+### AttachedFile {#AttachedFile}
+```
+public static final int AttachedFile
+```
+
+
+노드가 `AttachedFile`임을 지정합니다.
+
+### Document {#Document}
+```
+public static final int Document
+```
+
+
+노드가 `Document`임을 지정합니다.
+
+### Image {#Image}
+```
+public static final int Image
+```
+
+
+노드가 `Image`임을 지정합니다.
+
+### InkDrawing {#InkDrawing}
+```
+public static final int InkDrawing
+```
+
+
+노드가 [InkDrawing](../../com.aspose.note/nodetype\#InkDrawing)임을 지정합니다.
+
+### InkParagraph {#InkParagraph}
+```
+public static final int InkParagraph
+```
+
+
+노드가 [InkParagraph](../../com.aspose.note/nodetype\#InkParagraph)임을 지정합니다.
+
+### InkWord {#InkWord}
+```
+public static final int InkWord
+```
+
+
+노드가 [InkWord](../../com.aspose.note/nodetype\#InkWord)임을 지정합니다.
+
+### Loop {#Loop}
+```
+public static final int Loop
+```
+
+
+노드가 [Loop](../../com.aspose.note/nodetype\#Loop)임을 지정합니다.
+
+### Outline {#Outline}
+```
+public static final int Outline
+```
+
+
+노드가 `Outline`임을 지정합니다.
+
+### OutlineElement {#OutlineElement}
+```
+public static final int OutlineElement
+```
+
+
+노드가 `OutlineElement`임을 지정합니다.
+
+### OutlineGroup {#OutlineGroup}
+```
+public static final int OutlineGroup
+```
+
+
+노드가 `OutlineGroup`임을 지정합니다.
+
+### Page {#Page}
+```
+public static final int Page
+```
+
+
+노드가 `Page`임을 지정합니다.
+
+### PageSeries {#PageSeries}
+```
+public static final int PageSeries
+```
+
+
+노드가 `PageSeries`임을 지정합니다.
+
+### RichText {#RichText}
+```
+public static final int RichText
+```
+
+
+노드가 `RichText`임을 지정합니다.
+
+### Section {#Section}
+```
+public static final int Section
+```
+
+
+노드가 `Section`임을 지정합니다.
+
+### Table {#Table}
+```
+public static final int Table
+```
+
+
+노드가 `Table`임을 지정합니다.
+
+### TableCell {#TableCell}
+```
+public static final int TableCell
+```
+
+
+노드가 `TableCell`임을 지정합니다.
+
+### TableRow {#TableRow}
+```
+public static final int TableRow
+```
+
+
+노드가 `TableRow`임을 지정합니다.
+
+### Title {#Title}
+```
+public static final int Title
+```
+
+
+노드가 `Title`임을 지정합니다.
+

--- a/korean/java/com.aspose.note/notebook/_index.md
+++ b/korean/java/com.aspose.note/notebook/_index.md
@@ -1,0 +1,438 @@
+---
+title: "노트북"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "Aspose.Note 노트북을 나타냅니다."
+type: docs
+weight: 56
+url: /ko/java/com.aspose.note/notebook/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.note.INotebookChildNode](../../com.aspose.note/inotebookchildnode), com.aspose.ms.System.Collections.Generic.IGenericEnumerable
+```
+public class Notebook implements INotebookChildNode, System.Collections.Generic.IGenericEnumerable<INotebookChildNode>
+```
+
+Aspose.Note 노트북을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Notebook()](#Notebook--) | `Notebook` 클래스의 새 인스턴스를 초기화합니다. |
+| [Notebook(String filePath)](#Notebook-java.lang.String-) | `Notebook` 클래스의 새 인스턴스를 초기화합니다. |
+| [Notebook(String filePath, NotebookLoadOptions loadOptions)](#Notebook-java.lang.String-com.aspose.note.NotebookLoadOptions-) | `Notebook` 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [&lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass)](#-T1-getChildNodes-java.lang.Class-T1--) | 노드 유형별로 모든 자식 노드를 가져옵니다. |
+| [appendChild(INotebookChildNode newChild)](#appendChild-com.aspose.note.INotebookChildNode-) | 노드를 목록 끝에 추가합니다. |
+| [getColor()](#getColor--) | 색상을 가져오거나 설정합니다. |
+| [getCount()](#getCount--) | `Notebook`에 포함된 요소 수를 가져옵니다. |
+| [getDisplayName()](#getDisplayName--) | 표시 이름을 가져오거나 설정합니다. |
+| [getFileFormat()](#getFileFormat--) | 파일 형식을 가져옵니다 (OneNote 2010, OneNote Online). |
+| [getGuid()](#getGuid--) | 객체의 전역 고유 ID를 가져옵니다. |
+| [getGuidInternal()](#getGuidInternal--) |  |
+| [get_Item(int index)](#get-Item-int-) | 지정된 인덱스로 노트북 자식 노드를 가져옵니다. |
+| [isHistoryEnabled()](#isHistoryEnabled--) | 히스토리가 활성화되어 있는지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [iterator()](#iterator--) | `Notebook`의 자식 노드를 순회하는 열거자를 반환합니다. |
+| [loadChildDocument(InputStream stream)](#loadChildDocument-java.io.InputStream-) | 자식 문서 노드를 추가합니다. |
+| [loadChildDocument(InputStream stream, LoadOptions loadOptions)](#loadChildDocument-java.io.InputStream-com.aspose.note.LoadOptions-) | 자식 문서 노드를 추가합니다. |
+| [loadChildDocument(String filePath)](#loadChildDocument-java.lang.String-) | 자식 문서 노드를 추가합니다. |
+| [loadChildDocument(String filePath, LoadOptions loadOptions)](#loadChildDocument-java.lang.String-com.aspose.note.LoadOptions-) | 자식 문서 노드를 추가합니다. |
+| [loadChildNotebook(String filePath)](#loadChildNotebook-java.lang.String-) | 자식 노트북 노드를 추가합니다. |
+| [loadChildNotebook(String filePath, NotebookLoadOptions loadOptions)](#loadChildNotebook-java.lang.String-com.aspose.note.NotebookLoadOptions-) | 자식 노트북 노드를 추가합니다. |
+| [removeChild(INotebookChildNode oldChild)](#removeChild-com.aspose.note.INotebookChildNode-) | 자식 노드를 제거합니다. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | OneNote 문서를 스트림에 저장합니다. |
+| [save(OutputStream stream, NotebookSaveOptions options)](#save-java.io.OutputStream-com.aspose.note.NotebookSaveOptions-) | 지정된 저장 옵션을 사용하여 OneNote 문서를 스트림에 저장합니다. |
+| [save(OutputStream stream, int format)](#save-java.io.OutputStream-int-) | 지정된 형식으로 OneNote 문서를 스트림에 저장합니다. |
+| [save(String fileName)](#save-java.lang.String-) | OneNote 문서를 파일에 저장합니다. |
+| [save(String fileName, NotebookSaveOptions options)](#save-java.lang.String-com.aspose.note.NotebookSaveOptions-) | 지정된 저장 옵션을 사용하여 OneNote 문서를 파일에 저장합니다. |
+| [save(String fileName, int format)](#save-java.lang.String-int-) | 지정된 형식으로 OneNote 문서를 파일에 저장합니다. |
+| [setColor(Color value)](#setColor-java.awt.Color-) | 색상을 가져오거나 설정합니다. |
+| [setDisplayName(String value)](#setDisplayName-java.lang.String-) | 표시 이름을 가져오거나 설정합니다. |
+| [setHistoryEnabled(boolean value)](#setHistoryEnabled-boolean-) | 히스토리가 활성화되어 있는지 여부를 나타내는 값을 가져오거나 설정합니다. |
+### Notebook() {#Notebook--}
+```
+public Notebook()
+```
+
+
+`Notebook` 클래스의 새 인스턴스를 초기화합니다.
+
+### Notebook(String filePath) {#Notebook-java.lang.String-}
+```
+public Notebook(String filePath)
+```
+
+
+`Notebook` 클래스의 새 인스턴스를 초기화합니다. 파일에서 기존 OneNote 노트북을 엽니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| filePath | java.lang.String | 파일 경로. |
+
+### Notebook(String filePath, NotebookLoadOptions loadOptions) {#Notebook-java.lang.String-com.aspose.note.NotebookLoadOptions-}
+```
+public Notebook(String filePath, NotebookLoadOptions loadOptions)
+```
+
+
+새 `Notebook` 클래스의 인스턴스를 초기화합니다. 파일에서 기존 OneNote 노트북을 엽니다. "lazy"/instant와 같은 추가 옵션을 지정할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| filePath | java.lang.String | 파일 경로. |
+| loadOptions | [NotebookLoadOptions](../../com.aspose.note/notebookloadoptions) | 로드 옵션입니다. |
+
+### &lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass) {#-T1-getChildNodes-java.lang.Class-T1--}
+```
+public List<T1> <T1>getChildNodes(Class<T1> typeParameterClass)
+```
+
+
+노드 유형별로 모든 자식 노드를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| typeParameterClass | java.lang.Class&lt;T1&gt; |  |
+
+**Returns:**
+java.util.List&lt;T1&gt; - 자식 노드의 목록입니다.
+
+`T1`: 반환된 목록에 있는 요소의 유형입니다.
+### appendChild(INotebookChildNode newChild) {#appendChild-com.aspose.note.INotebookChildNode-}
+```
+public INotebookChildNode appendChild(INotebookChildNode newChild)
+```
+
+
+노드를 목록 끝에 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| newChild | [INotebookChildNode](../../com.aspose.note/inotebookchildnode) | 추가할 노드입니다. |
+
+**Returns:**
+[INotebookChildNode](../../com.aspose.note/inotebookchildnode) - The added node.
+### getColor() {#getColor--}
+```
+public Color getColor()
+```
+
+
+색상을 가져오거나 설정합니다.
+
+**Returns:**
+java.awt.Color
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+`Notebook`에 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### getDisplayName() {#getDisplayName--}
+```
+public String getDisplayName()
+```
+
+
+표시 이름을 가져오거나 설정합니다.
+
+**Returns:**
+java.lang.String
+### getFileFormat() {#getFileFormat--}
+```
+public int getFileFormat()
+```
+
+
+파일 형식을 가져옵니다 (OneNote 2010, OneNote Online).
+
+**Returns:**
+int
+### getGuid() {#getGuid--}
+```
+public UUID getGuid()
+```
+
+
+객체의 전역 고유 ID를 가져옵니다.
+
+값: GUID입니다.
+
+**Returns:**
+java.util.UUID
+### getGuidInternal() {#getGuidInternal--}
+```
+public System.Guid getGuidInternal()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Guid
+### get_Item(int index) {#get-Item-int-}
+```
+public INotebookChildNode get_Item(int index)
+```
+
+
+지정된 인덱스로 노트북 자식 노드를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| index | int | 자식 노드의 인덱스입니다. |
+
+**Returns:**
+[INotebookChildNode](../../com.aspose.note/inotebookchildnode) - The child node on the `index` position.
+### isHistoryEnabled() {#isHistoryEnabled--}
+```
+public boolean isHistoryEnabled()
+```
+
+
+히스토리가 활성화되어 있는지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public System.Collections.Generic.IGenericEnumerator<INotebookChildNode> iterator()
+```
+
+
+`Notebook`의 자식 노드를 순회하는 열거자를 반환합니다.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;com.aspose.note.INotebookChildNode&gt; - `IEnumerator`입니다.
+### loadChildDocument(InputStream stream) {#loadChildDocument-java.io.InputStream-}
+```
+public void loadChildDocument(InputStream stream)
+```
+
+
+자식 문서 노드를 추가합니다. 스트림에서 기존 OneNote 문서를 엽니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.InputStream | 스트림입니다. |
+
+### loadChildDocument(InputStream stream, LoadOptions loadOptions) {#loadChildDocument-java.io.InputStream-com.aspose.note.LoadOptions-}
+```
+public void loadChildDocument(InputStream stream, LoadOptions loadOptions)
+```
+
+
+자식 문서 노드를 추가합니다. 스트림에서 기존 OneNote 문서를 엽니다. 추가 로드 옵션을 지정할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.InputStream | 스트림입니다. |
+| loadOptions | [LoadOptions](../../com.aspose.note/loadoptions) | 로드 옵션입니다. |
+
+### loadChildDocument(String filePath) {#loadChildDocument-java.lang.String-}
+```
+public void loadChildDocument(String filePath)
+```
+
+
+자식 문서 노드를 추가합니다. 파일에서 기존 OneNote 문서를 엽니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| filePath | java.lang.String | 파일 경로. |
+
+### loadChildDocument(String filePath, LoadOptions loadOptions) {#loadChildDocument-java.lang.String-com.aspose.note.LoadOptions-}
+```
+public void loadChildDocument(String filePath, LoadOptions loadOptions)
+```
+
+
+자식 문서 노드를 추가합니다. 파일에서 기존 OneNote 문서를 엽니다. 추가 로드 옵션을 지정할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| filePath | java.lang.String | 파일 경로. |
+| loadOptions | [LoadOptions](../../com.aspose.note/loadoptions) | 로드 옵션입니다. |
+
+### loadChildNotebook(String filePath) {#loadChildNotebook-java.lang.String-}
+```
+public void loadChildNotebook(String filePath)
+```
+
+
+자식 노트북 노드를 추가합니다. 파일에서 기존 OneNote 노트북을 엽니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| filePath | java.lang.String | 파일 경로. |
+
+### loadChildNotebook(String filePath, NotebookLoadOptions loadOptions) {#loadChildNotebook-java.lang.String-com.aspose.note.NotebookLoadOptions-}
+```
+public void loadChildNotebook(String filePath, NotebookLoadOptions loadOptions)
+```
+
+
+자식 노트북 노드를 추가합니다. 파일에서 기존 OneNote 노트북을 엽니다. 추가 로드 옵션을 지정할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| filePath | java.lang.String | 파일 경로. |
+| loadOptions | [NotebookLoadOptions](../../com.aspose.note/notebookloadoptions) | 로드 옵션입니다. |
+
+### removeChild(INotebookChildNode oldChild) {#removeChild-com.aspose.note.INotebookChildNode-}
+```
+public INotebookChildNode removeChild(INotebookChildNode oldChild)
+```
+
+
+자식 노드를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| oldChild | [INotebookChildNode](../../com.aspose.note/inotebookchildnode) | 제거할 노드입니다. |
+
+**Returns:**
+[INotebookChildNode](../../com.aspose.note/inotebookchildnode) - The removed node.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+OneNote 문서를 스트림에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.OutputStream | 스트림입니다. |
+
+### save(OutputStream stream, NotebookSaveOptions options) {#save-java.io.OutputStream-com.aspose.note.NotebookSaveOptions-}
+```
+public void save(OutputStream stream, NotebookSaveOptions options)
+```
+
+
+지정된 저장 옵션을 사용하여 OneNote 문서를 스트림에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.OutputStream | 스트림입니다. |
+| options | [NotebookSaveOptions](../../com.aspose.note/notebooksaveoptions) | 문서를 저장하는 옵션을 지정합니다. |
+
+### save(OutputStream stream, int format) {#save-java.io.OutputStream-int-}
+```
+public void save(OutputStream stream, int format)
+```
+
+
+지정된 형식으로 OneNote 문서를 스트림에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.OutputStream | 스트림입니다. |
+| format | int | 문서를 저장할 형식. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+OneNote 문서를 파일에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 파일이름 | java.lang.String | 파일의 전체 이름입니다. 지정된 전체 이름을 가진 파일이 이미 존재하면 기존 파일이 덮어쓰기됩니다. |
+
+### save(String fileName, NotebookSaveOptions options) {#save-java.lang.String-com.aspose.note.NotebookSaveOptions-}
+```
+public void save(String fileName, NotebookSaveOptions options)
+```
+
+
+지정된 저장 옵션을 사용하여 OneNote 문서를 파일에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 파일이름 | java.lang.String | 파일의 전체 이름입니다. 지정된 전체 이름을 가진 파일이 이미 존재하면 기존 파일이 덮어쓰기됩니다. |
+| options | [NotebookSaveOptions](../../com.aspose.note/notebooksaveoptions) | 문서가 파일에 저장되는 옵션을 지정합니다. |
+
+### save(String fileName, int format) {#save-java.lang.String-int-}
+```
+public void save(String fileName, int format)
+```
+
+
+지정된 형식으로 OneNote 문서를 파일에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 파일이름 | java.lang.String | 파일의 전체 이름입니다. 지정된 전체 이름을 가진 파일이 이미 존재하면 기존 파일이 덮어쓰기됩니다. |
+| format | int | 문서를 저장할 형식. |
+
+### setColor(Color value) {#setColor-java.awt.Color-}
+```
+public void setColor(Color value)
+```
+
+
+색상을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.Color |  |
+
+### setDisplayName(String value) {#setDisplayName-java.lang.String-}
+```
+public void setDisplayName(String value)
+```
+
+
+표시 이름을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setHistoryEnabled(boolean value) {#setHistoryEnabled-boolean-}
+```
+public void setHistoryEnabled(boolean value)
+```
+
+
+히스토리가 활성화되어 있는지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+

--- a/korean/java/com.aspose.note/notebookimagesaveoptions/_index.md
+++ b/korean/java/com.aspose.note/notebookimagesaveoptions/_index.md
@@ -1,0 +1,34 @@
+---
+title: "NotebookImageSaveOptions"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "노트북 페이지를 이미지로 렌더링할 때 추가 옵션을 지정할 수 있습니다."
+type: docs
+weight: 57
+url: /ko/java/com.aspose.note/notebookimagesaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.NotebookSaveOptions](../../com.aspose.note/notebooksaveoptions), com.aspose.note.NotebookSaveOptionsGeneric
+```
+public class NotebookImageSaveOptions extends NotebookSaveOptionsGeneric<ImageSaveOptions>
+```
+
+노트북 페이지를 이미지로 렌더링할 때 추가 옵션을 지정할 수 있습니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [NotebookImageSaveOptions(int format)](#NotebookImageSaveOptions-int-) | 새 `NotebookImageSaveOptions` 클래스의 인스턴스를 초기화합니다. |
+### NotebookImageSaveOptions(int format) {#NotebookImageSaveOptions-int-}
+```
+public NotebookImageSaveOptions(int format)
+```
+
+
+새 `NotebookImageSaveOptions` 클래스의 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| format | int | 노트북이 저장되는 형식. |
+

--- a/korean/java/com.aspose.note/notebookloadoptions/_index.md
+++ b/korean/java/com.aspose.note/notebookloadoptions/_index.md
@@ -1,0 +1,99 @@
+---
+title: "NotebookLoadOptions"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "노트북을 로드하는 데 사용되는 옵션입니다."
+type: docs
+weight: 58
+url: /ko/java/com.aspose.note/notebookloadoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class NotebookLoadOptions
+```
+
+노트북을 로드하는 데 사용되는 옵션입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [NotebookLoadOptions()](#NotebookLoadOptions--) | 새 `NotebookLoadOptions` 클래스의 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getDeferredLoading()](#getDeferredLoading--) | 자식 문서를 나중에 명시적으로 로드해야 하는지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [getInstantLoading()](#getInstantLoading--) | 부모 문서가 로드되는 동안 자식 문서를 로드해야 하는지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [setDeferredLoading(boolean value)](#setDeferredLoading-boolean-) | 자식 문서를 나중에 명시적으로 로드해야 하는지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [setInstantLoading(boolean value)](#setInstantLoading-boolean-) | 부모 문서가 로드되는 동안 자식 문서를 로드해야 하는지 여부를 나타내는 값을 가져오거나 설정합니다. |
+### NotebookLoadOptions() {#NotebookLoadOptions--}
+```
+public NotebookLoadOptions()
+```
+
+
+새 `NotebookLoadOptions` 클래스의 인스턴스를 초기화합니다.
+
+### getDeferredLoading() {#getDeferredLoading--}
+```
+public final boolean getDeferredLoading()
+```
+
+
+자식 문서를 나중에 명시적으로 로드해야 하는지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+--------------------
+
+기본값은 `false`이며, 따라서 하위 문서는 암시적으로 로드됩니다. 값 `true`는 사용자가 `Notebook.loadChildDocument`를 호출하거나 노트북 자체가 로드된 후 각 노트북의 하위 노드를 호출해야 함을 나타냅니다. 값이 `true`이면 `NotebookLoadOptions.instantLoading` 옵션은 무시됩니다. 노트북이 스트림에서 로드되는 경우, 값은 사용자가 `false`로 명시적으로 설정했더라도 항상 `true`입니다.
+
+**Returns:**
+boolean
+### getInstantLoading() {#getInstantLoading--}
+```
+public boolean getInstantLoading()
+```
+
+
+부모 문서가 로드되는 동안 자식 문서를 로드해야 하는지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+--------------------
+
+기본값은 `false`이며, 하위 문서는 지연 로드됩니다. 즉, 특정 하위 항목에 직접 접근할 때까지 로드를 연기해야 합니다. 값 `true`는 로드를 즉시 수행해야 함을 나타냅니다.
+
+**Returns:**
+boolean
+### setDeferredLoading(boolean value) {#setDeferredLoading-boolean-}
+```
+public final void setDeferredLoading(boolean value)
+```
+
+
+자식 문서를 나중에 명시적으로 로드해야 하는지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+--------------------
+
+기본값은 `false`이며, 따라서 하위 문서는 암시적으로 로드됩니다. 값 `true`는 사용자가 `Notebook.loadChildDocument`를 호출하거나 노트북 자체가 로드된 후 각 노트북의 하위 노드를 호출해야 함을 나타냅니다. 값이 `true`이면 `NotebookLoadOptions.instantLoading` 옵션은 무시됩니다. 노트북이 스트림에서 로드되는 경우, 값은 사용자가 `false`로 명시적으로 설정했더라도 항상 `true`입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setInstantLoading(boolean value) {#setInstantLoading-boolean-}
+```
+public void setInstantLoading(boolean value)
+```
+
+
+부모 문서가 로드되는 동안 자식 문서를 로드해야 하는지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+--------------------
+
+기본값은 `false`이며, 하위 문서는 지연 로드됩니다. 즉, 특정 하위 항목에 직접 접근할 때까지 로드를 연기해야 합니다. 값 `true`는 로드를 즉시 수행해야 함을 나타냅니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+

--- a/korean/java/com.aspose.note/notebookonesaveoptions/_index.md
+++ b/korean/java/com.aspose.note/notebookonesaveoptions/_index.md
@@ -1,0 +1,29 @@
+---
+title: "NotebookOneSaveOptions"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "노트북을 OneNote 형식으로 저장할 때 추가 옵션을 지정할 수 있습니다."
+type: docs
+weight: 59
+url: /ko/java/com.aspose.note/notebookonesaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.NotebookSaveOptions](../../com.aspose.note/notebooksaveoptions), com.aspose.note.NotebookSaveOptionsGeneric
+```
+public class NotebookOneSaveOptions extends NotebookSaveOptionsGeneric<OneSaveOptions>
+```
+
+노트북을 OneNote 형식으로 저장할 때 추가 옵션을 지정할 수 있습니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [NotebookOneSaveOptions()](#NotebookOneSaveOptions--) | 새 `NotebookOneSaveOptions` 클래스의 새 인스턴스를 초기화합니다. |
+### NotebookOneSaveOptions() {#NotebookOneSaveOptions--}
+```
+public NotebookOneSaveOptions()
+```
+
+
+새 `NotebookOneSaveOptions` 클래스의 새 인스턴스를 초기화합니다.
+

--- a/korean/java/com.aspose.note/notebookpdfsaveoptions/_index.md
+++ b/korean/java/com.aspose.note/notebookpdfsaveoptions/_index.md
@@ -1,0 +1,29 @@
+---
+title: "NotebookPdfSaveOptions"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "노트북 페이지를 PDF로 렌더링할 때 추가 옵션을 지정할 수 있습니다."
+type: docs
+weight: 60
+url: /ko/java/com.aspose.note/notebookpdfsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.NotebookSaveOptions](../../com.aspose.note/notebooksaveoptions), com.aspose.note.NotebookSaveOptionsGeneric
+```
+public class NotebookPdfSaveOptions extends NotebookSaveOptionsGeneric<PdfSaveOptions>
+```
+
+노트북 페이지를 PDF로 렌더링할 때 추가 옵션을 지정할 수 있습니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [NotebookPdfSaveOptions()](#NotebookPdfSaveOptions--) | 새 `NotebookPdfSaveOptions` 클래스의 새 인스턴스를 초기화합니다. |
+### NotebookPdfSaveOptions() {#NotebookPdfSaveOptions--}
+```
+public NotebookPdfSaveOptions()
+```
+
+
+새 `NotebookPdfSaveOptions` 클래스의 새 인스턴스를 초기화합니다.
+

--- a/korean/java/com.aspose.note/notebooksaveoptions/_index.md
+++ b/korean/java/com.aspose.note/notebooksaveoptions/_index.md
@@ -1,0 +1,100 @@
+---
+title: "NotebookSaveOptions"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "특정 형식에 대한 노트북 저장 옵션을 나타내는 추상 기본 클래스입니다."
+type: docs
+weight: 61
+url: /ko/java/com.aspose.note/notebooksaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class NotebookSaveOptions
+```
+
+특정 형식에 대한 노트북 저장 옵션을 나타내는 추상 기본 클래스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getDeferredSaving()](#getDeferredSaving--) | 자식 문서를 명시적으로 저장해야 하는지를 나타내는 값을 가져오거나 설정합니다. |
+| [getDocumentSaveOptionsInternal()](#getDocumentSaveOptionsInternal--) | 노트북의 모든 자식 문서에 대한 저장 옵션을 가져옵니다. |
+| [getFlatten()](#getFlatten--) | 노트북 자식 계층 구조가 평탄화되어 저장되는지를 나타내는 값을 가져오거나 설정합니다. |
+| [getSaveFormat()](#getSaveFormat--) | 노트북이 저장되는 형식을 가져옵니다. |
+| [setDeferredSaving(boolean value)](#setDeferredSaving-boolean-) | 자식 문서를 명시적으로 저장해야 하는지를 나타내는 값을 가져오거나 설정합니다. |
+| [setFlatten(boolean value)](#setFlatten-boolean-) | 노트북 자식 계층 구조가 평탄화되어 저장되는지를 나타내는 값을 가져오거나 설정합니다. |
+### getDeferredSaving() {#getDeferredSaving--}
+```
+public boolean getDeferredSaving()
+```
+
+
+자식 문서를 명시적으로 저장해야 하는지를 나타내는 값을 가져오거나 설정합니다.
+
+--------------------
+
+기본값은 `false`이며, 따라서 하위 문서는 암시적으로 저장됩니다. `true` 값은 사용자가 각 노트북의 하위 노드를 명시적으로 저장해야 함을 나타냅니다. 노트북을 스트림에 저장하는 경우, 사용자가 `false`로 명시적으로 설정했더라도 값은 항상 `true`입니다.
+
+**Returns:**
+boolean
+### getDocumentSaveOptionsInternal() {#getDocumentSaveOptionsInternal--}
+```
+public abstract SaveOptions getDocumentSaveOptionsInternal()
+```
+
+
+노트북의 모든 자식 문서에 대한 저장 옵션을 가져옵니다.
+
+**Returns:**
+[SaveOptions](../../com.aspose.note/saveoptions) - The `SaveOptions`.
+### getFlatten() {#getFlatten--}
+```
+public boolean getFlatten()
+```
+
+
+노트북 자식 계층 구조가 평탄화되어 저장되는지를 나타내는 값을 가져오거나 설정합니다.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public abstract int getSaveFormat()
+```
+
+
+노트북이 저장되는 형식을 가져옵니다.
+
+**Returns:**
+int
+### setDeferredSaving(boolean value) {#setDeferredSaving-boolean-}
+```
+public void setDeferredSaving(boolean value)
+```
+
+
+자식 문서를 명시적으로 저장해야 하는지를 나타내는 값을 가져오거나 설정합니다.
+
+--------------------
+
+기본값은 `false`이며, 따라서 하위 문서는 암시적으로 저장됩니다. `true` 값은 사용자가 각 노트북의 하위 노드를 명시적으로 저장해야 함을 나타냅니다. 노트북을 스트림에 저장하는 경우, 사용자가 `false`로 명시적으로 설정했더라도 값은 항상 `true`입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setFlatten(boolean value) {#setFlatten-boolean-}
+```
+public void setFlatten(boolean value)
+```
+
+
+노트북 자식 계층 구조가 평탄화되어 저장되는지를 나타내는 값을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+

--- a/korean/java/com.aspose.note/notebooksaveoptionsgeneric/_index.md
+++ b/korean/java/com.aspose.note/notebooksaveoptionsgeneric/_index.md
@@ -1,0 +1,68 @@
+---
+title: "NotebookSaveOptionsGeneric"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "특정 형식에 대한 노트북 저장 옵션을 나타내고 모든 문서 하위 노드에 대한 공통 저장 옵션을 제공하는 추상 기본 클래스입니다."
+type: docs
+weight: 62
+url: /ko/java/com.aspose.note/notebooksaveoptionsgeneric/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.NotebookSaveOptions](../../com.aspose.note/notebooksaveoptions)
+```
+public abstract class NotebookSaveOptionsGeneric<TDocumentSaveOptions> extends NotebookSaveOptions
+```
+
+특정 형식에 대한 노트북 저장 옵션을 나타내고 모든 문서 하위 노드에 대한 공통 저장 옵션을 제공하는 추상 기본 클래스입니다.
+
+`TDocumentSaveOptions`: 모든 노트북의 하위 문서에 대한 저장 옵션입니다.
+
+TDocumentSaveOptions :
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [NotebookSaveOptionsGeneric()](#NotebookSaveOptionsGeneric--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getDocumentSaveOptions()](#getDocumentSaveOptions--) | 모든 노트북 하위 문서에 대한 저장 옵션을 가져오거나 설정합니다. |
+| [getDocumentSaveOptionsInternal()](#getDocumentSaveOptionsInternal--) | 노트북의 모든 자식 문서에 대한 저장 옵션을 가져옵니다. |
+| [getSaveFormat()](#getSaveFormat--) | 노트북이 저장되는 형식을 가져옵니다. |
+### NotebookSaveOptionsGeneric() {#NotebookSaveOptionsGeneric--}
+```
+public NotebookSaveOptionsGeneric()
+```
+
+
+### getDocumentSaveOptions() {#getDocumentSaveOptions--}
+```
+public TDocumentSaveOptions getDocumentSaveOptions()
+```
+
+
+모든 노트북 하위 문서에 대한 저장 옵션을 가져오거나 설정합니다.
+
+**Returns:**
+TDocumentSaveOptions
+### getDocumentSaveOptionsInternal() {#getDocumentSaveOptionsInternal--}
+```
+public SaveOptions getDocumentSaveOptionsInternal()
+```
+
+
+노트북의 모든 자식 문서에 대한 저장 옵션을 가져옵니다.
+
+**Returns:**
+[SaveOptions](../../com.aspose.note/saveoptions) - The `SaveOptions`.
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+노트북이 저장되는 형식을 가져옵니다.
+
+**Returns:**
+int

--- a/korean/java/com.aspose.note/notecheckbox/_index.md
+++ b/korean/java/com.aspose.note/notecheckbox/_index.md
@@ -1,0 +1,883 @@
+---
+title: "NoteCheckBox"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "완료와 미완료 상태를 전환할 수 있는 노트 태그를 나타냅니다."
+type: docs
+weight: 53
+url: /ko/java/com.aspose.note/notecheckbox/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.note.TagExtended, [com.aspose.note.CheckBox](../../com.aspose.note/checkbox)
+
+**All Implemented Interfaces:**
+[com.aspose.note.INoteTag](../../com.aspose.note/inotetag), com.aspose.ms.System.IEquatable
+```
+public class NoteCheckBox extends CheckBox implements INoteTag, System.IEquatable<NoteCheckBox>
+```
+
+완료와 미완료 상태를 전환할 수 있는 노트 태그를 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [createBlueCheckBox()](#createBlueCheckBox--) | * 새로운 노트 태그를 BlueCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다. |
+| [createBlueCheckBox(String label)](#createBlueCheckBox-java.lang.String-) | * 새로운 노트 체크박스를 BlueCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다. |
+| [createBlueCheckBox1()](#createBlueCheckBox1--) | * 새로운 노트 태그를 BlueCheckBox1Empty 아이콘과 기본 레이블로 생성합니다. |
+| [createBlueCheckBox1(String label)](#createBlueCheckBox1-java.lang.String-) | * 새로운 노트 체크박스를 BlueCheckBox1Empty 아이콘과 지정된 레이블로 생성합니다. |
+| [createBlueCheckBox2()](#createBlueCheckBox2--) | * 새로운 노트 태그를 BlueCheckBox2Empty 아이콘과 기본 레이블로 생성합니다. |
+| [createBlueCheckBox2(String label)](#createBlueCheckBox2-java.lang.String-) | * 새로운 노트 체크박스를 BlueCheckBox2Empty 아이콘과 지정된 레이블로 생성합니다. |
+| [createBlueCheckBox3()](#createBlueCheckBox3--) | * 새로운 노트 태그를 BlueCheckBox3Empty 아이콘과 기본 레이블로 생성합니다. |
+| [createBlueCheckBox3(String label)](#createBlueCheckBox3-java.lang.String-) | * 새로운 노트 체크박스를 BlueCheckBox3Empty 아이콘과 지정된 레이블로 생성합니다. |
+| [createBlueExclamationCheckBox()](#createBlueExclamationCheckBox--) | * 새로운 노트 태그를 BlueExclamationCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다. |
+| [createBlueExclamationCheckBox(String label)](#createBlueExclamationCheckBox-java.lang.String-) | * 새로운 노트 체크박스를 BlueExclamationCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다. |
+| [createBlueFlagCheckBox()](#createBlueFlagCheckBox--) | * 새로운 노트 태그를 BlueFlagCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다. |
+| [createBlueFlagCheckBox(String label)](#createBlueFlagCheckBox-java.lang.String-) | * 새로운 노트 체크박스를 BlueFlagCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다. |
+| [createBluePersonCheckBox()](#createBluePersonCheckBox--) | \* 새 노트 태그를 BluePersonCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다. |
+| [createBluePersonCheckBox(String label)](#createBluePersonCheckBox-java.lang.String-) | \* 새 노트 체크박스를 BluePersonCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다. |
+| [createBlueRightArrowCheckBox()](#createBlueRightArrowCheckBox--) | \* 새 노트 태그를 BlueRightArrowCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다. |
+| [createBlueRightArrowCheckBox(String label)](#createBlueRightArrowCheckBox-java.lang.String-) | \* 새 노트 체크박스를 BlueRightArrowCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다. |
+| [createBlueStarCheckBox()](#createBlueStarCheckBox--) | \* 새 노트 태그를 BlueStarCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다. |
+| [createBlueStarCheckBox(String label)](#createBlueStarCheckBox-java.lang.String-) | \* 새 노트 체크박스를 BlueStarCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenCheckBox()](#createGreenCheckBox--) | \* 새 노트 태그를 GreenCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenCheckBox(String label)](#createGreenCheckBox-java.lang.String-) | \* 새 노트 체크박스를 GreenCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenCheckBox1()](#createGreenCheckBox1--) | \* 새 노트 태그를 GreenCheckBox1Empty 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenCheckBox1(String label)](#createGreenCheckBox1-java.lang.String-) | \* 새 노트 체크박스를 GreenCheckBox1Empty 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenCheckBox2()](#createGreenCheckBox2--) | \* 새 노트 태그를 GreenCheckBox2Empty 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenCheckBox2(String label)](#createGreenCheckBox2-java.lang.String-) | \* 새 노트 체크박스를 GreenCheckBox2Empty 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenCheckBox3()](#createGreenCheckBox3--) | \* 새 노트 태그를 GreenCheckBox3Empty 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenCheckBox3(String label)](#createGreenCheckBox3-java.lang.String-) | \* 새 노트 체크박스를 GreenCheckBox3Empty 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenExclamationCheckBox()](#createGreenExclamationCheckBox--) | \* 새 노트 태그를 GreenExclamationCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenExclamationCheckBox(String label)](#createGreenExclamationCheckBox-java.lang.String-) | \* 새 노트 체크박스를 GreenExclamationCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenFlagCheckBox()](#createGreenFlagCheckBox--) | \* 새 노트 태그를 GreenFlagCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenFlagCheckBox(String label)](#createGreenFlagCheckBox-java.lang.String-) | \* 새 노트 체크박스를 GreenFlagCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenPersonCheckBox()](#createGreenPersonCheckBox--) | \* 새 노트 태그를 GreenPersonCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenPersonCheckBox(String label)](#createGreenPersonCheckBox-java.lang.String-) | \* 새 노트 체크박스를 GreenPersonCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenRightArrowCheckBox()](#createGreenRightArrowCheckBox--) | \* 새 노트 태그를 GreenRightArrowCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenRightArrowCheckBox(String label)](#createGreenRightArrowCheckBox-java.lang.String-) | \* 새 노트 체크박스를 GreenRightArrowCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenStarCheckBox()](#createGreenStarCheckBox--) | \* 새 노트 태그를 GreenStarCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenStarCheckBox(String label)](#createGreenStarCheckBox-java.lang.String-) | \* 새 노트 체크박스를 GreenStarCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다. |
+| [createRedFlagCheckBox()](#createRedFlagCheckBox--) | \* 새 노트 태그를 RedFlagCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다. |
+| [createRedFlagCheckBox(String label)](#createRedFlagCheckBox-java.lang.String-) | * RedFlagCheckBoxEmpty 아이콘과 지정된 레이블을 사용하여 새 노트 체크박스를 생성합니다. |
+| [createYellowCheckBox()](#createYellowCheckBox--) | * YellowCheckBoxEmpty 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowCheckBox(String label)](#createYellowCheckBox-java.lang.String-) | * YellowCheckBoxEmpty 아이콘과 지정된 레이블을 사용하여 새 노트 체크박스를 생성합니다. |
+| [createYellowCheckBox1()](#createYellowCheckBox1--) | * YellowCheckBox1Empty 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowCheckBox1(String label)](#createYellowCheckBox1-java.lang.String-) | * YellowCheckBox1Empty 아이콘과 지정된 레이블을 사용하여 새 노트 체크박스를 생성합니다. |
+| [createYellowCheckBox2()](#createYellowCheckBox2--) | * YellowCheckBox2Empty 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowCheckBox2(String label)](#createYellowCheckBox2-java.lang.String-) | * YellowCheckBox2Empty 아이콘과 지정된 레이블을 사용하여 새 노트 체크박스를 생성합니다. |
+| [createYellowCheckBox3()](#createYellowCheckBox3--) | * YellowCheckBox3Empty 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowCheckBox3(String label)](#createYellowCheckBox3-java.lang.String-) | * YellowCheckBox3Empty 아이콘과 지정된 레이블을 사용하여 새 노트 체크박스를 생성합니다. |
+| [createYellowExclamationCheckBox()](#createYellowExclamationCheckBox--) | * YellowExclamationCheckBoxEmpty 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowExclamationCheckBox(String label)](#createYellowExclamationCheckBox-java.lang.String-) | * YellowExclamationCheckBoxEmpty 아이콘과 지정된 레이블을 사용하여 새 노트 체크박스를 생성합니다. |
+| [createYellowPersonCheckBox()](#createYellowPersonCheckBox--) | * YellowPersonCheckBoxEmpty 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowPersonCheckBox(String label)](#createYellowPersonCheckBox-java.lang.String-) | * YellowPersonCheckBoxEmpty 아이콘과 지정된 레이블을 사용하여 새 노트 체크박스를 생성합니다. |
+| [createYellowRightArrowCheckBox()](#createYellowRightArrowCheckBox--) | * YellowRightArrowCheckBoxEmpty 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowRightArrowCheckBox(String label)](#createYellowRightArrowCheckBox-java.lang.String-) | * YellowRightArrowCheckBoxEmpty 아이콘과 지정된 레이블을 사용하여 새 노트 체크박스를 생성합니다. |
+| [createYellowStarCheckBox()](#createYellowStarCheckBox--) | * YellowStarCheckBoxEmpty 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowStarCheckBox(String label)](#createYellowStarCheckBox-java.lang.String-) | * YellowStarCheckBoxEmpty 아이콘과 지정된 레이블을 사용하여 새 노트 체크박스를 생성합니다. |
+| [equals(NoteCheckBox other)](#equals-com.aspose.note.NoteCheckBox-) | 지정된 객체가 현재 객체와 같은지 여부를 결정합니다. |
+| [equals(Object obj)](#equals-java.lang.Object-) | 지정된 객체가 현재 객체와 같은지 여부를 결정합니다. |
+| [getFontColor()](#getFontColor--) | 글꼴 색상을 가져오거나 설정합니다. |
+| [getHighlight()](#getHighlight--) | 하이라이트 색상을 가져오거나 설정합니다. |
+| [getIcon()](#getIcon--) | 아이콘을 가져오거나 설정합니다. |
+| [getLabel()](#getLabel--) | 레이블 텍스트를 가져오거나 설정합니다. |
+| [hashCode()](#hashCode--) | 해당 유형에 대한 해시 함수로 사용됩니다. |
+| [setFontColor(Color value)](#setFontColor-java.awt.Color-) | 글꼴 색상을 가져오거나 설정합니다. |
+| [setHighlight(Color value)](#setHighlight-java.awt.Color-) | 하이라이트 색상을 가져오거나 설정합니다. |
+| [setLabel(String value)](#setLabel-java.lang.String-) | 레이블 텍스트를 가져오거나 설정합니다. |
+### createBlueCheckBox() {#createBlueCheckBox--}
+```
+public static NoteCheckBox createBlueCheckBox()
+```
+
+
+* 새로운 노트 태그를 BlueCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox(String label) {#createBlueCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createBlueCheckBox(String label)
+```
+
+
+* 새로운 노트 체크박스를 BlueCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox1() {#createBlueCheckBox1--}
+```
+public static NoteCheckBox createBlueCheckBox1()
+```
+
+
+* 새로운 노트 태그를 BlueCheckBox1Empty 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox1(String label) {#createBlueCheckBox1-java.lang.String-}
+```
+public static NoteCheckBox createBlueCheckBox1(String label)
+```
+
+
+* 새로운 노트 체크박스를 BlueCheckBox1Empty 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox2() {#createBlueCheckBox2--}
+```
+public static NoteCheckBox createBlueCheckBox2()
+```
+
+
+* 새로운 노트 태그를 BlueCheckBox2Empty 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox2(String label) {#createBlueCheckBox2-java.lang.String-}
+```
+public static NoteCheckBox createBlueCheckBox2(String label)
+```
+
+
+* 새로운 노트 체크박스를 BlueCheckBox2Empty 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox3() {#createBlueCheckBox3--}
+```
+public static NoteCheckBox createBlueCheckBox3()
+```
+
+
+* 새로운 노트 태그를 BlueCheckBox3Empty 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox3(String label) {#createBlueCheckBox3-java.lang.String-}
+```
+public static NoteCheckBox createBlueCheckBox3(String label)
+```
+
+
+* 새로운 노트 체크박스를 BlueCheckBox3Empty 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueExclamationCheckBox() {#createBlueExclamationCheckBox--}
+```
+public static NoteCheckBox createBlueExclamationCheckBox()
+```
+
+
+* 새로운 노트 태그를 BlueExclamationCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueExclamationCheckBox(String label) {#createBlueExclamationCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createBlueExclamationCheckBox(String label)
+```
+
+
+* 새로운 노트 체크박스를 BlueExclamationCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueFlagCheckBox() {#createBlueFlagCheckBox--}
+```
+public static NoteCheckBox createBlueFlagCheckBox()
+```
+
+
+* 새로운 노트 태그를 BlueFlagCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueFlagCheckBox(String label) {#createBlueFlagCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createBlueFlagCheckBox(String label)
+```
+
+
+* 새로운 노트 체크박스를 BlueFlagCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBluePersonCheckBox() {#createBluePersonCheckBox--}
+```
+public static NoteCheckBox createBluePersonCheckBox()
+```
+
+
+\* 새 노트 태그를 BluePersonCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBluePersonCheckBox(String label) {#createBluePersonCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createBluePersonCheckBox(String label)
+```
+
+
+\* 새 노트 체크박스를 BluePersonCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueRightArrowCheckBox() {#createBlueRightArrowCheckBox--}
+```
+public static NoteCheckBox createBlueRightArrowCheckBox()
+```
+
+
+\* 새 노트 태그를 BlueRightArrowCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueRightArrowCheckBox(String label) {#createBlueRightArrowCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createBlueRightArrowCheckBox(String label)
+```
+
+
+\* 새 노트 체크박스를 BlueRightArrowCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueStarCheckBox() {#createBlueStarCheckBox--}
+```
+public static NoteCheckBox createBlueStarCheckBox()
+```
+
+
+\* 새 노트 태그를 BlueStarCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueStarCheckBox(String label) {#createBlueStarCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createBlueStarCheckBox(String label)
+```
+
+
+\* 새 노트 체크박스를 BlueStarCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox() {#createGreenCheckBox--}
+```
+public static NoteCheckBox createGreenCheckBox()
+```
+
+
+\* 새 노트 태그를 GreenCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox(String label) {#createGreenCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createGreenCheckBox(String label)
+```
+
+
+\* 새 노트 체크박스를 GreenCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox1() {#createGreenCheckBox1--}
+```
+public static NoteCheckBox createGreenCheckBox1()
+```
+
+
+\* 새 노트 태그를 GreenCheckBox1Empty 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox1(String label) {#createGreenCheckBox1-java.lang.String-}
+```
+public static NoteCheckBox createGreenCheckBox1(String label)
+```
+
+
+\* 새 노트 체크박스를 GreenCheckBox1Empty 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox2() {#createGreenCheckBox2--}
+```
+public static NoteCheckBox createGreenCheckBox2()
+```
+
+
+\* 새 노트 태그를 GreenCheckBox2Empty 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox2(String label) {#createGreenCheckBox2-java.lang.String-}
+```
+public static NoteCheckBox createGreenCheckBox2(String label)
+```
+
+
+\* 새 노트 체크박스를 GreenCheckBox2Empty 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox3() {#createGreenCheckBox3--}
+```
+public static NoteCheckBox createGreenCheckBox3()
+```
+
+
+\* 새 노트 태그를 GreenCheckBox3Empty 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox3(String label) {#createGreenCheckBox3-java.lang.String-}
+```
+public static NoteCheckBox createGreenCheckBox3(String label)
+```
+
+
+\* 새 노트 체크박스를 GreenCheckBox3Empty 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenExclamationCheckBox() {#createGreenExclamationCheckBox--}
+```
+public static NoteCheckBox createGreenExclamationCheckBox()
+```
+
+
+\* 새 노트 태그를 GreenExclamationCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenExclamationCheckBox(String label) {#createGreenExclamationCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createGreenExclamationCheckBox(String label)
+```
+
+
+\* 새 노트 체크박스를 GreenExclamationCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenFlagCheckBox() {#createGreenFlagCheckBox--}
+```
+public static NoteCheckBox createGreenFlagCheckBox()
+```
+
+
+\* 새 노트 태그를 GreenFlagCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenFlagCheckBox(String label) {#createGreenFlagCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createGreenFlagCheckBox(String label)
+```
+
+
+\* 새 노트 체크박스를 GreenFlagCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenPersonCheckBox() {#createGreenPersonCheckBox--}
+```
+public static NoteCheckBox createGreenPersonCheckBox()
+```
+
+
+\* 새 노트 태그를 GreenPersonCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenPersonCheckBox(String label) {#createGreenPersonCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createGreenPersonCheckBox(String label)
+```
+
+
+\* 새 노트 체크박스를 GreenPersonCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenRightArrowCheckBox() {#createGreenRightArrowCheckBox--}
+```
+public static NoteCheckBox createGreenRightArrowCheckBox()
+```
+
+
+\* 새 노트 태그를 GreenRightArrowCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenRightArrowCheckBox(String label) {#createGreenRightArrowCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createGreenRightArrowCheckBox(String label)
+```
+
+
+\* 새 노트 체크박스를 GreenRightArrowCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenStarCheckBox() {#createGreenStarCheckBox--}
+```
+public static NoteCheckBox createGreenStarCheckBox()
+```
+
+
+\* 새 노트 태그를 GreenStarCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenStarCheckBox(String label) {#createGreenStarCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createGreenStarCheckBox(String label)
+```
+
+
+\* 새 노트 체크박스를 GreenStarCheckBoxEmpty 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createRedFlagCheckBox() {#createRedFlagCheckBox--}
+```
+public static NoteCheckBox createRedFlagCheckBox()
+```
+
+
+\* 새 노트 태그를 RedFlagCheckBoxEmpty 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createRedFlagCheckBox(String label) {#createRedFlagCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createRedFlagCheckBox(String label)
+```
+
+
+* RedFlagCheckBoxEmpty 아이콘과 지정된 레이블을 사용하여 새 노트 체크박스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox() {#createYellowCheckBox--}
+```
+public static NoteCheckBox createYellowCheckBox()
+```
+
+
+* YellowCheckBoxEmpty 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox(String label) {#createYellowCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createYellowCheckBox(String label)
+```
+
+
+* YellowCheckBoxEmpty 아이콘과 지정된 레이블을 사용하여 새 노트 체크박스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox1() {#createYellowCheckBox1--}
+```
+public static NoteCheckBox createYellowCheckBox1()
+```
+
+
+* YellowCheckBox1Empty 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox1(String label) {#createYellowCheckBox1-java.lang.String-}
+```
+public static NoteCheckBox createYellowCheckBox1(String label)
+```
+
+
+* YellowCheckBox1Empty 아이콘과 지정된 레이블을 사용하여 새 노트 체크박스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox2() {#createYellowCheckBox2--}
+```
+public static NoteCheckBox createYellowCheckBox2()
+```
+
+
+* YellowCheckBox2Empty 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox2(String label) {#createYellowCheckBox2-java.lang.String-}
+```
+public static NoteCheckBox createYellowCheckBox2(String label)
+```
+
+
+* YellowCheckBox2Empty 아이콘과 지정된 레이블을 사용하여 새 노트 체크박스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox3() {#createYellowCheckBox3--}
+```
+public static NoteCheckBox createYellowCheckBox3()
+```
+
+
+* YellowCheckBox3Empty 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox3(String label) {#createYellowCheckBox3-java.lang.String-}
+```
+public static NoteCheckBox createYellowCheckBox3(String label)
+```
+
+
+* YellowCheckBox3Empty 아이콘과 지정된 레이블을 사용하여 새 노트 체크박스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowExclamationCheckBox() {#createYellowExclamationCheckBox--}
+```
+public static NoteCheckBox createYellowExclamationCheckBox()
+```
+
+
+* YellowExclamationCheckBoxEmpty 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowExclamationCheckBox(String label) {#createYellowExclamationCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createYellowExclamationCheckBox(String label)
+```
+
+
+* YellowExclamationCheckBoxEmpty 아이콘과 지정된 레이블을 사용하여 새 노트 체크박스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowPersonCheckBox() {#createYellowPersonCheckBox--}
+```
+public static NoteCheckBox createYellowPersonCheckBox()
+```
+
+
+* YellowPersonCheckBoxEmpty 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowPersonCheckBox(String label) {#createYellowPersonCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createYellowPersonCheckBox(String label)
+```
+
+
+* YellowPersonCheckBoxEmpty 아이콘과 지정된 레이블을 사용하여 새 노트 체크박스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowRightArrowCheckBox() {#createYellowRightArrowCheckBox--}
+```
+public static NoteCheckBox createYellowRightArrowCheckBox()
+```
+
+
+* YellowRightArrowCheckBoxEmpty 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowRightArrowCheckBox(String label) {#createYellowRightArrowCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createYellowRightArrowCheckBox(String label)
+```
+
+
+* YellowRightArrowCheckBoxEmpty 아이콘과 지정된 레이블을 사용하여 새 노트 체크박스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowStarCheckBox() {#createYellowStarCheckBox--}
+```
+public static NoteCheckBox createYellowStarCheckBox()
+```
+
+
+* YellowStarCheckBoxEmpty 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowStarCheckBox(String label) {#createYellowStarCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createYellowStarCheckBox(String label)
+```
+
+
+* YellowStarCheckBoxEmpty 아이콘과 지정된 레이블을 사용하여 새 노트 체크박스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### equals(NoteCheckBox other) {#equals-com.aspose.note.NoteCheckBox-}
+```
+public final boolean equals(NoteCheckBox other)
+```
+
+
+지정된 객체가 현재 객체와 같은지 여부를 결정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| other | [NoteCheckBox](../../com.aspose.note/notecheckbox) | 객체입니다. |
+
+**Returns:**
+boolean - 그 `boolean`.
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+지정된 객체가 현재 객체와 같은지 여부를 결정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | java.lang.Object | 객체입니다. |
+
+**Returns:**
+boolean - 그 `boolean`.
+### getFontColor() {#getFontColor--}
+```
+public final Color getFontColor()
+```
+
+
+글꼴 색상을 가져오거나 설정합니다.
+
+**Returns:**
+java.awt.Color
+### getHighlight() {#getHighlight--}
+```
+public final Color getHighlight()
+```
+
+
+하이라이트 색상을 가져오거나 설정합니다.
+
+**Returns:**
+java.awt.Color
+### getIcon() {#getIcon--}
+```
+public int getIcon()
+```
+
+
+아이콘을 가져오거나 설정합니다.
+
+값: [TagIcon](../../com.aspose.note.infrastructure/tagicon)입니다.
+
+**Returns:**
+int
+### getLabel() {#getLabel--}
+```
+public final String getLabel()
+```
+
+
+레이블 텍스트를 가져오거나 설정합니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+해당 유형에 대한 해시 함수로 사용됩니다.
+
+**Returns:**
+int - `int`입니다.
+### setFontColor(Color value) {#setFontColor-java.awt.Color-}
+```
+public final void setFontColor(Color value)
+```
+
+
+글꼴 색상을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.Color |  |
+
+### setHighlight(Color value) {#setHighlight-java.awt.Color-}
+```
+public final void setHighlight(Color value)
+```
+
+
+하이라이트 색상을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.Color |  |
+
+### setLabel(String value) {#setLabel-java.lang.String-}
+```
+public final void setLabel(String value)
+```
+
+
+레이블 텍스트를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+

--- a/korean/java/com.aspose.note/notetag/_index.md
+++ b/korean/java/com.aspose.note/notetag/_index.md
@@ -1,0 +1,3262 @@
+---
+title: "NoteTag"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "노트 태그를 나타냅니다."
+type: docs
+weight: 54
+url: /ko/java/com.aspose.note/notetag/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.note.TagExtended
+
+**All Implemented Interfaces:**
+[com.aspose.note.INoteTag](../../com.aspose.note/inotetag), com.aspose.ms.System.IEquatable
+```
+public final class NoteTag extends TagExtended implements INoteTag, System.IEquatable<NoteTag>
+```
+
+노트 태그를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [NoteTag()](#NoteTag--) | 아이콘 없이 [NoteTag](../../com.aspose.note/notetag) 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [createAwardRibbon()](#createAwardRibbon--) | \* AwardRibbon 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createAwardRibbon(String label)](#createAwardRibbon-java.lang.String-) | \* AwardRibbon 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createBinoculars()](#createBinoculars--) | \* Binoculars 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createBinoculars(String label)](#createBinoculars-java.lang.String-) | \* Binoculars 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createBlankPaperWithLines()](#createBlankPaperWithLines--) | \* BlankPaperWithLines 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createBlankPaperWithLines(String label)](#createBlankPaperWithLines-java.lang.String-) | \* BlankPaperWithLines 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createBlueCheckMark()](#createBlueCheckMark--) | \* BlueCheckMark 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createBlueCheckMark(String label)](#createBlueCheckMark-java.lang.String-) | \* BlueCheckMark 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createBlueCircle()](#createBlueCircle--) | \* BlueCircle 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createBlueCircle(String label)](#createBlueCircle-java.lang.String-) | \* BlueCircle 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createBlueCircle1()](#createBlueCircle1--) | \* BlueCircle1 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createBlueCircle1(String label)](#createBlueCircle1-java.lang.String-) | \* BlueCircle1 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createBlueCircle2()](#createBlueCircle2--) | \* BlueCircle2 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createBlueCircle2(String label)](#createBlueCircle2-java.lang.String-) | \* BlueCircle2 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createBlueCircle3()](#createBlueCircle3--) | \* BlueCircle3 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createBlueCircle3(String label)](#createBlueCircle3-java.lang.String-) | \* BlueCircle3 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createBlueDownArrow()](#createBlueDownArrow--) | \* BlueDownArrow 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createBlueDownArrow(String label)](#createBlueDownArrow-java.lang.String-) | \* BlueDownArrow 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createBlueEightPointStar()](#createBlueEightPointStar--) | \* BlueEightPointStar 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createBlueEightPointStar(String label)](#createBlueEightPointStar-java.lang.String-) | \* BlueEightPointStar 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createBlueFollowUpFlag()](#createBlueFollowUpFlag--) | \* BlueFollowUpFlag 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createBlueFollowUpFlag(String label)](#createBlueFollowUpFlag-java.lang.String-) | \* 새 노트 태그를 BlueFollowUpFlag 아이콘과 지정된 레이블로 생성합니다. |
+| [createBlueLeftArrow()](#createBlueLeftArrow--) | \* 새 노트 태그를 BlueLeftArrow 아이콘과 기본 레이블로 생성합니다. |
+| [createBlueLeftArrow(String label)](#createBlueLeftArrow-java.lang.String-) | \* 새 노트 태그를 BlueLeftArrow 아이콘과 지정된 레이블로 생성합니다. |
+| [createBlueRightArrow()](#createBlueRightArrow--) | \* 새 노트 태그를 BlueRightArrow 아이콘과 기본 레이블로 생성합니다. |
+| [createBlueRightArrow(String label)](#createBlueRightArrow-java.lang.String-) | \* 새 노트 태그를 BlueRightArrow 아이콘과 지정된 레이블로 생성합니다. |
+| [createBlueSolidTarget()](#createBlueSolidTarget--) | \* 새 노트 태그를 BlueSolidTarget 아이콘과 기본 레이블로 생성합니다. |
+| [createBlueSolidTarget(String label)](#createBlueSolidTarget-java.lang.String-) | \* 새 노트 태그를 BlueSolidTarget 아이콘과 지정된 레이블로 생성합니다. |
+| [createBlueSquare()](#createBlueSquare--) | \* 새 노트 태그를 BlueSquare 아이콘과 기본 레이블로 생성합니다. |
+| [createBlueSquare(String label)](#createBlueSquare-java.lang.String-) | \* 새 노트 태그를 BlueSquare 아이콘과 지정된 레이블로 생성합니다. |
+| [createBlueStar()](#createBlueStar--) | \* 새 노트 태그를 BlueStar 아이콘과 기본 레이블로 생성합니다. |
+| [createBlueStar(String label)](#createBlueStar-java.lang.String-) | \* 새 노트 태그를 BlueStar 아이콘과 지정된 레이블로 생성합니다. |
+| [createBlueSun()](#createBlueSun--) | \* 새 노트 태그를 BlueSun 아이콘과 기본 레이블로 생성합니다. |
+| [createBlueSun(String label)](#createBlueSun-java.lang.String-) | \* 새 노트 태그를 BlueSun 아이콘과 지정된 레이블로 생성합니다. |
+| [createBlueTarget()](#createBlueTarget--) | \* 새 노트 태그를 BlueTarget 아이콘과 기본 레이블로 생성합니다. |
+| [createBlueTarget(String label)](#createBlueTarget-java.lang.String-) | \* 새 노트 태그를 BlueTarget 아이콘과 지정된 레이블로 생성합니다. |
+| [createBlueTriangle()](#createBlueTriangle--) | \* 새 노트 태그를 BlueTriangle 아이콘과 기본 레이블로 생성합니다. |
+| [createBlueTriangle(String label)](#createBlueTriangle-java.lang.String-) | \* 새 노트 태그를 BlueTriangle 아이콘과 지정된 레이블로 생성합니다. |
+| [createBlueUmbrella()](#createBlueUmbrella--) | \* 새 노트 태그를 BlueUmbrella 아이콘과 기본 레이블로 생성합니다. |
+| [createBlueUmbrella(String label)](#createBlueUmbrella-java.lang.String-) | \* 새 노트 태그를 BlueUmbrella 아이콘과 지정된 레이블로 생성합니다. |
+| [createBlueUpArrow()](#createBlueUpArrow--) | \* 새 노트 태그를 BlueUpArrow 아이콘과 기본 레이블로 생성합니다. |
+| [createBlueUpArrow(String label)](#createBlueUpArrow-java.lang.String-) | \* 새 노트 태그를 BlueUpArrow 아이콘과 지정된 레이블로 생성합니다. |
+| [createBlueXNo()](#createBlueXNo--) | \* 새 노트 태그를 BlueXNo 아이콘과 기본 레이블로 생성합니다. |
+| [createBlueXNo(String label)](#createBlueXNo-java.lang.String-) | \* 새 노트 태그를 BlueXNo 아이콘과 지정된 레이블로 생성합니다. |
+| [createBlueXWithDots()](#createBlueXWithDots--) | \* 새 노트 태그를 BlueXWithDots 아이콘과 기본 레이블로 생성합니다. |
+| [createBlueXWithDots(String label)](#createBlueXWithDots-java.lang.String-) | \* 새 노트 태그를 BlueXWithDots 아이콘과 지정된 레이블로 생성합니다. |
+| [createCalendarDateWithClock()](#createCalendarDateWithClock--) | \* CalendarDateWithClock 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createCalendarDateWithClock(String label)](#createCalendarDateWithClock-java.lang.String-) | \* CalendarDateWithClock 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createCar()](#createCar--) | \* Car 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createCar(String label)](#createCar-java.lang.String-) | \* Car 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createClosedEnvelope()](#createClosedEnvelope--) | \* ClosedEnvelope 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createClosedEnvelope(String label)](#createClosedEnvelope-java.lang.String-) | \* ClosedEnvelope 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createCloud()](#createCloud--) | \* Cloud 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createCloud(String label)](#createCloud-java.lang.String-) | \* Cloud 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createCoinsWithWindowBackdrop()](#createCoinsWithWindowBackdrop--) | \* CoinsWithWindowBackdrop 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createCoinsWithWindowBackdrop(String label)](#createCoinsWithWindowBackdrop-java.lang.String-) | \* CoinsWithWindowBackdrop 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createCommentBubble()](#createCommentBubble--) | \* CommentBubble 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createCommentBubble(String label)](#createCommentBubble-java.lang.String-) | \* CommentBubble 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createContactInformation()](#createContactInformation--) | \* ContactInformation 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createContactInformation(String label)](#createContactInformation-java.lang.String-) | \* ContactInformation 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createContactPersonOnCard()](#createContactPersonOnCard--) | \* ContactPersonOnCard 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createContactPersonOnCard(String label)](#createContactPersonOnCard-java.lang.String-) | \* ContactPersonOnCard 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createDollarSign()](#createDollarSign--) | \* DollarSign 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createDollarSign(String label)](#createDollarSign-java.lang.String-) | \* DollarSign 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createEMailMessage()](#createEMailMessage--) | \* EMailMessage 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createEMailMessage(String label)](#createEMailMessage-java.lang.String-) | \* EMailMessage 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createFrowningFace()](#createFrowningFace--) | \* FrowningFace 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createFrowningFace(String label)](#createFrowningFace-java.lang.String-) | \* FrowningFace 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createGlobe()](#createGlobe--) | \* Globe 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createGlobe(String label)](#createGlobe-java.lang.String-) | \* Globe 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createGreenCheckMark()](#createGreenCheckMark--) | \* GreenCheckMark 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createGreenCheckMark(String label)](#createGreenCheckMark-java.lang.String-) | * 새 노트 태그를 GreenCheckMark 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenCircle()](#createGreenCircle--) | * 새 노트 태그를 GreenCircle 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenCircle(String label)](#createGreenCircle-java.lang.String-) | * 새 노트 태그를 GreenCircle 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenCircle1()](#createGreenCircle1--) | * 새 노트 태그를 GreenCircle1 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenCircle1(String label)](#createGreenCircle1-java.lang.String-) | * 새 노트 태그를 GreenCircle1 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenCircle2()](#createGreenCircle2--) | * 새 노트 태그를 GreenCircle2 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenCircle2(String label)](#createGreenCircle2-java.lang.String-) | * 새 노트 태그를 GreenCircle2 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenCircle3()](#createGreenCircle3--) | * 새 노트 태그를 GreenCircle3 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenCircle3(String label)](#createGreenCircle3-java.lang.String-) | * 새 노트 태그를 GreenCircle3 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenDownArrow()](#createGreenDownArrow--) | * 새 노트 태그를 GreenDownArrow 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenDownArrow(String label)](#createGreenDownArrow-java.lang.String-) | * 새 노트 태그를 GreenDownArrow 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenEightPointStar()](#createGreenEightPointStar--) | * 새 노트 태그를 GreenEightPointStar 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenEightPointStar(String label)](#createGreenEightPointStar-java.lang.String-) | * 새 노트 태그를 GreenEightPointStar 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenLeftArrow()](#createGreenLeftArrow--) | * 새 노트 태그를 GreenLeftArrow 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenLeftArrow(String label)](#createGreenLeftArrow-java.lang.String-) | * 새 노트 태그를 GreenLeftArrow 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenRightArrow()](#createGreenRightArrow--) | * 새 노트 태그를 GreenRightArrow 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenRightArrow(String label)](#createGreenRightArrow-java.lang.String-) | * 새 노트 태그를 GreenRightArrow 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenSolidArrow()](#createGreenSolidArrow--) | * 새 노트 태그를 GreenSolidArrow 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenSolidArrow(String label)](#createGreenSolidArrow-java.lang.String-) | * 새 노트 태그를 GreenSolidArrow 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenSquare()](#createGreenSquare--) | * 새 노트 태그를 GreenSquare 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenSquare(String label)](#createGreenSquare-java.lang.String-) | * 새 노트 태그를 GreenSquare 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenStar()](#createGreenStar--) | * 새 노트 태그를 GreenStar 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenStar(String label)](#createGreenStar-java.lang.String-) | * 새 노트 태그를 GreenStar 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenSun()](#createGreenSun--) | * 새 노트 태그를 GreenSun 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenSun(String label)](#createGreenSun-java.lang.String-) | * 새 노트 태그를 GreenSun 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenTarget()](#createGreenTarget--) | \* 새 노트 태그를 GreenTarget 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenTarget(String label)](#createGreenTarget-java.lang.String-) | \* 새 노트 태그를 GreenTarget 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenTriangle()](#createGreenTriangle--) | \* 새 노트 태그를 GreenTriangle 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenTriangle(String label)](#createGreenTriangle-java.lang.String-) | \* 새 노트 태그를 GreenTriangle 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenUmbrella()](#createGreenUmbrella--) | \* 새 노트 태그를 GreenUmbrella 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenUmbrella(String label)](#createGreenUmbrella-java.lang.String-) | \* 새 노트 태그를 GreenUmbrella 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenUpArrow()](#createGreenUpArrow--) | \* 새 노트 태그를 GreenUpArrow 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenUpArrow(String label)](#createGreenUpArrow-java.lang.String-) | \* 새 노트 태그를 GreenUpArrow 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenXNo()](#createGreenXNo--) | \* 새 노트 태그를 GreenXNo 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenXNo(String label)](#createGreenXNo-java.lang.String-) | \* 새 노트 태그를 GreenXNo 아이콘과 지정된 레이블로 생성합니다. |
+| [createGreenXWithDots()](#createGreenXWithDots--) | \* 새 노트 태그를 GreenXWithDots 아이콘과 기본 레이블로 생성합니다. |
+| [createGreenXWithDots(String label)](#createGreenXWithDots-java.lang.String-) | \* 새 노트 태그를 GreenXWithDots 아이콘과 지정된 레이블로 생성합니다. |
+| [createHeart()](#createHeart--) | \* 새 노트 태그를 Heart 아이콘과 기본 레이블로 생성합니다. |
+| [createHeart(String label)](#createHeart-java.lang.String-) | \* 새 노트 태그를 Heart 아이콘과 지정된 레이블로 생성합니다. |
+| [createHighPriority()](#createHighPriority--) | \* 새 노트 태그를 HighPriority 아이콘과 기본 레이블로 생성합니다. |
+| [createHighPriority(String label)](#createHighPriority-java.lang.String-) | \* 새 노트 태그를 HighPriority 아이콘과 지정된 레이블로 생성합니다. |
+| [createHome()](#createHome--) | \* 새 노트 태그를 Home 아이콘과 기본 레이블로 생성합니다. |
+| [createHome(String label)](#createHome-java.lang.String-) | \* 새 노트 태그를 Home 아이콘과 지정된 레이블로 생성합니다. |
+| [createHyperlinkGlobe()](#createHyperlinkGlobe--) | \* 새 노트 태그를 HyperlinkGlobe 아이콘과 기본 레이블로 생성합니다. |
+| [createHyperlinkGlobe(String label)](#createHyperlinkGlobe-java.lang.String-) | \* 새 노트 태그를 HyperlinkGlobe 아이콘과 지정된 레이블로 생성합니다. |
+| [createInstantMessagingContactPerson()](#createInstantMessagingContactPerson--) | \* 새 노트 태그를 InstantMessagingContactPerson 아이콘과 기본 레이블로 생성합니다. |
+| [createInstantMessagingContactPerson(String label)](#createInstantMessagingContactPerson-java.lang.String-) | \* 새 노트 태그를 InstantMessagingContactPerson 아이콘과 지정된 레이블로 생성합니다. |
+| [createLaptop()](#createLaptop--) | \* 새 노트 태그를 Laptop 아이콘과 기본 레이블로 생성합니다. |
+| [createLaptop(String label)](#createLaptop-java.lang.String-) | \* 새 노트 태그를 Laptop 아이콘과 지정된 레이블로 생성합니다. |
+| [createLightBulb()](#createLightBulb--) | \* 새 노트 태그를 LightBulb 아이콘과 기본 레이블로 생성합니다. |
+| [createLightBulb(String label)](#createLightBulb-java.lang.String-) | * LightBulb 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다. |
+| [createLightningBolt()](#createLightningBolt--) | * LightningBolt 아이콘과 기본 레이블로 새 노트 태그를 생성합니다. |
+| [createLightningBolt(String label)](#createLightningBolt-java.lang.String-) | * LightningBolt 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다. |
+| [createMeeting()](#createMeeting--) | * Meeting 아이콘과 기본 레이블로 새 노트 태그를 생성합니다. |
+| [createMeeting(String label)](#createMeeting-java.lang.String-) | * Meeting 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다. |
+| [createMobilePhone()](#createMobilePhone--) | * MobilePhone 아이콘과 기본 레이블로 새 노트 태그를 생성합니다. |
+| [createMobilePhone(String label)](#createMobilePhone-java.lang.String-) | * MobilePhone 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다. |
+| [createMovieClip()](#createMovieClip--) | * MovieClip 아이콘과 기본 레이블로 새 노트 태그를 생성합니다. |
+| [createMovieClip(String label)](#createMovieClip-java.lang.String-) | * MovieClip 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다. |
+| [createMusicalNote()](#createMusicalNote--) | * MusicalNote 아이콘과 기본 레이블로 새 노트 태그를 생성합니다. |
+| [createMusicalNote(String label)](#createMusicalNote-java.lang.String-) | * MusicalNote 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다. |
+| [createNoIcon()](#createNoIcon--) | * 아이콘 없이 기본 레이블로 새 노트 태그를 생성합니다. |
+| [createNoIcon(String label)](#createNoIcon-java.lang.String-) | * 아이콘 없이 새 노트 태그를 생성합니다. |
+| [createNotebookWithClock()](#createNotebookWithClock--) | * NotebookWithClock 아이콘과 기본 레이블로 새 노트 태그를 생성합니다. |
+| [createNotebookWithClock(String label)](#createNotebookWithClock-java.lang.String-) | * NotebookWithClock 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다. |
+| [createOpenBook()](#createOpenBook--) | * OpenBook 아이콘과 기본 레이블로 새 노트 태그를 생성합니다. |
+| [createOpenBook(String label)](#createOpenBook-java.lang.String-) | * OpenBook 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다. |
+| [createOpenEnvelope()](#createOpenEnvelope--) | * OpenEnvelope 아이콘과 기본 레이블로 새 노트 태그를 생성합니다. |
+| [createOpenEnvelope(String label)](#createOpenEnvelope-java.lang.String-) | * OpenEnvelope 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다. |
+| [createOrangeSquare()](#createOrangeSquare--) | * OrangeSquare 아이콘과 기본 레이블로 새 노트 태그를 생성합니다. |
+| [createOrangeSquare(String label)](#createOrangeSquare-java.lang.String-) | * OrangeSquare 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다. |
+| [createPadlock()](#createPadlock--) | * Padlock 아이콘과 기본 레이블로 새 노트 태그를 생성합니다. |
+| [createPadlock(String label)](#createPadlock-java.lang.String-) | * Padlock 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다. |
+| [createPaperClip()](#createPaperClip--) | * PaperClip 아이콘과 기본 레이블로 새 노트 태그를 생성합니다. |
+| [createPaperClip(String label)](#createPaperClip-java.lang.String-) | * PaperClip 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다. |
+| [createPen()](#createPen--) | \* Pen 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createPen(String label)](#createPen-java.lang.String-) | \* Pen 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createPersonWithExclamationMark()](#createPersonWithExclamationMark--) | \* PersonWithExclamationMark 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createPersonWithExclamationMark(String label)](#createPersonWithExclamationMark-java.lang.String-) | \* PersonWithExclamationMark 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createPinkSquare()](#createPinkSquare--) | \* PinkSquare 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createPinkSquare(String label)](#createPinkSquare-java.lang.String-) | \* PinkSquare 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createPlane()](#createPlane--) | \* Plane 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createPlane(String label)](#createPlane-java.lang.String-) | \* Plane 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createPresentationSlide()](#createPresentationSlide--) | \* PresentationSlide 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createPresentationSlide(String label)](#createPresentationSlide-java.lang.String-) | \* PresentationSlide 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createPushpin()](#createPushpin--) | \* Pushpin 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createPushpin(String label)](#createPushpin-java.lang.String-) | \* Pushpin 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createQuestionBalloon()](#createQuestionBalloon--) | \* QuestionBalloon 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createQuestionBalloon(String label)](#createQuestionBalloon-java.lang.String-) | \* QuestionBalloon 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createQuestionMark()](#createQuestionMark--) | \* QuestionMark 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createQuestionMark(String label)](#createQuestionMark-java.lang.String-) | \* QuestionMark 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createQuotationMark()](#createQuotationMark--) | \* QuotationMark 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createQuotationMark(String label)](#createQuotationMark-java.lang.String-) | \* QuotationMark 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createRedSquare()](#createRedSquare--) | \* RedSquare 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createRedSquare(String label)](#createRedSquare-java.lang.String-) | \* RedSquare 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createReminderBell()](#createReminderBell--) | \* ReminderBell 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createReminderBell(String label)](#createReminderBell-java.lang.String-) | \* ReminderBell 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createResearch()](#createResearch--) | \* Research 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createResearch(String label)](#createResearch-java.lang.String-) | \* Research 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createRoseOnStem()](#createRoseOnStem--) | \* RoseOnStem 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createRoseOnStem(String label)](#createRoseOnStem-java.lang.String-) | * RoseOnStem 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createScheduledTask()](#createScheduledTask--) | * ScheduledTask 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createScheduledTask(String label)](#createScheduledTask-java.lang.String-) | * ScheduledTask 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createSmilingFace()](#createSmilingFace--) | * SmilingFace 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createSmilingFace(String label)](#createSmilingFace-java.lang.String-) | * SmilingFace 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createSunflower()](#createSunflower--) | * Sunflower 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createSunflower(String label)](#createSunflower-java.lang.String-) | * Sunflower 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createTelephoneWithClock()](#createTelephoneWithClock--) | * TelephoneWithClock 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createTelephoneWithClock(String label)](#createTelephoneWithClock-java.lang.String-) | * TelephoneWithClock 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createTimeSensitive()](#createTimeSensitive--) | * TimeSensitive 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createTimeSensitive(String label)](#createTimeSensitive-java.lang.String-) | * TimeSensitive 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createTwoPeople()](#createTwoPeople--) | * TwoPeople 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createTwoPeople(String label)](#createTwoPeople-java.lang.String-) | * TwoPeople 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowCheckMark()](#createYellowCheckMark--) | * YellowCheckMark 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowCheckMark(String label)](#createYellowCheckMark-java.lang.String-) | * YellowCheckMark 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowCircle()](#createYellowCircle--) | * YellowCircle 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowCircle(String label)](#createYellowCircle-java.lang.String-) | * YellowCircle 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowCircle1()](#createYellowCircle1--) | * YellowCircle1 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowCircle1(String label)](#createYellowCircle1-java.lang.String-) | * YellowCircle1 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowCircle2()](#createYellowCircle2--) | * YellowCircle2 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowCircle2(String label)](#createYellowCircle2-java.lang.String-) | * YellowCircle2 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowCircle3()](#createYellowCircle3--) | * YellowCircle3 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowCircle3(String label)](#createYellowCircle3-java.lang.String-) | * YellowCircle3 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowDownArrow()](#createYellowDownArrow--) | * YellowDownArrow 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowDownArrow(String label)](#createYellowDownArrow-java.lang.String-) | * YellowDownArrow 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다. |
+| [createYellowEightPointStar()](#createYellowEightPointStar--) | * 새 노트 태그를 YellowEightPointStar 아이콘과 기본 레이블로 생성합니다. |
+| [createYellowEightPointStar(String label)](#createYellowEightPointStar-java.lang.String-) | * 새 노트 태그를 YellowEightPointStar 아이콘과 지정된 레이블로 생성합니다. |
+| [createYellowKey()](#createYellowKey--) | * 새 노트 태그를 YellowKey 아이콘과 기본 레이블로 생성합니다. |
+| [createYellowKey(String label)](#createYellowKey-java.lang.String-) | * 새 노트 태그를 YellowKey 아이콘과 지정된 레이블로 생성합니다. |
+| [createYellowLeftArrow()](#createYellowLeftArrow--) | * 새 노트 태그를 YellowLeftArrow 아이콘과 기본 레이블로 생성합니다. |
+| [createYellowLeftArrow(String label)](#createYellowLeftArrow-java.lang.String-) | * 새 노트 태그를 YellowLeftArrow 아이콘과 지정된 레이블로 생성합니다. |
+| [createYellowRightArrow()](#createYellowRightArrow--) | * 새 노트 태그를 YellowRightArrow 아이콘과 기본 레이블로 생성합니다. |
+| [createYellowRightArrow(String label)](#createYellowRightArrow-java.lang.String-) | * 새 노트 태그를 YellowRightArrow 아이콘과 지정된 레이블로 생성합니다. |
+| [createYellowSolidTarget()](#createYellowSolidTarget--) | * 새 노트 태그를 YellowSolidTarget 아이콘과 기본 레이블로 생성합니다. |
+| [createYellowSolidTarget(String label)](#createYellowSolidTarget-java.lang.String-) | * 새 노트 태그를 YellowSolidTarget 아이콘과 지정된 레이블로 생성합니다. |
+| [createYellowSquare()](#createYellowSquare--) | * 새 노트 태그를 YellowSquare 아이콘과 기본 레이블로 생성합니다. |
+| [createYellowSquare(String label)](#createYellowSquare-java.lang.String-) | * 새 노트 태그를 YellowSquare 아이콘과 지정된 레이블로 생성합니다. |
+| [createYellowStar()](#createYellowStar--) | * 새 노트 태그를 YellowStar 아이콘과 기본 레이블로 생성합니다. |
+| [createYellowStar(String label)](#createYellowStar-java.lang.String-) | * 새 노트 태그를 YellowStar 아이콘과 지정된 레이블로 생성합니다. |
+| [createYellowSun()](#createYellowSun--) | * 새 노트 태그를 YellowSun 아이콘과 기본 레이블로 생성합니다. |
+| [createYellowSun(String label)](#createYellowSun-java.lang.String-) | * 새 노트 태그를 YellowSun 아이콘과 지정된 레이블로 생성합니다. |
+| [createYellowTarget()](#createYellowTarget--) | * 새 노트 태그를 YellowTarget 아이콘과 기본 레이블로 생성합니다. |
+| [createYellowTarget(String label)](#createYellowTarget-java.lang.String-) | * 새 노트 태그를 YellowTarget 아이콘과 지정된 레이블로 생성합니다. |
+| [createYellowTriangle()](#createYellowTriangle--) | * 새 노트 태그를 YellowTriangle 아이콘과 기본 레이블로 생성합니다. |
+| [createYellowTriangle(String label)](#createYellowTriangle-java.lang.String-) | * 새 노트 태그를 YellowTriangle 아이콘과 지정된 레이블로 생성합니다. |
+| [createYellowUmbrella()](#createYellowUmbrella--) | * 새 노트 태그를 YellowUmbrella 아이콘과 기본 레이블로 생성합니다. |
+| [createYellowUmbrella(String label)](#createYellowUmbrella-java.lang.String-) | * 새 노트 태그를 YellowUmbrella 아이콘과 지정된 레이블로 생성합니다. |
+| [createYellowUpArrow()](#createYellowUpArrow--) | * 새 노트 태그를 YellowUpArrow 아이콘과 기본 레이블로 생성합니다. |
+| [createYellowUpArrow(String label)](#createYellowUpArrow-java.lang.String-) | * 새 노트 태그를 YellowUpArrow 아이콘과 지정된 레이블로 생성합니다. |
+| [createYellowX()](#createYellowX--) | * 새 노트 태그를 YellowX 아이콘과 기본 레이블로 생성합니다. |
+| [createYellowX(String label)](#createYellowX-java.lang.String-) | * 새 노트 태그를 YellowX 아이콘과 지정된 레이블로 생성합니다. |
+| [createYellowXWithDots()](#createYellowXWithDots--) | * 새 노트 태그를 YellowXWithDots 아이콘과 기본 레이블로 생성합니다. |
+| [createYellowXWithDots(String label)](#createYellowXWithDots-java.lang.String-) | * 새 노트 태그를 YellowXWithDots 아이콘과 지정된 레이블로 생성합니다. |
+| [equals(NoteTag other)](#equals-com.aspose.note.NoteTag-) | 지정된 객체가 현재 객체와 같은지 여부를 결정합니다. |
+| [equals(Object obj)](#equals-java.lang.Object-) | 지정된 객체가 현재 객체와 같은지 여부를 결정합니다. |
+| [getCompletedTime()](#getCompletedTime--) | 완료 시간을 가져오거나 설정합니다. |
+| [getCreationTime()](#getCreationTime--) | 생성 시간을 가져오거나 설정합니다. |
+| [getFontColor()](#getFontColor--) | 글꼴 색상을 가져오거나 설정합니다. |
+| [getHighlight()](#getHighlight--) | 하이라이트 색상을 가져오거나 설정합니다. |
+| [getIcon()](#getIcon--) | 아이콘을 가져오거나 설정합니다. |
+| [getLabel()](#getLabel--) | 레이블 텍스트를 가져옵니다. |
+| [getStatus()](#getStatus--) | 상태를 가져오거나 설정합니다. |
+| [hashCode()](#hashCode--) | 해당 유형에 대한 해시 함수로 사용됩니다. |
+| [setCreationTime(Date value)](#setCreationTime-java.util.Date-) | 생성 시간을 가져오거나 설정합니다. |
+| [setFontColor(Color value)](#setFontColor-java.awt.Color-) | 글꼴 색상을 가져오거나 설정합니다. |
+| [setHighlight(Color value)](#setHighlight-java.awt.Color-) | 하이라이트 색상을 가져오거나 설정합니다. |
+| [setIcon(int value)](#setIcon-int-) | 아이콘을 가져오거나 설정합니다. |
+| [setLabel(String value)](#setLabel-java.lang.String-) | 레이블 텍스트를 설정합니다. |
+### NoteTag() {#NoteTag--}
+```
+public NoteTag()
+```
+
+
+아이콘 없이 [NoteTag](../../com.aspose.note/notetag) 클래스의 새 인스턴스를 초기화합니다.
+
+### createAwardRibbon() {#createAwardRibbon--}
+```
+public static NoteTag createAwardRibbon()
+```
+
+
+\* AwardRibbon 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createAwardRibbon(String label) {#createAwardRibbon-java.lang.String-}
+```
+public static NoteTag createAwardRibbon(String label)
+```
+
+
+\* AwardRibbon 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBinoculars() {#createBinoculars--}
+```
+public static NoteTag createBinoculars()
+```
+
+
+\* Binoculars 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBinoculars(String label) {#createBinoculars-java.lang.String-}
+```
+public static NoteTag createBinoculars(String label)
+```
+
+
+\* Binoculars 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlankPaperWithLines() {#createBlankPaperWithLines--}
+```
+public static NoteTag createBlankPaperWithLines()
+```
+
+
+\* BlankPaperWithLines 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlankPaperWithLines(String label) {#createBlankPaperWithLines-java.lang.String-}
+```
+public static NoteTag createBlankPaperWithLines(String label)
+```
+
+
+\* BlankPaperWithLines 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCheckMark() {#createBlueCheckMark--}
+```
+public static NoteTag createBlueCheckMark()
+```
+
+
+\* BlueCheckMark 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCheckMark(String label) {#createBlueCheckMark-java.lang.String-}
+```
+public static NoteTag createBlueCheckMark(String label)
+```
+
+
+\* BlueCheckMark 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle() {#createBlueCircle--}
+```
+public static NoteTag createBlueCircle()
+```
+
+
+\* BlueCircle 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle(String label) {#createBlueCircle-java.lang.String-}
+```
+public static NoteTag createBlueCircle(String label)
+```
+
+
+\* BlueCircle 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle1() {#createBlueCircle1--}
+```
+public static NoteTag createBlueCircle1()
+```
+
+
+\* BlueCircle1 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle1(String label) {#createBlueCircle1-java.lang.String-}
+```
+public static NoteTag createBlueCircle1(String label)
+```
+
+
+\* BlueCircle1 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle2() {#createBlueCircle2--}
+```
+public static NoteTag createBlueCircle2()
+```
+
+
+\* BlueCircle2 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle2(String label) {#createBlueCircle2-java.lang.String-}
+```
+public static NoteTag createBlueCircle2(String label)
+```
+
+
+\* BlueCircle2 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle3() {#createBlueCircle3--}
+```
+public static NoteTag createBlueCircle3()
+```
+
+
+\* BlueCircle3 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle3(String label) {#createBlueCircle3-java.lang.String-}
+```
+public static NoteTag createBlueCircle3(String label)
+```
+
+
+\* BlueCircle3 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueDownArrow() {#createBlueDownArrow--}
+```
+public static NoteTag createBlueDownArrow()
+```
+
+
+\* BlueDownArrow 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueDownArrow(String label) {#createBlueDownArrow-java.lang.String-}
+```
+public static NoteTag createBlueDownArrow(String label)
+```
+
+
+\* BlueDownArrow 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueEightPointStar() {#createBlueEightPointStar--}
+```
+public static NoteTag createBlueEightPointStar()
+```
+
+
+\* BlueEightPointStar 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueEightPointStar(String label) {#createBlueEightPointStar-java.lang.String-}
+```
+public static NoteTag createBlueEightPointStar(String label)
+```
+
+
+\* BlueEightPointStar 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueFollowUpFlag() {#createBlueFollowUpFlag--}
+```
+public static NoteTag createBlueFollowUpFlag()
+```
+
+
+\* BlueFollowUpFlag 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueFollowUpFlag(String label) {#createBlueFollowUpFlag-java.lang.String-}
+```
+public static NoteTag createBlueFollowUpFlag(String label)
+```
+
+
+\* 새 노트 태그를 BlueFollowUpFlag 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueLeftArrow() {#createBlueLeftArrow--}
+```
+public static NoteTag createBlueLeftArrow()
+```
+
+
+\* 새 노트 태그를 BlueLeftArrow 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueLeftArrow(String label) {#createBlueLeftArrow-java.lang.String-}
+```
+public static NoteTag createBlueLeftArrow(String label)
+```
+
+
+\* 새 노트 태그를 BlueLeftArrow 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueRightArrow() {#createBlueRightArrow--}
+```
+public static NoteTag createBlueRightArrow()
+```
+
+
+\* 새 노트 태그를 BlueRightArrow 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueRightArrow(String label) {#createBlueRightArrow-java.lang.String-}
+```
+public static NoteTag createBlueRightArrow(String label)
+```
+
+
+\* 새 노트 태그를 BlueRightArrow 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueSolidTarget() {#createBlueSolidTarget--}
+```
+public static NoteTag createBlueSolidTarget()
+```
+
+
+\* 새 노트 태그를 BlueSolidTarget 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueSolidTarget(String label) {#createBlueSolidTarget-java.lang.String-}
+```
+public static NoteTag createBlueSolidTarget(String label)
+```
+
+
+\* 새 노트 태그를 BlueSolidTarget 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueSquare() {#createBlueSquare--}
+```
+public static NoteTag createBlueSquare()
+```
+
+
+\* 새 노트 태그를 BlueSquare 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueSquare(String label) {#createBlueSquare-java.lang.String-}
+```
+public static NoteTag createBlueSquare(String label)
+```
+
+
+\* 새 노트 태그를 BlueSquare 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueStar() {#createBlueStar--}
+```
+public static NoteTag createBlueStar()
+```
+
+
+\* 새 노트 태그를 BlueStar 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueStar(String label) {#createBlueStar-java.lang.String-}
+```
+public static NoteTag createBlueStar(String label)
+```
+
+
+\* 새 노트 태그를 BlueStar 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueSun() {#createBlueSun--}
+```
+public static NoteTag createBlueSun()
+```
+
+
+\* 새 노트 태그를 BlueSun 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueSun(String label) {#createBlueSun-java.lang.String-}
+```
+public static NoteTag createBlueSun(String label)
+```
+
+
+\* 새 노트 태그를 BlueSun 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueTarget() {#createBlueTarget--}
+```
+public static NoteTag createBlueTarget()
+```
+
+
+\* 새 노트 태그를 BlueTarget 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueTarget(String label) {#createBlueTarget-java.lang.String-}
+```
+public static NoteTag createBlueTarget(String label)
+```
+
+
+\* 새 노트 태그를 BlueTarget 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueTriangle() {#createBlueTriangle--}
+```
+public static NoteTag createBlueTriangle()
+```
+
+
+\* 새 노트 태그를 BlueTriangle 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueTriangle(String label) {#createBlueTriangle-java.lang.String-}
+```
+public static NoteTag createBlueTriangle(String label)
+```
+
+
+\* 새 노트 태그를 BlueTriangle 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueUmbrella() {#createBlueUmbrella--}
+```
+public static NoteTag createBlueUmbrella()
+```
+
+
+\* 새 노트 태그를 BlueUmbrella 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueUmbrella(String label) {#createBlueUmbrella-java.lang.String-}
+```
+public static NoteTag createBlueUmbrella(String label)
+```
+
+
+\* 새 노트 태그를 BlueUmbrella 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueUpArrow() {#createBlueUpArrow--}
+```
+public static NoteTag createBlueUpArrow()
+```
+
+
+\* 새 노트 태그를 BlueUpArrow 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueUpArrow(String label) {#createBlueUpArrow-java.lang.String-}
+```
+public static NoteTag createBlueUpArrow(String label)
+```
+
+
+\* 새 노트 태그를 BlueUpArrow 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueXNo() {#createBlueXNo--}
+```
+public static NoteTag createBlueXNo()
+```
+
+
+\* 새 노트 태그를 BlueXNo 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueXNo(String label) {#createBlueXNo-java.lang.String-}
+```
+public static NoteTag createBlueXNo(String label)
+```
+
+
+\* 새 노트 태그를 BlueXNo 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueXWithDots() {#createBlueXWithDots--}
+```
+public static NoteTag createBlueXWithDots()
+```
+
+
+\* 새 노트 태그를 BlueXWithDots 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueXWithDots(String label) {#createBlueXWithDots-java.lang.String-}
+```
+public static NoteTag createBlueXWithDots(String label)
+```
+
+
+\* 새 노트 태그를 BlueXWithDots 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCalendarDateWithClock() {#createCalendarDateWithClock--}
+```
+public static NoteTag createCalendarDateWithClock()
+```
+
+
+\* CalendarDateWithClock 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCalendarDateWithClock(String label) {#createCalendarDateWithClock-java.lang.String-}
+```
+public static NoteTag createCalendarDateWithClock(String label)
+```
+
+
+\* CalendarDateWithClock 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCar() {#createCar--}
+```
+public static NoteTag createCar()
+```
+
+
+\* Car 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCar(String label) {#createCar-java.lang.String-}
+```
+public static NoteTag createCar(String label)
+```
+
+
+\* Car 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createClosedEnvelope() {#createClosedEnvelope--}
+```
+public static NoteTag createClosedEnvelope()
+```
+
+
+\* ClosedEnvelope 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createClosedEnvelope(String label) {#createClosedEnvelope-java.lang.String-}
+```
+public static NoteTag createClosedEnvelope(String label)
+```
+
+
+\* ClosedEnvelope 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCloud() {#createCloud--}
+```
+public static NoteTag createCloud()
+```
+
+
+\* Cloud 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCloud(String label) {#createCloud-java.lang.String-}
+```
+public static NoteTag createCloud(String label)
+```
+
+
+\* Cloud 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCoinsWithWindowBackdrop() {#createCoinsWithWindowBackdrop--}
+```
+public static NoteTag createCoinsWithWindowBackdrop()
+```
+
+
+\* CoinsWithWindowBackdrop 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCoinsWithWindowBackdrop(String label) {#createCoinsWithWindowBackdrop-java.lang.String-}
+```
+public static NoteTag createCoinsWithWindowBackdrop(String label)
+```
+
+
+\* CoinsWithWindowBackdrop 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCommentBubble() {#createCommentBubble--}
+```
+public static NoteTag createCommentBubble()
+```
+
+
+\* CommentBubble 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCommentBubble(String label) {#createCommentBubble-java.lang.String-}
+```
+public static NoteTag createCommentBubble(String label)
+```
+
+
+\* CommentBubble 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createContactInformation() {#createContactInformation--}
+```
+public static NoteTag createContactInformation()
+```
+
+
+\* ContactInformation 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createContactInformation(String label) {#createContactInformation-java.lang.String-}
+```
+public static NoteTag createContactInformation(String label)
+```
+
+
+\* ContactInformation 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createContactPersonOnCard() {#createContactPersonOnCard--}
+```
+public static NoteTag createContactPersonOnCard()
+```
+
+
+\* ContactPersonOnCard 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createContactPersonOnCard(String label) {#createContactPersonOnCard-java.lang.String-}
+```
+public static NoteTag createContactPersonOnCard(String label)
+```
+
+
+\* ContactPersonOnCard 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createDollarSign() {#createDollarSign--}
+```
+public static NoteTag createDollarSign()
+```
+
+
+\* DollarSign 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createDollarSign(String label) {#createDollarSign-java.lang.String-}
+```
+public static NoteTag createDollarSign(String label)
+```
+
+
+\* DollarSign 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createEMailMessage() {#createEMailMessage--}
+```
+public static NoteTag createEMailMessage()
+```
+
+
+\* EMailMessage 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createEMailMessage(String label) {#createEMailMessage-java.lang.String-}
+```
+public static NoteTag createEMailMessage(String label)
+```
+
+
+\* EMailMessage 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createFrowningFace() {#createFrowningFace--}
+```
+public static NoteTag createFrowningFace()
+```
+
+
+\* FrowningFace 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createFrowningFace(String label) {#createFrowningFace-java.lang.String-}
+```
+public static NoteTag createFrowningFace(String label)
+```
+
+
+\* FrowningFace 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGlobe() {#createGlobe--}
+```
+public static NoteTag createGlobe()
+```
+
+
+\* Globe 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGlobe(String label) {#createGlobe-java.lang.String-}
+```
+public static NoteTag createGlobe(String label)
+```
+
+
+\* Globe 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCheckMark() {#createGreenCheckMark--}
+```
+public static NoteTag createGreenCheckMark()
+```
+
+
+\* GreenCheckMark 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCheckMark(String label) {#createGreenCheckMark-java.lang.String-}
+```
+public static NoteTag createGreenCheckMark(String label)
+```
+
+
+* 새 노트 태그를 GreenCheckMark 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle() {#createGreenCircle--}
+```
+public static NoteTag createGreenCircle()
+```
+
+
+* 새 노트 태그를 GreenCircle 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle(String label) {#createGreenCircle-java.lang.String-}
+```
+public static NoteTag createGreenCircle(String label)
+```
+
+
+* 새 노트 태그를 GreenCircle 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle1() {#createGreenCircle1--}
+```
+public static NoteTag createGreenCircle1()
+```
+
+
+* 새 노트 태그를 GreenCircle1 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle1(String label) {#createGreenCircle1-java.lang.String-}
+```
+public static NoteTag createGreenCircle1(String label)
+```
+
+
+* 새 노트 태그를 GreenCircle1 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle2() {#createGreenCircle2--}
+```
+public static NoteTag createGreenCircle2()
+```
+
+
+* 새 노트 태그를 GreenCircle2 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle2(String label) {#createGreenCircle2-java.lang.String-}
+```
+public static NoteTag createGreenCircle2(String label)
+```
+
+
+* 새 노트 태그를 GreenCircle2 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle3() {#createGreenCircle3--}
+```
+public static NoteTag createGreenCircle3()
+```
+
+
+* 새 노트 태그를 GreenCircle3 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle3(String label) {#createGreenCircle3-java.lang.String-}
+```
+public static NoteTag createGreenCircle3(String label)
+```
+
+
+* 새 노트 태그를 GreenCircle3 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenDownArrow() {#createGreenDownArrow--}
+```
+public static NoteTag createGreenDownArrow()
+```
+
+
+* 새 노트 태그를 GreenDownArrow 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenDownArrow(String label) {#createGreenDownArrow-java.lang.String-}
+```
+public static NoteTag createGreenDownArrow(String label)
+```
+
+
+* 새 노트 태그를 GreenDownArrow 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenEightPointStar() {#createGreenEightPointStar--}
+```
+public static NoteTag createGreenEightPointStar()
+```
+
+
+* 새 노트 태그를 GreenEightPointStar 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenEightPointStar(String label) {#createGreenEightPointStar-java.lang.String-}
+```
+public static NoteTag createGreenEightPointStar(String label)
+```
+
+
+* 새 노트 태그를 GreenEightPointStar 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenLeftArrow() {#createGreenLeftArrow--}
+```
+public static NoteTag createGreenLeftArrow()
+```
+
+
+* 새 노트 태그를 GreenLeftArrow 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenLeftArrow(String label) {#createGreenLeftArrow-java.lang.String-}
+```
+public static NoteTag createGreenLeftArrow(String label)
+```
+
+
+* 새 노트 태그를 GreenLeftArrow 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenRightArrow() {#createGreenRightArrow--}
+```
+public static NoteTag createGreenRightArrow()
+```
+
+
+* 새 노트 태그를 GreenRightArrow 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenRightArrow(String label) {#createGreenRightArrow-java.lang.String-}
+```
+public static NoteTag createGreenRightArrow(String label)
+```
+
+
+* 새 노트 태그를 GreenRightArrow 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenSolidArrow() {#createGreenSolidArrow--}
+```
+public static NoteTag createGreenSolidArrow()
+```
+
+
+* 새 노트 태그를 GreenSolidArrow 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenSolidArrow(String label) {#createGreenSolidArrow-java.lang.String-}
+```
+public static NoteTag createGreenSolidArrow(String label)
+```
+
+
+* 새 노트 태그를 GreenSolidArrow 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenSquare() {#createGreenSquare--}
+```
+public static NoteTag createGreenSquare()
+```
+
+
+* 새 노트 태그를 GreenSquare 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenSquare(String label) {#createGreenSquare-java.lang.String-}
+```
+public static NoteTag createGreenSquare(String label)
+```
+
+
+* 새 노트 태그를 GreenSquare 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenStar() {#createGreenStar--}
+```
+public static NoteTag createGreenStar()
+```
+
+
+* 새 노트 태그를 GreenStar 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenStar(String label) {#createGreenStar-java.lang.String-}
+```
+public static NoteTag createGreenStar(String label)
+```
+
+
+* 새 노트 태그를 GreenStar 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenSun() {#createGreenSun--}
+```
+public static NoteTag createGreenSun()
+```
+
+
+* 새 노트 태그를 GreenSun 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenSun(String label) {#createGreenSun-java.lang.String-}
+```
+public static NoteTag createGreenSun(String label)
+```
+
+
+* 새 노트 태그를 GreenSun 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenTarget() {#createGreenTarget--}
+```
+public static NoteTag createGreenTarget()
+```
+
+
+\* 새 노트 태그를 GreenTarget 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenTarget(String label) {#createGreenTarget-java.lang.String-}
+```
+public static NoteTag createGreenTarget(String label)
+```
+
+
+\* 새 노트 태그를 GreenTarget 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenTriangle() {#createGreenTriangle--}
+```
+public static NoteTag createGreenTriangle()
+```
+
+
+\* 새 노트 태그를 GreenTriangle 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenTriangle(String label) {#createGreenTriangle-java.lang.String-}
+```
+public static NoteTag createGreenTriangle(String label)
+```
+
+
+\* 새 노트 태그를 GreenTriangle 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenUmbrella() {#createGreenUmbrella--}
+```
+public static NoteTag createGreenUmbrella()
+```
+
+
+\* 새 노트 태그를 GreenUmbrella 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenUmbrella(String label) {#createGreenUmbrella-java.lang.String-}
+```
+public static NoteTag createGreenUmbrella(String label)
+```
+
+
+\* 새 노트 태그를 GreenUmbrella 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenUpArrow() {#createGreenUpArrow--}
+```
+public static NoteTag createGreenUpArrow()
+```
+
+
+\* 새 노트 태그를 GreenUpArrow 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenUpArrow(String label) {#createGreenUpArrow-java.lang.String-}
+```
+public static NoteTag createGreenUpArrow(String label)
+```
+
+
+\* 새 노트 태그를 GreenUpArrow 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenXNo() {#createGreenXNo--}
+```
+public static NoteTag createGreenXNo()
+```
+
+
+\* 새 노트 태그를 GreenXNo 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenXNo(String label) {#createGreenXNo-java.lang.String-}
+```
+public static NoteTag createGreenXNo(String label)
+```
+
+
+\* 새 노트 태그를 GreenXNo 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenXWithDots() {#createGreenXWithDots--}
+```
+public static NoteTag createGreenXWithDots()
+```
+
+
+\* 새 노트 태그를 GreenXWithDots 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenXWithDots(String label) {#createGreenXWithDots-java.lang.String-}
+```
+public static NoteTag createGreenXWithDots(String label)
+```
+
+
+\* 새 노트 태그를 GreenXWithDots 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHeart() {#createHeart--}
+```
+public static NoteTag createHeart()
+```
+
+
+\* 새 노트 태그를 Heart 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHeart(String label) {#createHeart-java.lang.String-}
+```
+public static NoteTag createHeart(String label)
+```
+
+
+\* 새 노트 태그를 Heart 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHighPriority() {#createHighPriority--}
+```
+public static NoteTag createHighPriority()
+```
+
+
+\* 새 노트 태그를 HighPriority 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHighPriority(String label) {#createHighPriority-java.lang.String-}
+```
+public static NoteTag createHighPriority(String label)
+```
+
+
+\* 새 노트 태그를 HighPriority 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHome() {#createHome--}
+```
+public static NoteTag createHome()
+```
+
+
+\* 새 노트 태그를 Home 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHome(String label) {#createHome-java.lang.String-}
+```
+public static NoteTag createHome(String label)
+```
+
+
+\* 새 노트 태그를 Home 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHyperlinkGlobe() {#createHyperlinkGlobe--}
+```
+public static NoteTag createHyperlinkGlobe()
+```
+
+
+\* 새 노트 태그를 HyperlinkGlobe 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHyperlinkGlobe(String label) {#createHyperlinkGlobe-java.lang.String-}
+```
+public static NoteTag createHyperlinkGlobe(String label)
+```
+
+
+\* 새 노트 태그를 HyperlinkGlobe 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createInstantMessagingContactPerson() {#createInstantMessagingContactPerson--}
+```
+public static NoteTag createInstantMessagingContactPerson()
+```
+
+
+\* 새 노트 태그를 InstantMessagingContactPerson 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createInstantMessagingContactPerson(String label) {#createInstantMessagingContactPerson-java.lang.String-}
+```
+public static NoteTag createInstantMessagingContactPerson(String label)
+```
+
+
+\* 새 노트 태그를 InstantMessagingContactPerson 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createLaptop() {#createLaptop--}
+```
+public static NoteTag createLaptop()
+```
+
+
+\* 새 노트 태그를 Laptop 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createLaptop(String label) {#createLaptop-java.lang.String-}
+```
+public static NoteTag createLaptop(String label)
+```
+
+
+\* 새 노트 태그를 Laptop 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createLightBulb() {#createLightBulb--}
+```
+public static NoteTag createLightBulb()
+```
+
+
+\* 새 노트 태그를 LightBulb 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createLightBulb(String label) {#createLightBulb-java.lang.String-}
+```
+public static NoteTag createLightBulb(String label)
+```
+
+
+* LightBulb 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createLightningBolt() {#createLightningBolt--}
+```
+public static NoteTag createLightningBolt()
+```
+
+
+* LightningBolt 아이콘과 기본 레이블로 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createLightningBolt(String label) {#createLightningBolt-java.lang.String-}
+```
+public static NoteTag createLightningBolt(String label)
+```
+
+
+* LightningBolt 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMeeting() {#createMeeting--}
+```
+public static NoteTag createMeeting()
+```
+
+
+* Meeting 아이콘과 기본 레이블로 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMeeting(String label) {#createMeeting-java.lang.String-}
+```
+public static NoteTag createMeeting(String label)
+```
+
+
+* Meeting 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMobilePhone() {#createMobilePhone--}
+```
+public static NoteTag createMobilePhone()
+```
+
+
+* MobilePhone 아이콘과 기본 레이블로 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMobilePhone(String label) {#createMobilePhone-java.lang.String-}
+```
+public static NoteTag createMobilePhone(String label)
+```
+
+
+* MobilePhone 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMovieClip() {#createMovieClip--}
+```
+public static NoteTag createMovieClip()
+```
+
+
+* MovieClip 아이콘과 기본 레이블로 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMovieClip(String label) {#createMovieClip-java.lang.String-}
+```
+public static NoteTag createMovieClip(String label)
+```
+
+
+* MovieClip 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMusicalNote() {#createMusicalNote--}
+```
+public static NoteTag createMusicalNote()
+```
+
+
+* MusicalNote 아이콘과 기본 레이블로 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMusicalNote(String label) {#createMusicalNote-java.lang.String-}
+```
+public static NoteTag createMusicalNote(String label)
+```
+
+
+* MusicalNote 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createNoIcon() {#createNoIcon--}
+```
+public static NoteTag createNoIcon()
+```
+
+
+* 아이콘 없이 기본 레이블로 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createNoIcon(String label) {#createNoIcon-java.lang.String-}
+```
+public static NoteTag createNoIcon(String label)
+```
+
+
+* 아이콘 없이 새 노트 태그를 생성하고 지정된 레이블을 사용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createNotebookWithClock() {#createNotebookWithClock--}
+```
+public static NoteTag createNotebookWithClock()
+```
+
+
+* NotebookWithClock 아이콘과 기본 레이블로 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createNotebookWithClock(String label) {#createNotebookWithClock-java.lang.String-}
+```
+public static NoteTag createNotebookWithClock(String label)
+```
+
+
+* NotebookWithClock 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createOpenBook() {#createOpenBook--}
+```
+public static NoteTag createOpenBook()
+```
+
+
+* OpenBook 아이콘과 기본 레이블로 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createOpenBook(String label) {#createOpenBook-java.lang.String-}
+```
+public static NoteTag createOpenBook(String label)
+```
+
+
+* OpenBook 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createOpenEnvelope() {#createOpenEnvelope--}
+```
+public static NoteTag createOpenEnvelope()
+```
+
+
+* OpenEnvelope 아이콘과 기본 레이블로 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createOpenEnvelope(String label) {#createOpenEnvelope-java.lang.String-}
+```
+public static NoteTag createOpenEnvelope(String label)
+```
+
+
+* OpenEnvelope 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createOrangeSquare() {#createOrangeSquare--}
+```
+public static NoteTag createOrangeSquare()
+```
+
+
+* OrangeSquare 아이콘과 기본 레이블로 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createOrangeSquare(String label) {#createOrangeSquare-java.lang.String-}
+```
+public static NoteTag createOrangeSquare(String label)
+```
+
+
+* OrangeSquare 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPadlock() {#createPadlock--}
+```
+public static NoteTag createPadlock()
+```
+
+
+* Padlock 아이콘과 기본 레이블로 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPadlock(String label) {#createPadlock-java.lang.String-}
+```
+public static NoteTag createPadlock(String label)
+```
+
+
+* Padlock 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPaperClip() {#createPaperClip--}
+```
+public static NoteTag createPaperClip()
+```
+
+
+* PaperClip 아이콘과 기본 레이블로 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPaperClip(String label) {#createPaperClip-java.lang.String-}
+```
+public static NoteTag createPaperClip(String label)
+```
+
+
+* PaperClip 아이콘과 지정된 레이블로 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPen() {#createPen--}
+```
+public static NoteTag createPen()
+```
+
+
+\* Pen 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPen(String label) {#createPen-java.lang.String-}
+```
+public static NoteTag createPen(String label)
+```
+
+
+\* Pen 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPersonWithExclamationMark() {#createPersonWithExclamationMark--}
+```
+public static NoteTag createPersonWithExclamationMark()
+```
+
+
+\* PersonWithExclamationMark 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPersonWithExclamationMark(String label) {#createPersonWithExclamationMark-java.lang.String-}
+```
+public static NoteTag createPersonWithExclamationMark(String label)
+```
+
+
+\* PersonWithExclamationMark 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPinkSquare() {#createPinkSquare--}
+```
+public static NoteTag createPinkSquare()
+```
+
+
+\* PinkSquare 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPinkSquare(String label) {#createPinkSquare-java.lang.String-}
+```
+public static NoteTag createPinkSquare(String label)
+```
+
+
+\* PinkSquare 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPlane() {#createPlane--}
+```
+public static NoteTag createPlane()
+```
+
+
+\* Plane 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPlane(String label) {#createPlane-java.lang.String-}
+```
+public static NoteTag createPlane(String label)
+```
+
+
+\* Plane 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPresentationSlide() {#createPresentationSlide--}
+```
+public static NoteTag createPresentationSlide()
+```
+
+
+\* PresentationSlide 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPresentationSlide(String label) {#createPresentationSlide-java.lang.String-}
+```
+public static NoteTag createPresentationSlide(String label)
+```
+
+
+\* PresentationSlide 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPushpin() {#createPushpin--}
+```
+public static NoteTag createPushpin()
+```
+
+
+\* Pushpin 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPushpin(String label) {#createPushpin-java.lang.String-}
+```
+public static NoteTag createPushpin(String label)
+```
+
+
+\* Pushpin 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createQuestionBalloon() {#createQuestionBalloon--}
+```
+public static NoteTag createQuestionBalloon()
+```
+
+
+\* QuestionBalloon 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createQuestionBalloon(String label) {#createQuestionBalloon-java.lang.String-}
+```
+public static NoteTag createQuestionBalloon(String label)
+```
+
+
+\* QuestionBalloon 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createQuestionMark() {#createQuestionMark--}
+```
+public static NoteTag createQuestionMark()
+```
+
+
+\* QuestionMark 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createQuestionMark(String label) {#createQuestionMark-java.lang.String-}
+```
+public static NoteTag createQuestionMark(String label)
+```
+
+
+\* QuestionMark 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createQuotationMark() {#createQuotationMark--}
+```
+public static NoteTag createQuotationMark()
+```
+
+
+\* QuotationMark 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createQuotationMark(String label) {#createQuotationMark-java.lang.String-}
+```
+public static NoteTag createQuotationMark(String label)
+```
+
+
+\* QuotationMark 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createRedSquare() {#createRedSquare--}
+```
+public static NoteTag createRedSquare()
+```
+
+
+\* RedSquare 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createRedSquare(String label) {#createRedSquare-java.lang.String-}
+```
+public static NoteTag createRedSquare(String label)
+```
+
+
+\* RedSquare 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createReminderBell() {#createReminderBell--}
+```
+public static NoteTag createReminderBell()
+```
+
+
+\* ReminderBell 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createReminderBell(String label) {#createReminderBell-java.lang.String-}
+```
+public static NoteTag createReminderBell(String label)
+```
+
+
+\* ReminderBell 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createResearch() {#createResearch--}
+```
+public static NoteTag createResearch()
+```
+
+
+\* Research 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createResearch(String label) {#createResearch-java.lang.String-}
+```
+public static NoteTag createResearch(String label)
+```
+
+
+\* Research 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createRoseOnStem() {#createRoseOnStem--}
+```
+public static NoteTag createRoseOnStem()
+```
+
+
+\* RoseOnStem 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createRoseOnStem(String label) {#createRoseOnStem-java.lang.String-}
+```
+public static NoteTag createRoseOnStem(String label)
+```
+
+
+* RoseOnStem 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createScheduledTask() {#createScheduledTask--}
+```
+public static NoteTag createScheduledTask()
+```
+
+
+* ScheduledTask 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createScheduledTask(String label) {#createScheduledTask-java.lang.String-}
+```
+public static NoteTag createScheduledTask(String label)
+```
+
+
+* ScheduledTask 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createSmilingFace() {#createSmilingFace--}
+```
+public static NoteTag createSmilingFace()
+```
+
+
+* SmilingFace 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createSmilingFace(String label) {#createSmilingFace-java.lang.String-}
+```
+public static NoteTag createSmilingFace(String label)
+```
+
+
+* SmilingFace 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createSunflower() {#createSunflower--}
+```
+public static NoteTag createSunflower()
+```
+
+
+* Sunflower 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createSunflower(String label) {#createSunflower-java.lang.String-}
+```
+public static NoteTag createSunflower(String label)
+```
+
+
+* Sunflower 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createTelephoneWithClock() {#createTelephoneWithClock--}
+```
+public static NoteTag createTelephoneWithClock()
+```
+
+
+* TelephoneWithClock 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createTelephoneWithClock(String label) {#createTelephoneWithClock-java.lang.String-}
+```
+public static NoteTag createTelephoneWithClock(String label)
+```
+
+
+* TelephoneWithClock 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createTimeSensitive() {#createTimeSensitive--}
+```
+public static NoteTag createTimeSensitive()
+```
+
+
+* TimeSensitive 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createTimeSensitive(String label) {#createTimeSensitive-java.lang.String-}
+```
+public static NoteTag createTimeSensitive(String label)
+```
+
+
+* TimeSensitive 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createTwoPeople() {#createTwoPeople--}
+```
+public static NoteTag createTwoPeople()
+```
+
+
+* TwoPeople 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createTwoPeople(String label) {#createTwoPeople-java.lang.String-}
+```
+public static NoteTag createTwoPeople(String label)
+```
+
+
+* TwoPeople 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCheckMark() {#createYellowCheckMark--}
+```
+public static NoteTag createYellowCheckMark()
+```
+
+
+* YellowCheckMark 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCheckMark(String label) {#createYellowCheckMark-java.lang.String-}
+```
+public static NoteTag createYellowCheckMark(String label)
+```
+
+
+* YellowCheckMark 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle() {#createYellowCircle--}
+```
+public static NoteTag createYellowCircle()
+```
+
+
+* YellowCircle 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle(String label) {#createYellowCircle-java.lang.String-}
+```
+public static NoteTag createYellowCircle(String label)
+```
+
+
+* YellowCircle 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle1() {#createYellowCircle1--}
+```
+public static NoteTag createYellowCircle1()
+```
+
+
+* YellowCircle1 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle1(String label) {#createYellowCircle1-java.lang.String-}
+```
+public static NoteTag createYellowCircle1(String label)
+```
+
+
+* YellowCircle1 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle2() {#createYellowCircle2--}
+```
+public static NoteTag createYellowCircle2()
+```
+
+
+* YellowCircle2 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle2(String label) {#createYellowCircle2-java.lang.String-}
+```
+public static NoteTag createYellowCircle2(String label)
+```
+
+
+* YellowCircle2 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle3() {#createYellowCircle3--}
+```
+public static NoteTag createYellowCircle3()
+```
+
+
+* YellowCircle3 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle3(String label) {#createYellowCircle3-java.lang.String-}
+```
+public static NoteTag createYellowCircle3(String label)
+```
+
+
+* YellowCircle3 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowDownArrow() {#createYellowDownArrow--}
+```
+public static NoteTag createYellowDownArrow()
+```
+
+
+* YellowDownArrow 아이콘과 기본 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowDownArrow(String label) {#createYellowDownArrow-java.lang.String-}
+```
+public static NoteTag createYellowDownArrow(String label)
+```
+
+
+* YellowDownArrow 아이콘과 지정된 레이블을 사용하여 새 노트 태그를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowEightPointStar() {#createYellowEightPointStar--}
+```
+public static NoteTag createYellowEightPointStar()
+```
+
+
+* 새 노트 태그를 YellowEightPointStar 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowEightPointStar(String label) {#createYellowEightPointStar-java.lang.String-}
+```
+public static NoteTag createYellowEightPointStar(String label)
+```
+
+
+* 새 노트 태그를 YellowEightPointStar 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowKey() {#createYellowKey--}
+```
+public static NoteTag createYellowKey()
+```
+
+
+* 새 노트 태그를 YellowKey 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowKey(String label) {#createYellowKey-java.lang.String-}
+```
+public static NoteTag createYellowKey(String label)
+```
+
+
+* 새 노트 태그를 YellowKey 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowLeftArrow() {#createYellowLeftArrow--}
+```
+public static NoteTag createYellowLeftArrow()
+```
+
+
+* 새 노트 태그를 YellowLeftArrow 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowLeftArrow(String label) {#createYellowLeftArrow-java.lang.String-}
+```
+public static NoteTag createYellowLeftArrow(String label)
+```
+
+
+* 새 노트 태그를 YellowLeftArrow 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowRightArrow() {#createYellowRightArrow--}
+```
+public static NoteTag createYellowRightArrow()
+```
+
+
+* 새 노트 태그를 YellowRightArrow 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowRightArrow(String label) {#createYellowRightArrow-java.lang.String-}
+```
+public static NoteTag createYellowRightArrow(String label)
+```
+
+
+* 새 노트 태그를 YellowRightArrow 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowSolidTarget() {#createYellowSolidTarget--}
+```
+public static NoteTag createYellowSolidTarget()
+```
+
+
+* 새 노트 태그를 YellowSolidTarget 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowSolidTarget(String label) {#createYellowSolidTarget-java.lang.String-}
+```
+public static NoteTag createYellowSolidTarget(String label)
+```
+
+
+* 새 노트 태그를 YellowSolidTarget 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowSquare() {#createYellowSquare--}
+```
+public static NoteTag createYellowSquare()
+```
+
+
+* 새 노트 태그를 YellowSquare 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowSquare(String label) {#createYellowSquare-java.lang.String-}
+```
+public static NoteTag createYellowSquare(String label)
+```
+
+
+* 새 노트 태그를 YellowSquare 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowStar() {#createYellowStar--}
+```
+public static NoteTag createYellowStar()
+```
+
+
+* 새 노트 태그를 YellowStar 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowStar(String label) {#createYellowStar-java.lang.String-}
+```
+public static NoteTag createYellowStar(String label)
+```
+
+
+* 새 노트 태그를 YellowStar 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowSun() {#createYellowSun--}
+```
+public static NoteTag createYellowSun()
+```
+
+
+* 새 노트 태그를 YellowSun 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowSun(String label) {#createYellowSun-java.lang.String-}
+```
+public static NoteTag createYellowSun(String label)
+```
+
+
+* 새 노트 태그를 YellowSun 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowTarget() {#createYellowTarget--}
+```
+public static NoteTag createYellowTarget()
+```
+
+
+* 새 노트 태그를 YellowTarget 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowTarget(String label) {#createYellowTarget-java.lang.String-}
+```
+public static NoteTag createYellowTarget(String label)
+```
+
+
+* 새 노트 태그를 YellowTarget 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowTriangle() {#createYellowTriangle--}
+```
+public static NoteTag createYellowTriangle()
+```
+
+
+* 새 노트 태그를 YellowTriangle 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowTriangle(String label) {#createYellowTriangle-java.lang.String-}
+```
+public static NoteTag createYellowTriangle(String label)
+```
+
+
+* 새 노트 태그를 YellowTriangle 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowUmbrella() {#createYellowUmbrella--}
+```
+public static NoteTag createYellowUmbrella()
+```
+
+
+* 새 노트 태그를 YellowUmbrella 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowUmbrella(String label) {#createYellowUmbrella-java.lang.String-}
+```
+public static NoteTag createYellowUmbrella(String label)
+```
+
+
+* 새 노트 태그를 YellowUmbrella 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowUpArrow() {#createYellowUpArrow--}
+```
+public static NoteTag createYellowUpArrow()
+```
+
+
+* 새 노트 태그를 YellowUpArrow 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowUpArrow(String label) {#createYellowUpArrow-java.lang.String-}
+```
+public static NoteTag createYellowUpArrow(String label)
+```
+
+
+* 새 노트 태그를 YellowUpArrow 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowX() {#createYellowX--}
+```
+public static NoteTag createYellowX()
+```
+
+
+* 새 노트 태그를 YellowX 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowX(String label) {#createYellowX-java.lang.String-}
+```
+public static NoteTag createYellowX(String label)
+```
+
+
+* 새 노트 태그를 YellowX 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowXWithDots() {#createYellowXWithDots--}
+```
+public static NoteTag createYellowXWithDots()
+```
+
+
+* 새 노트 태그를 YellowXWithDots 아이콘과 기본 레이블로 생성합니다.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowXWithDots(String label) {#createYellowXWithDots-java.lang.String-}
+```
+public static NoteTag createYellowXWithDots(String label)
+```
+
+
+* 새 노트 태그를 YellowXWithDots 아이콘과 지정된 레이블로 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 레이블 | java.lang.String | 태그의 레이블입니다. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### equals(NoteTag other) {#equals-com.aspose.note.NoteTag-}
+```
+public boolean equals(NoteTag other)
+```
+
+
+지정된 객체가 현재 객체와 같은지 여부를 결정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| other | [NoteTag](../../com.aspose.note/notetag) | 객체입니다. |
+
+**Returns:**
+boolean - `bool`입니다.
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+지정된 객체가 현재 객체와 같은지 여부를 결정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | java.lang.Object | 객체입니다. |
+
+**Returns:**
+boolean - `bool`입니다.
+### getCompletedTime() {#getCompletedTime--}
+```
+public final Date getCompletedTime()
+```
+
+
+완료 시간을 가져오거나 설정합니다.
+
+값: `Nullable{DateTime}`.
+
+**Returns:**
+java.util.Date
+### getCreationTime() {#getCreationTime--}
+```
+public final Date getCreationTime()
+```
+
+
+생성 시간을 가져오거나 설정합니다.
+
+값: java.util.Date입니다.
+
+**Returns:**
+java.util.Date
+### getFontColor() {#getFontColor--}
+```
+public Color getFontColor()
+```
+
+
+글꼴 색상을 가져오거나 설정합니다.
+
+**Returns:**
+java.awt.Color
+### getHighlight() {#getHighlight--}
+```
+public Color getHighlight()
+```
+
+
+하이라이트 색상을 가져오거나 설정합니다.
+
+**Returns:**
+java.awt.Color
+### getIcon() {#getIcon--}
+```
+public final int getIcon()
+```
+
+
+아이콘을 가져오거나 설정합니다.
+
+값: [TagIcon](../../com.aspose.note.infrastructure/tagicon)입니다.
+
+**Returns:**
+int
+### getLabel() {#getLabel--}
+```
+public String getLabel()
+```
+
+
+레이블 텍스트를 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getStatus() {#getStatus--}
+```
+public final int getStatus()
+```
+
+
+상태를 가져오거나 설정합니다.
+
+값: [TagStatus](../../com.aspose.note/tagstatus)입니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+해당 유형에 대한 해시 함수로 사용됩니다.
+
+**Returns:**
+int - `int`입니다.
+### setCreationTime(Date value) {#setCreationTime-java.util.Date-}
+```
+public final void setCreationTime(Date value)
+```
+
+
+생성 시간을 가져오거나 설정합니다.
+
+값: java.util.Date입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Date |  |
+
+### setFontColor(Color value) {#setFontColor-java.awt.Color-}
+```
+public void setFontColor(Color value)
+```
+
+
+글꼴 색상을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.Color |  |
+
+### setHighlight(Color value) {#setHighlight-java.awt.Color-}
+```
+public void setHighlight(Color value)
+```
+
+
+하이라이트 색상을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.Color |  |
+
+### setIcon(int value) {#setIcon-int-}
+```
+public final void setIcon(int value)
+```
+
+
+아이콘을 가져오거나 설정합니다.
+
+값: [TagIcon](../../com.aspose.note.infrastructure/tagicon)입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setLabel(String value) {#setLabel-java.lang.String-}
+```
+public void setLabel(String value)
+```
+
+
+레이블 텍스트를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+

--- a/korean/java/com.aspose.note/notetask/_index.md
+++ b/korean/java/com.aspose.note/notetask/_index.md
@@ -1,0 +1,196 @@
+---
+title: "NoteTask"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "노트 작업을 나타냅니다."
+type: docs
+weight: 55
+url: /ko/java/com.aspose.note/notetask/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.note.TagExtended, [com.aspose.note.CheckBox](../../com.aspose.note/checkbox)
+```
+public final class NoteTask extends CheckBox
+```
+
+노트 작업을 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [createCustomFollowUpDate(Date dueDate)](#createCustomFollowUpDate-java.util.Date-) | NoFollowUpDateFlag 아이콘과 지정된 마감일을 사용하여 새 노트 작업을 생성합니다. |
+| [createFollowUpNextWeek()](#createFollowUpNextWeek--) | * 다음 주 FollowUpNextWeekFlag 아이콘으로 새 노트 태그를 생성합니다. |
+| [createFollowUpThisWeek()](#createFollowUpThisWeek--) | * 이번 주 FollowUpThisWeekFlag 아이콘으로 새 노트 태그를 생성합니다. |
+| [createFollowUpToday()](#createFollowUpToday--) | * 오늘 FollowUpTodayFlag 아이콘으로 새 노트 태그를 생성합니다. |
+| [createFollowUpTomorrow()](#createFollowUpTomorrow--) | * 내일 FollowUpTomorrowFlag 아이콘으로 새 노트 태그를 생성합니다. |
+| [createNoFollowUpDate()](#createNoFollowUpDate--) | * NoFollowUpDateFlag 아이콘으로 새 노트 태그를 생성합니다. |
+| [equals(NoteTask other)](#equals-com.aspose.note.NoteTask-) | 지정된 객체가 현재 객체와 같은지 여부를 결정합니다. |
+| [equals(Object obj)](#equals-java.lang.Object-) | 지정된 객체가 현재 객체와 같은지 여부를 결정합니다. |
+| [getDueDate()](#getDueDate--) | 마감일을 가져오거나 설정합니다. |
+| [getIcon()](#getIcon--) | 아이콘을 가져오거나 설정합니다. |
+| [getLabel()](#getLabel--) |  |
+| [hashCode()](#hashCode--) | 해당 유형에 대한 해시 함수로 사용됩니다. |
+| [setDueDate(Date value)](#setDueDate-java.util.Date-) | 마감일을 가져오거나 설정합니다. |
+| [setOpen()](#setOpen--) | 태그를 열림 상태로 설정합니다. |
+### createCustomFollowUpDate(Date dueDate) {#createCustomFollowUpDate-java.util.Date-}
+```
+public static NoteTask createCustomFollowUpDate(Date dueDate)
+```
+
+
+NoFollowUpDateFlag 아이콘과 지정된 마감일을 사용하여 새 노트 작업을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| dueDate | java.util.Date | 마감일. |
+
+**Returns:**
+[NoteTask](../../com.aspose.note/notetask) - The [NoteTask](../../com.aspose.note/notetask).
+### createFollowUpNextWeek() {#createFollowUpNextWeek--}
+```
+public static NoteTask createFollowUpNextWeek()
+```
+
+
+* 다음 주 FollowUpNextWeekFlag 아이콘으로 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTask](../../com.aspose.note/notetask) - The [NoteTask](../../com.aspose.note/notetask).
+### createFollowUpThisWeek() {#createFollowUpThisWeek--}
+```
+public static NoteTask createFollowUpThisWeek()
+```
+
+
+* 이번 주 FollowUpThisWeekFlag 아이콘으로 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTask](../../com.aspose.note/notetask) - The [NoteTask](../../com.aspose.note/notetask).
+### createFollowUpToday() {#createFollowUpToday--}
+```
+public static NoteTask createFollowUpToday()
+```
+
+
+* 오늘 FollowUpTodayFlag 아이콘으로 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTask](../../com.aspose.note/notetask) - The [NoteTask](../../com.aspose.note/notetask).
+### createFollowUpTomorrow() {#createFollowUpTomorrow--}
+```
+public static NoteTask createFollowUpTomorrow()
+```
+
+
+* 내일 FollowUpTomorrowFlag 아이콘으로 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTask](../../com.aspose.note/notetask) - The [NoteTask](../../com.aspose.note/notetask).
+### createNoFollowUpDate() {#createNoFollowUpDate--}
+```
+public static NoteTask createNoFollowUpDate()
+```
+
+
+* NoFollowUpDateFlag 아이콘으로 새 노트 태그를 생성합니다.
+
+**Returns:**
+[NoteTask](../../com.aspose.note/notetask) - The [NoteTask](../../com.aspose.note/notetask).
+### equals(NoteTask other) {#equals-com.aspose.note.NoteTask-}
+```
+public boolean equals(NoteTask other)
+```
+
+
+지정된 객체가 현재 객체와 같은지 여부를 결정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| other | [NoteTask](../../com.aspose.note/notetask) | 객체입니다. |
+
+**Returns:**
+boolean - `bool`입니다.
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+지정된 객체가 현재 객체와 같은지 여부를 결정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | java.lang.Object | 객체입니다. |
+
+**Returns:**
+boolean - `bool`입니다.
+### getDueDate() {#getDueDate--}
+```
+public Date getDueDate()
+```
+
+
+마감일을 가져오거나 설정합니다.
+
+값: `DateTime`.
+
+**Returns:**
+java.util.Date
+### getIcon() {#getIcon--}
+```
+public int getIcon()
+```
+
+
+아이콘을 가져오거나 설정합니다.
+
+값: [TagIcon](../../com.aspose.note.infrastructure/tagicon)입니다.
+
+**Returns:**
+int
+### getLabel() {#getLabel--}
+```
+public String getLabel()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+해당 유형에 대한 해시 함수로 사용됩니다.
+
+**Returns:**
+int - `int`입니다.
+### setDueDate(Date value) {#setDueDate-java.util.Date-}
+```
+public void setDueDate(Date value)
+```
+
+
+마감일을 가져오거나 설정합니다.
+
+값: `DateTime`.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Date |  |
+
+### setOpen() {#setOpen--}
+```
+public void setOpen()
+```
+
+
+태그를 열림 상태로 설정합니다.
+

--- a/korean/java/com.aspose.note/numberformat/_index.md
+++ b/korean/java/com.aspose.note/numberformat/_index.md
@@ -1,0 +1,104 @@
+---
+title: "NumberFormat"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "자동 번호 매기기된 객체 그룹에 사용할 수 있는 번호 매기기 형식을 지정합니다."
+type: docs
+weight: 63
+url: /ko/java/com.aspose.note/numberformat/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class NumberFormat extends System.Enum
+```
+
+자동 번호가 매겨진 개체 그룹에 사용할 수 있는 번호 매기기 형식을 지정합니다. 전체 목록은 `[MSDN][]`에 지정되어 있습니다.
+
+
+[MSDN]: https://msdn.microsoft.com/en-us/library/dd923798%28v=office.12%29.aspx
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ChineseCounting](#ChineseCounting) | 시퀀스가 중국 수 체계의 연속 번호로 구성되도록 지정합니다. |
+| [ChineseCountingThousand](#ChineseCountingThousand) | 시퀀스가 중국 수 천 단위 체계의 연속 번호로 구성되도록 지정합니다. |
+| [DecimalNumbers](#DecimalNumbers) | 시퀀스가 10진수 번호 매기기로 구성되도록 지정합니다. |
+| [LowerLetter](#LowerLetter) | 시퀀스가 라틴 알파벳 소문자 하나의 한 글자 또는 그 이상의 반복으로 구성되도록 지정합니다. |
+| [LowerRoman](#LowerRoman) | 시퀀스가 소문자 로마 숫자로 구성되도록 지정합니다. |
+| [TaiwaneseCounting](#TaiwaneseCounting) | 시퀀스가 대만 수 체계의 연속 번호로 구성되도록 지정합니다. |
+| [TaiwaneseCountingThousand](#TaiwaneseCountingThousand) | 시퀀스가 대만 수 천 단위 체계의 연속 번호로 구성되도록 지정합니다. |
+| [UpperLetter](#UpperLetter) | 시퀀스가 라틴 알파벳 대문자 하나의 한 글자 또는 그 이상의 반복으로 구성되도록 지정합니다. |
+| [UpperRoman](#UpperRoman) | 시퀀스가 대문자 로마 숫자로 구성되도록 지정합니다. |
+### ChineseCounting {#ChineseCounting}
+```
+public static final byte ChineseCounting
+```
+
+
+시퀀스가 중국 수 체계의 연속 번호로 구성되도록 지정합니다.
+
+### ChineseCountingThousand {#ChineseCountingThousand}
+```
+public static final byte ChineseCountingThousand
+```
+
+
+시퀀스가 중국 수 천 단위 체계의 연속 번호로 구성되도록 지정합니다.
+
+### DecimalNumbers {#DecimalNumbers}
+```
+public static final byte DecimalNumbers
+```
+
+
+시퀀스가 10진수 번호 매기기로 구성되도록 지정합니다. 예: 1, 2, 3, \\u2026, 8, 9, 10, 11, 12, \\u2026, 18, 19, 20, 21.
+
+### LowerLetter {#LowerLetter}
+```
+public static final byte LowerLetter
+```
+
+
+시퀀스가 라틴 알파벳 소문자 하나의 한 글자 또는 그 이상의 반복으로 구성되도록 지정합니다. 예: a, b, c, \\u2026, y, z, aa, bb, cc, \\u2026, yy, zz, aaa, bbb, ccc.
+
+### LowerRoman {#LowerRoman}
+```
+public static final byte LowerRoman
+```
+
+
+시퀀스가 소문자 로마 숫자로 구성되도록 지정합니다. 예: i, ii, iii, iv, \\u2026, xviii, xix, xx, xxi.
+
+### TaiwaneseCounting {#TaiwaneseCounting}
+```
+public static final byte TaiwaneseCounting
+```
+
+
+시퀀스가 대만 수 체계의 연속 번호로 구성되도록 지정합니다.
+
+### TaiwaneseCountingThousand {#TaiwaneseCountingThousand}
+```
+public static final byte TaiwaneseCountingThousand
+```
+
+
+시퀀스가 대만 수 천 단위 체계의 연속 번호로 구성되도록 지정합니다.
+
+### UpperLetter {#UpperLetter}
+```
+public static final byte UpperLetter
+```
+
+
+시퀀스가 라틴 알파벳 대문자 하나의 한 글자 또는 그 이상의 반복으로 구성되도록 지정합니다. 예: A, B, C, \\u2026, Y, Z, AA, BB, CC, \\u2026, YY, ZZ, AAA, BBB, CCC.
+
+### UpperRoman {#UpperRoman}
+```
+public static final byte UpperRoman
+```
+
+
+시퀀스가 대문자 로마 숫자로 구성되도록 지정합니다. 예: I, II, III, IV, \\u2026, XVIII, XIX, XX, XXI.
+

--- a/korean/java/com.aspose.note/numberlist/_index.md
+++ b/korean/java/com.aspose.note/numberlist/_index.md
@@ -1,0 +1,341 @@
+---
+title: "NumberList"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "번호 매기기 또는 글머리표 목록을 나타냅니다."
+type: docs
+weight: 64
+url: /ko/java/com.aspose.note/numberlist/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class NumberList
+```
+
+번호 매기기 또는 글머리표 목록을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [NumberList(String bulletedSymbol, String font, int fontSize)](#NumberList-java.lang.String-java.lang.String-int-) | `NumberList` 클래스의 새 인스턴스를 초기화합니다. |
+| [NumberList(String format, byte numberFormat, String font, int fontSize)](#NumberList-java.lang.String-byte-java.lang.String-int-) | `NumberList` 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(NumberList other)](#equals-com.aspose.note.NumberList-) | 지정된 객체가 현재 객체와 같은지 여부를 결정합니다. |
+| [equals(Object obj)](#equals-java.lang.Object-) | 지정된 객체가 현재 객체와 같은지 여부를 결정합니다. |
+| [getFont()](#getFont--) | 글꼴 이름을 가져오거나 설정합니다. |
+| [getFontColor()](#getFontColor--) | 글꼴 색상을 가져오거나 설정합니다. |
+| [getFontSize()](#getFontSize--) | 글꼴 크기를 가져오거나 설정합니다. |
+| [getFormat()](#getFormat--) | 줄 머리글의 형식을 가져오거나 설정합니다. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 마지막 수정 시간을 가져오거나 설정합니다. |
+| [getNumberFormat()](#getNumberFormat--) | 자동 번호가 매겨진 객체 그룹에 사용되는 번호 형식을 가져오거나 설정합니다. |
+| [getNumberedListHeader(int sequenceNumber)](#getNumberedListHeader-int-) | 번호 매겨진 목록 머리글을 가져옵니다. |
+| [getRestart()](#getRestart--) | 목록 항목의 자동 번호 값을 재정의하는 숫자 값을 가져오거나 설정합니다. |
+| [hashCode()](#hashCode--) | 해당 유형에 대한 해시 함수로 사용됩니다. |
+| [isBold()](#isBold--) | 텍스트 스타일이 굵게인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [isItalic()](#isItalic--) | 텍스트 스타일이 이탤릭인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [setBold(boolean value)](#setBold-boolean-) | 텍스트 스타일이 굵게인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [setFont(String value)](#setFont-java.lang.String-) | 글꼴 이름을 가져오거나 설정합니다. |
+| [setFontColor(Color value)](#setFontColor-java.awt.Color-) | 글꼴 색상을 가져오거나 설정합니다. |
+| [setFontSize(int value)](#setFontSize-int-) | 글꼴 크기를 가져오거나 설정합니다. |
+| [setFormat(String value)](#setFormat-java.lang.String-) | 줄 머리글의 형식을 가져오거나 설정합니다. |
+| [setItalic(boolean value)](#setItalic-boolean-) | 텍스트 스타일이 이탤릭인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 마지막 수정 시간을 가져오거나 설정합니다. |
+| [setNumberFormat(Byte value)](#setNumberFormat-java.lang.Byte-) | 자동 번호가 매겨진 객체 그룹에 사용되는 번호 형식을 가져오거나 설정합니다. |
+| [setRestart(int value)](#setRestart-int-) | 목록 항목의 자동 번호 값을 재정의하는 숫자 값을 가져오거나 설정합니다. |
+### NumberList(String bulletedSymbol, String font, int fontSize) {#NumberList-java.lang.String-java.lang.String-int-}
+```
+public NumberList(String bulletedSymbol, String font, int fontSize)
+```
+
+
+`NumberList` 클래스의 새 인스턴스를 초기화합니다. 이 인스턴스는 글머리표 목록을 나타냅니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| bulletedSymbol | java.lang.String | 글머리표를 나타내는 기호. |
+| font | java.lang.String | 글머리표용 글꼴. |
+| fontSize | int | 글머리표용 글꼴 크기. |
+
+### NumberList(String format, byte numberFormat, String font, int fontSize) {#NumberList-java.lang.String-byte-java.lang.String-int-}
+```
+public NumberList(String format, byte numberFormat, String font, int fontSize)
+```
+
+
+`NumberList` 클래스의 새 인스턴스를 초기화합니다. 이 인스턴스는 번호 매겨진 목록을 나타냅니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| format | java.lang.String | 번호 매겨진 머리글의 형식. |
+| numberFormat | byte | 헤더에 있는 번호의 형식입니다. |
+| font | java.lang.String | 번호가 매겨진 헤더에 대한 글꼴입니다. |
+| fontSize | int | 번호가 매겨진 헤더에 대한 글꼴 크기입니다. |
+
+### equals(NumberList other) {#equals-com.aspose.note.NumberList-}
+```
+public boolean equals(NumberList other)
+```
+
+
+지정된 객체가 현재 객체와 같은지 여부를 결정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| other | [NumberList](../../com.aspose.note/numberlist) | 객체입니다. |
+
+**Returns:**
+boolean - `bool`입니다.
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+지정된 객체가 현재 객체와 같은지 여부를 결정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | java.lang.Object | 객체입니다. |
+
+**Returns:**
+boolean - `bool`입니다.
+### getFont() {#getFont--}
+```
+public String getFont()
+```
+
+
+글꼴 이름을 가져오거나 설정합니다.
+
+**Returns:**
+java.lang.String
+### getFontColor() {#getFontColor--}
+```
+public Color getFontColor()
+```
+
+
+글꼴 색상을 가져오거나 설정합니다.
+
+**Returns:**
+java.awt.Color
+### getFontSize() {#getFontSize--}
+```
+public int getFontSize()
+```
+
+
+글꼴 크기를 가져오거나 설정합니다.
+
+**Returns:**
+int
+### getFormat() {#getFormat--}
+```
+public String getFormat()
+```
+
+
+줄 헤더의 형식을 가져오거나 설정합니다. 글머리표 목록의 경우 글머리 기호를 나타냅니다.
+
+**Returns:**
+java.lang.String
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+마지막 수정 시간을 가져오거나 설정합니다.
+
+**Returns:**
+java.util.Date
+### getNumberFormat() {#getNumberFormat--}
+```
+public Byte getNumberFormat()
+```
+
+
+자동 번호가 매겨진 객체 그룹에 사용되는 번호 형식을 가져오거나 설정합니다. 글머리표 목록의 경우 null이어야 합니다.
+
+**Returns:**
+java.lang.Byte
+### getNumberedListHeader(int sequenceNumber) {#getNumberedListHeader-int-}
+```
+public String getNumberedListHeader(int sequenceNumber)
+```
+
+
+번호 매겨진 목록 머리글을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| sequenceNumber | int | 번호가 매겨진 목록의 순서 번호입니다. |
+
+**Returns:**
+java.lang.String - 지정된 순서 번호의 문자열 표현입니다.
+### getRestart() {#getRestart--}
+```
+public int getRestart()
+```
+
+
+목록 항목의 자동 번호 값을 재정의하는 숫자 값을 가져오거나 설정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+해당 유형에 대한 해시 함수로 사용됩니다.
+
+**Returns:**
+int - `int`입니다.
+### isBold() {#isBold--}
+```
+public boolean isBold()
+```
+
+
+텍스트 스타일이 굵게인지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Returns:**
+boolean
+### isItalic() {#isItalic--}
+```
+public boolean isItalic()
+```
+
+
+텍스트 스타일이 이탤릭인지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Returns:**
+boolean
+### setBold(boolean value) {#setBold-boolean-}
+```
+public void setBold(boolean value)
+```
+
+
+텍스트 스타일이 굵게인지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setFont(String value) {#setFont-java.lang.String-}
+```
+public void setFont(String value)
+```
+
+
+글꼴 이름을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setFontColor(Color value) {#setFontColor-java.awt.Color-}
+```
+public void setFontColor(Color value)
+```
+
+
+글꼴 색상을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.Color |  |
+
+### setFontSize(int value) {#setFontSize-int-}
+```
+public void setFontSize(int value)
+```
+
+
+글꼴 크기를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setFormat(String value) {#setFormat-java.lang.String-}
+```
+public void setFormat(String value)
+```
+
+
+줄 헤더의 형식을 가져오거나 설정합니다. 글머리표 목록의 경우 글머리 기호를 나타냅니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setItalic(boolean value) {#setItalic-boolean-}
+```
+public void setItalic(boolean value)
+```
+
+
+텍스트 스타일이 이탤릭인지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+마지막 수정 시간을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Date |  |
+
+### setNumberFormat(Byte value) {#setNumberFormat-java.lang.Byte-}
+```
+public void setNumberFormat(Byte value)
+```
+
+
+자동 번호가 매겨진 객체 그룹에 사용되는 번호 형식을 가져오거나 설정합니다. 글머리표 목록의 경우 null이어야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Byte |  |
+
+### setRestart(int value) {#setRestart-int-}
+```
+public void setRestart(int value)
+```
+
+
+목록 항목의 자동 번호 값을 재정의하는 숫자 값을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+

--- a/korean/java/com.aspose.note/onesaveoptions/_index.md
+++ b/korean/java/com.aspose.note/onesaveoptions/_index.md
@@ -1,0 +1,58 @@
+---
+title: "OneSaveOptions"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "문서를 OneNote 형식으로 저장할 때 추가 옵션을 지정할 수 있습니다."
+type: docs
+weight: 65
+url: /ko/java/com.aspose.note/onesaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.SaveOptions](../../com.aspose.note/saveoptions)
+```
+public final class OneSaveOptions extends SaveOptions
+```
+
+문서를 OneNote 형식으로 저장할 때 추가 옵션을 지정할 수 있습니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [OneSaveOptions()](#OneSaveOptions--) | `OneSaveOptions` 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getDocumentPassword()](#getDocumentPassword--) | 문서 내용을 암호화하기 위한 비밀번호를 가져오거나 설정합니다. |
+| [setDocumentPassword(String value)](#setDocumentPassword-java.lang.String-) | 문서 내용을 암호화하기 위한 비밀번호를 가져오거나 설정합니다. |
+### OneSaveOptions() {#OneSaveOptions--}
+```
+public OneSaveOptions()
+```
+
+
+`OneSaveOptions` 클래스의 새 인스턴스를 초기화합니다.
+
+### getDocumentPassword() {#getDocumentPassword--}
+```
+public String getDocumentPassword()
+```
+
+
+문서 내용을 암호화하기 위한 비밀번호를 가져오거나 설정합니다.
+
+**Returns:**
+java.lang.String
+### setDocumentPassword(String value) {#setDocumentPassword-java.lang.String-}
+```
+public void setDocumentPassword(String value)
+```
+
+
+문서 내용을 암호화하기 위한 비밀번호를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+

--- a/korean/java/com.aspose.note/outline/_index.md
+++ b/korean/java/com.aspose.note/outline/_index.md
@@ -1,0 +1,261 @@
+---
+title: "개요"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "개요를 나타냅니다."
+type: docs
+weight: 66
+url: /ko/java/com.aspose.note/outline/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode, com.aspose.note.IndentatedNode
+
+**All Implemented Interfaces:**
+[com.aspose.note.IPageChildNode](../../com.aspose.note/ipagechildnode)
+```
+public final class Outline extends IndentatedNode<IOutlineChildNode,Outline> implements IPageChildNode
+```
+
+개요를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Outline()](#Outline--) | 새 인스턴스를 초기화합니다 [Outline](../../com.aspose.note/outline) 클래스. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | 노드의 방문자를 수락합니다. |
+| [getDescendantsCannotBeMoved()](#getDescendantsCannotBeMoved--) | 개요의 하위 항목을 이동할 수 있는지 여부를 가져옵니다. |
+| [getHorizontalOffset()](#getHorizontalOffset--) | 수평 오프셋을 가져오거나 설정합니다. |
+| [getInternalIndentPosition()](#getInternalIndentPosition--) |  |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 마지막 수정 시간을 가져오거나 설정합니다. |
+| [getMaxHeight()](#getMaxHeight--) | 최대 높이를 가져오거나 설정합니다. |
+| [getMaxWidth()](#getMaxWidth--) | 최대 너비를 가져오거나 설정합니다. |
+| [getMinWidth()](#getMinWidth--) | 최소 너비를 가져오거나 설정합니다. |
+| [getReservedWidth()](#getReservedWidth--) | 예약된 너비를 가져오거나 설정합니다. |
+| [getVerticalOffset()](#getVerticalOffset--) | 수직 오프셋을 가져오거나 설정합니다. |
+| [setDescendantsCannotBeMoved(boolean value)](#setDescendantsCannotBeMoved-boolean-) | 개요의 하위 항목을 이동할 수 있는지 여부를 가져옵니다. |
+| [setHorizontalOffset(float value)](#setHorizontalOffset-float-) | 수평 오프셋을 가져오거나 설정합니다. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 마지막 수정 시간을 가져오거나 설정합니다. |
+| [setMaxHeight(float value)](#setMaxHeight-float-) | 최대 높이를 가져오거나 설정합니다. |
+| [setMaxWidth(float value)](#setMaxWidth-float-) | 최대 너비를 가져오거나 설정합니다. |
+| [setMinWidth(float value)](#setMinWidth-float-) | 최소 너비를 가져오거나 설정합니다. |
+| [setReservedWidth(float value)](#setReservedWidth-float-) | 예약된 너비를 가져오거나 설정합니다. |
+| [setVerticalOffset(float value)](#setVerticalOffset-float-) | 수직 오프셋을 가져오거나 설정합니다. |
+### Outline() {#Outline--}
+```
+public Outline()
+```
+
+
+새 인스턴스를 초기화합니다 [Outline](../../com.aspose.note/outline) 클래스.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+노드의 방문자를 수락합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor`에서 파생된 클래스의 객체. |
+
+### getDescendantsCannotBeMoved() {#getDescendantsCannotBeMoved--}
+```
+public boolean getDescendantsCannotBeMoved()
+```
+
+
+개요의 하위 항목을 이동할 수 있는지 여부를 가져옵니다.
+
+**Returns:**
+boolean
+### getHorizontalOffset() {#getHorizontalOffset--}
+```
+public float getHorizontalOffset()
+```
+
+
+수평 오프셋을 가져오거나 설정합니다.
+
+**Returns:**
+float
+### getInternalIndentPosition() {#getInternalIndentPosition--}
+```
+public int getInternalIndentPosition()
+```
+
+
+들여쓰기 크기를 얻기 위해 RgOutlineIndentDistance 배열에서 합산할 항목 수를 가져옵니다.
+
+**Returns:**
+int
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+마지막 수정 시간을 가져오거나 설정합니다.
+
+**Returns:**
+java.util.Date
+### getMaxHeight() {#getMaxHeight--}
+```
+public float getMaxHeight()
+```
+
+
+최대 높이를 가져오거나 설정합니다.
+
+**Returns:**
+float
+### getMaxWidth() {#getMaxWidth--}
+```
+public float getMaxWidth()
+```
+
+
+최대 너비를 가져오거나 설정합니다.
+
+**Returns:**
+float
+### getMinWidth() {#getMinWidth--}
+```
+public float getMinWidth()
+```
+
+
+최소 너비를 가져오거나 설정합니다.
+
+**Returns:**
+float
+### getReservedWidth() {#getReservedWidth--}
+```
+public float getReservedWidth()
+```
+
+
+예약된 너비를 가져오거나 설정합니다.
+
+**Returns:**
+float
+### getVerticalOffset() {#getVerticalOffset--}
+```
+public float getVerticalOffset()
+```
+
+
+수직 오프셋을 가져오거나 설정합니다.
+
+**Returns:**
+float
+### setDescendantsCannotBeMoved(boolean value) {#setDescendantsCannotBeMoved-boolean-}
+```
+public void setDescendantsCannotBeMoved(boolean value)
+```
+
+
+개요의 하위 항목을 이동할 수 있는지 여부를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setHorizontalOffset(float value) {#setHorizontalOffset-float-}
+```
+public void setHorizontalOffset(float value)
+```
+
+
+수평 오프셋을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+마지막 수정 시간을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Date |  |
+
+### setMaxHeight(float value) {#setMaxHeight-float-}
+```
+public void setMaxHeight(float value)
+```
+
+
+최대 높이를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setMaxWidth(float value) {#setMaxWidth-float-}
+```
+public void setMaxWidth(float value)
+```
+
+
+최대 너비를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setMinWidth(float value) {#setMinWidth-float-}
+```
+public void setMinWidth(float value)
+```
+
+
+최소 너비를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setReservedWidth(float value) {#setReservedWidth-float-}
+```
+public void setReservedWidth(float value)
+```
+
+
+예약된 너비를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setVerticalOffset(float value) {#setVerticalOffset-float-}
+```
+public void setVerticalOffset(float value)
+```
+
+
+수직 오프셋을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+

--- a/korean/java/com.aspose.note/outlineelement/_index.md
+++ b/korean/java/com.aspose.note/outlineelement/_index.md
@@ -1,0 +1,151 @@
+---
+title: "OutlineElement"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "OutlineElement를 나타냅니다."
+type: docs
+weight: 67
+url: /ko/java/com.aspose.note/outlineelement/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode, com.aspose.note.IndentatedNode
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineChildNode](../../com.aspose.note/ioutlinechildnode), [com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode)
+```
+public final class OutlineElement extends IndentatedNode<IOutlineElementChildNode,OutlineElement> implements IOutlineChildNode, IOutlineElementChildNode
+```
+
+OutlineElement를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [OutlineElement()](#OutlineElement--) | `OutlineElement` 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | 노드의 방문자를 수락합니다. |
+| [getAuthorMostRecent()](#getAuthorMostRecent--) | 아웃라인 요소의 가장 최근 작성자를 가져옵니다. |
+| [getAuthorOriginal()](#getAuthorOriginal--) | 아웃라인 요소의 원본 작성자를 가져옵니다. |
+| [getCreationTime()](#getCreationTime--) | 생성 시간을 가져오거나 설정합니다. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 마지막 수정 시간을 가져오거나 설정합니다. |
+| [getNumberList()](#getNumberList--) | 번호 매기기 목록 헤더의 스타일을 가져오거나 설정합니다. |
+| [setCreationTime(Date value)](#setCreationTime-java.util.Date-) | 생성 시간을 가져오거나 설정합니다. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 마지막 수정 시간을 가져오거나 설정합니다. |
+| [setNumberList(NumberList value)](#setNumberList-com.aspose.note.NumberList-) | 번호 매기기 목록 헤더의 스타일을 가져오거나 설정합니다. |
+### OutlineElement() {#OutlineElement--}
+```
+public OutlineElement()
+```
+
+
+`OutlineElement` 클래스의 새 인스턴스를 초기화합니다.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+노드의 방문자를 수락합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor`에서 파생된 클래스의 객체. |
+
+### getAuthorMostRecent() {#getAuthorMostRecent--}
+```
+public final String getAuthorMostRecent()
+```
+
+
+아웃라인 요소의 가장 최근 작성자를 가져옵니다.
+
+값: 가장 최근 작성자.
+
+**Returns:**
+java.lang.String
+### getAuthorOriginal() {#getAuthorOriginal--}
+```
+public final String getAuthorOriginal()
+```
+
+
+아웃라인 요소의 원본 작성자를 가져옵니다.
+
+값: 원본 작성자.
+
+**Returns:**
+java.lang.String
+### getCreationTime() {#getCreationTime--}
+```
+public Date getCreationTime()
+```
+
+
+생성 시간을 가져오거나 설정합니다.
+
+**Returns:**
+java.util.Date
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+마지막 수정 시간을 가져오거나 설정합니다.
+
+**Returns:**
+java.util.Date
+### getNumberList() {#getNumberList--}
+```
+public NumberList getNumberList()
+```
+
+
+번호 매기기 목록 헤더의 스타일을 가져오거나 설정합니다.
+
+**Returns:**
+[NumberList](../../com.aspose.note/numberlist)
+### setCreationTime(Date value) {#setCreationTime-java.util.Date-}
+```
+public void setCreationTime(Date value)
+```
+
+
+생성 시간을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Date |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+마지막 수정 시간을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Date |  |
+
+### setNumberList(NumberList value) {#setNumberList-com.aspose.note.NumberList-}
+```
+public void setNumberList(NumberList value)
+```
+
+
+번호 매기기 목록 헤더의 스타일을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [NumberList](../../com.aspose.note/numberlist) |  |
+

--- a/korean/java/com.aspose.note/outlinegroup/_index.md
+++ b/korean/java/com.aspose.note/outlinegroup/_index.md
@@ -1,0 +1,50 @@
+---
+title: "OutlineGroup"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "OutlineGroup를 나타냅니다."
+type: docs
+weight: 68
+url: /ko/java/com.aspose.note/outlinegroup/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode, com.aspose.note.IndentatedNode
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineChildNode](../../com.aspose.note/ioutlinechildnode), [com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode)
+```
+public final class OutlineGroup extends IndentatedNode<IOutlineChildNode,OutlineGroup> implements IOutlineChildNode, IOutlineElementChildNode
+```
+
+OutlineGroup를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [OutlineGroup()](#OutlineGroup--) | 새로운 `OutlineGroup` 클래스 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | 노드의 방문자를 수락합니다. |
+### OutlineGroup() {#OutlineGroup--}
+```
+public OutlineGroup()
+```
+
+
+새로운 `OutlineGroup` 클래스 인스턴스를 초기화합니다.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+노드의 방문자를 수락합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor`에서 파생된 클래스의 객체. |
+

--- a/korean/java/com.aspose.note/page/_index.md
+++ b/korean/java/com.aspose.note/page/_index.md
@@ -1,0 +1,385 @@
+---
+title: "Page"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "페이지를 나타냅니다."
+type: docs
+weight: 69
+url: /ko/java/com.aspose.note/page/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode
+```
+public final class Page extends CompositeNode<IPageChildNode>
+```
+
+페이지를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Page()](#Page--) | `Page` 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | 노드의 방문자를 수락합니다. |
+| [deepClone()](#deepClone--) | 페이지를 복제합니다. |
+| [deepClone(boolean cloneHistory)](#deepClone-boolean-) | 페이지를 복제합니다. |
+| [getAuthor()](#getAuthor--) | 작성자를 가져오거나 설정합니다. |
+| [getBackgroundColor()](#getBackgroundColor--) | 페이지의 배경색을 가져오거나 설정합니다. |
+| [getCreationTime()](#getCreationTime--) | 생성 시간을 가져오거나 설정합니다. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 마지막 수정 시간을 가져오거나 설정합니다. |
+| [getLevel()](#getLevel--) | 레벨을 가져오거나 설정합니다. |
+| [getMargin()](#getMargin--) | 여백을 가져오거나 설정합니다. |
+| [getPageContentRevisionSummary()](#getPageContentRevisionSummary--) | 페이지 및 해당 자식 노드에 대한 리비전 요약을 가져오거나 설정합니다. |
+| [getPageLayoutSize()](#getPageLayoutSize--) | 편집기에 표시되는 페이지의 레이아웃 크기를 가져옵니다. |
+| [getSizeType()](#getSizeType--) | 페이지의 크기 유형을 가져오거나 설정합니다. |
+| [getTitle()](#getTitle--) | 제목을 가져오거나 설정합니다. |
+| [isConflictPage()](#isConflictPage--) | 이 페이지가 충돌 페이지인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [setAuthor(String value)](#setAuthor-java.lang.String-) | 작성자를 가져오거나 설정합니다. |
+| [setBackgroundColor(Color value)](#setBackgroundColor-java.awt.Color-) | 페이지의 배경색을 가져오거나 설정합니다. |
+| [setConflictPage(boolean value)](#setConflictPage-boolean-) | 이 페이지가 충돌 페이지인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [setCreationTime(Date value)](#setCreationTime-java.util.Date-) | 생성 시간을 가져오거나 설정합니다. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 마지막 수정 시간을 가져오거나 설정합니다. |
+| [setLevel(byte value)](#setLevel-byte-) | 레벨을 가져오거나 설정합니다. |
+| [setMargin(Margins value)](#setMargin-com.aspose.note.Margins-) | 여백을 가져오거나 설정합니다. |
+| [setPageContentRevisionSummary(RevisionSummary value)](#setPageContentRevisionSummary-com.aspose.note.RevisionSummary-) | 페이지 및 해당 자식 노드에 대한 리비전 요약을 가져오거나 설정합니다. |
+| [setPageLayoutSize(Dimension2D value)](#setPageLayoutSize-java.awt.geom.Dimension2D-) | 편집기에서 표시되는 페이지 레이아웃 크기를 설정합니다. |
+| [setSizeType(int value)](#setSizeType-int-) | 페이지의 크기 유형을 가져오거나 설정합니다. |
+| [setTitle(Title value)](#setTitle-com.aspose.note.Title-) | 제목을 가져오거나 설정합니다. |
+### Page() {#Page--}
+```
+public Page()
+```
+
+
+`Page` 클래스의 새 인스턴스를 초기화합니다.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+노드의 방문자를 수락합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor`에서 파생된 클래스의 객체. |
+
+### deepClone() {#deepClone--}
+```
+public final Page deepClone()
+```
+
+
+페이지를 복제합니다.
+
+**Returns:**
+[Page](../../com.aspose.note/page) - A clone of the page.
+### deepClone(boolean cloneHistory) {#deepClone-boolean-}
+```
+public final Page deepClone(boolean cloneHistory)
+```
+
+
+페이지를 복제합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| cloneHistory | boolean | 페이지의 기록을 복제할지 여부를 지정합니다.. |
+
+**Returns:**
+[Page](../../com.aspose.note/page) - A clone of the page.
+### getAuthor() {#getAuthor--}
+```
+public String getAuthor()
+```
+
+
+작성자를 가져오거나 설정합니다.
+
+**Returns:**
+java.lang.String
+### getBackgroundColor() {#getBackgroundColor--}
+```
+public final Color getBackgroundColor()
+```
+
+
+페이지의 배경색을 가져오거나 설정합니다.
+
+**Returns:**
+java.awt.Color
+### getCreationTime() {#getCreationTime--}
+```
+public Date getCreationTime()
+```
+
+
+생성 시간을 가져오거나 설정합니다.
+
+**Returns:**
+java.util.Date
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+마지막 수정 시간을 가져오거나 설정합니다.
+
+**Returns:**
+java.util.Date
+### getLevel() {#getLevel--}
+```
+public byte getLevel()
+```
+
+
+레벨을 가져오거나 설정합니다.
+
+**Returns:**
+byte
+### getMargin() {#getMargin--}
+```
+public Margins getMargin()
+```
+
+
+여백을 가져오거나 설정합니다.
+
+**Returns:**
+[Margins](../../com.aspose.note/margins)
+### getPageContentRevisionSummary() {#getPageContentRevisionSummary--}
+```
+public RevisionSummary getPageContentRevisionSummary()
+```
+
+
+페이지 및 해당 자식 노드에 대한 리비전 요약을 가져오거나 설정합니다.
+
+**Returns:**
+[RevisionSummary](../../com.aspose.note/revisionsummary)
+### getPageLayoutSize() {#getPageLayoutSize--}
+```
+public final Dimension2D getPageLayoutSize()
+```
+
+
+편집기에 표시되는 페이지의 레이아웃 크기를 가져옵니다.
+
+--------------------
+
+이 값은 Microsoft OneNote 애플리케이션에서 문서를 열 때 기본 페이지 레이아웃을 표시하는 데 사용됩니다. 인쇄 및 문서 저장에는 영향을 주지 않습니다. Page.SizeType 속성이 PageSizeType.SizeByContent 로 설정된 경우 이 속성은 콘텐츠의 실제 크기를 반환합니다.
+
+**Returns:**
+java.awt.geom.Dimension2D
+### getSizeType() {#getSizeType--}
+```
+public final int getSizeType()
+```
+
+
+페이지의 크기 유형을 가져오거나 설정합니다.
+
+--------------------
+
+기본적으로 페이지는 자동으로 크기가 조정됩니다. 기본값은 [PageSizeType.SizeByContent](../../com.aspose.note/pagesizetype\#SizeByContent)입니다.
+
+**Returns:**
+int
+### getTitle() {#getTitle--}
+```
+public Title getTitle()
+```
+
+
+제목을 가져오거나 설정합니다.
+
+값: `Title`.
+
+**Returns:**
+[Title](../../com.aspose.note/title)
+### isConflictPage() {#isConflictPage--}
+```
+public final boolean isConflictPage()
+```
+
+
+이 페이지가 충돌 페이지인지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+--------------------
+
+두 사용자가 동일한 콘텐츠를 업데이트하려 할 때 충돌 페이지가 발생합니다. 이 경우 첫 번째 사용자의 변경 사항은 정상적으로 기록됩니다. 그러나 다른 사용자의 변경 사항은 병합될 수 없습니다. 따라서 페이지 사본이 생성되어 충돌로 표시됩니다.
+
+이 버전에서는 충돌이 첫 번째 사용자의 변경 사항을 우선하도록 해결됩니다. 따라서 문서에 충돌 페이지가 있는 경우 기록에는 표시되지만 저장 시 건너뛰게 됩니다. 이 플래그를 재설정하면 이러한 페이지를 일반 페이지처럼 기록에 저장할 수 있습니다.
+
+온라인 문서에서 충돌 페이지를 조작하는 자세한 예제를 찾을 수 있습니다.
+
+**Returns:**
+boolean
+### setAuthor(String value) {#setAuthor-java.lang.String-}
+```
+public void setAuthor(String value)
+```
+
+
+작성자를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setBackgroundColor(Color value) {#setBackgroundColor-java.awt.Color-}
+```
+public final void setBackgroundColor(Color value)
+```
+
+
+페이지의 배경색을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.Color |  |
+
+### setConflictPage(boolean value) {#setConflictPage-boolean-}
+```
+public final void setConflictPage(boolean value)
+```
+
+
+이 페이지가 충돌 페이지인지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+--------------------
+
+두 사용자가 동일한 콘텐츠를 업데이트하려 할 때 충돌 페이지가 발생합니다. 이 경우 첫 번째 사용자의 변경 사항은 정상적으로 기록됩니다. 그러나 다른 사용자의 변경 사항은 병합될 수 없습니다. 따라서 페이지 사본이 생성되어 충돌로 표시됩니다.
+
+이 버전에서는 충돌이 첫 번째 사용자의 변경 사항을 우선하도록 해결됩니다. 따라서 문서에 충돌 페이지가 있는 경우 기록에는 표시되지만 저장 시 건너뛰게 됩니다. 이 플래그를 재설정하면 이러한 페이지를 일반 페이지처럼 기록에 저장할 수 있습니다.
+
+온라인 문서에서 충돌 페이지를 조작하는 자세한 예제를 찾을 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setCreationTime(Date value) {#setCreationTime-java.util.Date-}
+```
+public void setCreationTime(Date value)
+```
+
+
+생성 시간을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Date |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+마지막 수정 시간을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Date |  |
+
+### setLevel(byte value) {#setLevel-byte-}
+```
+public void setLevel(byte value)
+```
+
+
+레벨을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | byte |  |
+
+### setMargin(Margins value) {#setMargin-com.aspose.note.Margins-}
+```
+public void setMargin(Margins value)
+```
+
+
+여백을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [Margins](../../com.aspose.note/margins) |  |
+
+### setPageContentRevisionSummary(RevisionSummary value) {#setPageContentRevisionSummary-com.aspose.note.RevisionSummary-}
+```
+public void setPageContentRevisionSummary(RevisionSummary value)
+```
+
+
+페이지 및 해당 자식 노드에 대한 리비전 요약을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [RevisionSummary](../../com.aspose.note/revisionsummary) |  |
+
+### setPageLayoutSize(Dimension2D value) {#setPageLayoutSize-java.awt.geom.Dimension2D-}
+```
+public final void setPageLayoutSize(Dimension2D value)
+```
+
+
+편집기에서 표시되는 페이지 레이아웃 크기를 설정합니다.
+
+--------------------
+
+이 값은 Microsoft OneNote 애플리케이션에서 문서를 열 때 기본 페이지 레이아웃을 표시하는 데 사용됩니다. 인쇄 및 문서 저장에는 영향을 주지 않습니다. Page.SizeType 속성이 PageSizeType.SizeByContent 로 설정된 경우 이 속성은 콘텐츠의 실제 크기를 반환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.geom.Dimension2D |  |
+
+### setSizeType(int value) {#setSizeType-int-}
+```
+public final void setSizeType(int value)
+```
+
+
+페이지의 크기 유형을 가져오거나 설정합니다.
+
+--------------------
+
+기본적으로 페이지는 자동으로 크기가 조정됩니다. 기본값은 [PageSizeType.SizeByContent](../../com.aspose.note/pagesizetype\#SizeByContent)입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTitle(Title value) {#setTitle-com.aspose.note.Title-}
+```
+public void setTitle(Title value)
+```
+
+
+제목을 가져오거나 설정합니다.
+
+값: `Title`.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [Title](../../com.aspose.note/title) |  |
+

--- a/korean/java/com.aspose.note/pagehistory/_index.md
+++ b/korean/java/com.aspose.note/pagehistory/_index.md
@@ -1,0 +1,260 @@
+---
+title: "PageHistory"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "페이지 기록을 나타냅니다."
+type: docs
+weight: 70
+url: /ko/java/com.aspose.note/pagehistory/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+com.aspose.ms.System.Collections.Generic.IGenericList
+```
+public class PageHistory implements System.Collections.Generic.IGenericList<Page>
+```
+
+페이지 기록을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageHistory(Page page)](#PageHistory-com.aspose.note.Page-) | 새 `PageHistory` 클래스 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [addItem(Page item)](#addItem-com.aspose.note.Page-) | `PageHistory`의 끝에 페이지 버전을 추가합니다. |
+| [addRange(System.Collections.Generic.IGenericEnumerable&lt;Page&gt; items)](#addRange-com.aspose.ms.System.Collections.Generic.IGenericEnumerable-com.aspose.note.Page--) | `PageHistory`의 끝에 페이지 버전들을 추가합니다. |
+| [clear()](#clear--) | 페이지 기록을 지웁니다. |
+| [containsItem(Page item)](#containsItem-com.aspose.note.Page-) | 페이지 기록에 페이지 버전이 포함되어 있는지 확인합니다. |
+| [copyToTArray(Page[] array, int arrayIndex)](#copyToTArray-com.aspose.note.Page---int-) | 페이지 버전을 배열에 복사하고, 특정 인덱스에서 시작합니다.. |
+| [getCurrent()](#getCurrent--) | 현재 페이지 버전을 가져옵니다. |
+| [get_Item(int index)](#get-Item-int-) | 지정된 인덱스의 `PageHistory`에서 페이지 버전을 가져오거나 설정합니다. |
+| [indexOfItem(Page item)](#indexOfItem-com.aspose.note.Page-) | 페이지 기록에서 특정 페이지 버전의 인덱스를 결정합니다. |
+| [insertItem(int index, Page item)](#insertItem-int-com.aspose.note.Page-) | 페이지 버전을 페이지 기록에 삽입합니다. |
+| [isReadOnly()](#isReadOnly--) | 페이지 기록이 읽기 전용인지 여부를 나타내는 값을 가져옵니다. |
+| [iterator()](#iterator--) | `PageHistory`의 자식 노드를 순회하는 열거자를 반환합니다. |
+| [removeAt(int index)](#removeAt-int-) | `PageHistory`의 지정된 인덱스에 있는 페이지 버전을 제거합니다. |
+| [removeItem(Page item)](#removeItem-com.aspose.note.Page-) | `PageHistory`에서 페이지 버전을 제거합니다. |
+| [removeRange(int index, int count)](#removeRange-int-int-) | `PageHistory`에서 페이지 버전 범위를 제거합니다. |
+| [set_Item(int index, Page value)](#set-Item-int-com.aspose.note.Page-) | 지정된 인덱스의 `PageHistory`에서 페이지 버전을 가져오거나 설정합니다. |
+| [size()](#size--) | 페이지 기록에 있는 페이지 버전 수를 가져옵니다. |
+### PageHistory(Page page) {#PageHistory-com.aspose.note.Page-}
+```
+public PageHistory(Page page)
+```
+
+
+새 `PageHistory` 클래스 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.note/page) | 현재 페이지 버전. |
+
+### addItem(Page item) {#addItem-com.aspose.note.Page-}
+```
+public void addItem(Page item)
+```
+
+
+`PageHistory`의 끝에 페이지 버전을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| item | [Page](../../com.aspose.note/page) | 페이지 버전. |
+
+### addRange(System.Collections.Generic.IGenericEnumerable&lt;Page&gt; items) {#addRange-com.aspose.ms.System.Collections.Generic.IGenericEnumerable-com.aspose.note.Page--}
+```
+public void addRange(System.Collections.Generic.IGenericEnumerable<Page> items)
+```
+
+
+`PageHistory`의 끝에 페이지 버전들을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 항목 | com.aspose.ms.System.Collections.Generic.IGenericEnumerable&lt;com.aspose.note.Page&gt; | 페이지 버전의 `IEnumerable\{Page\}` 컬렉션. |
+
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+페이지 기록을 지웁니다.
+
+### containsItem(Page item) {#containsItem-com.aspose.note.Page-}
+```
+public boolean containsItem(Page item)
+```
+
+
+페이지 기록에 페이지 버전이 포함되어 있는지 확인합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| item | [Page](../../com.aspose.note/page) | 페이지 버전. |
+
+**Returns:**
+boolean - `bool`입니다.
+### copyToTArray(Page[] array, int arrayIndex) {#copyToTArray-com.aspose.note.Page---int-}
+```
+public void copyToTArray(Page[] array, int arrayIndex)
+```
+
+
+페이지 버전을 배열에 복사하고, 특정 인덱스에서 시작합니다..
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| array | [Page\[\]](../../com.aspose.note/page) | 대상 배열. |
+| arrayIndex | int | 배열 인덱스. |
+
+### getCurrent() {#getCurrent--}
+```
+public Page getCurrent()
+```
+
+
+현재 페이지 버전을 가져옵니다.
+
+**Returns:**
+[Page](../../com.aspose.note/page)
+### get_Item(int index) {#get-Item-int-}
+```
+public Page get_Item(int index)
+```
+
+
+지정된 인덱스의 `PageHistory`에서 페이지 버전을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| index | int | 인덱스. |
+
+**Returns:**
+[Page](../../com.aspose.note/page) - The page version.
+### indexOfItem(Page item) {#indexOfItem-com.aspose.note.Page-}
+```
+public int indexOfItem(Page item)
+```
+
+
+페이지 기록에서 특정 페이지 버전의 인덱스를 결정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| item | [Page](../../com.aspose.note/page) | 페이지 버전. |
+
+**Returns:**
+int - `int`입니다.
+### insertItem(int index, Page item) {#insertItem-int-com.aspose.note.Page-}
+```
+public void insertItem(int index, Page item)
+```
+
+
+페이지 버전을 페이지 기록에 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| index | int | 인덱스. |
+| item | [Page](../../com.aspose.note/page) | 페이지 버전. |
+
+### isReadOnly() {#isReadOnly--}
+```
+public boolean isReadOnly()
+```
+
+
+페이지 기록이 읽기 전용인지 여부를 나타내는 값을 가져옵니다.
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public System.Collections.Generic.IGenericEnumerator<Page> iterator()
+```
+
+
+`PageHistory`의 자식 노드를 순회하는 열거자를 반환합니다.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;com.aspose.note.Page&gt; - `IEnumerator`.
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+`PageHistory`의 지정된 인덱스에 있는 페이지 버전을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| index | int | 인덱스. |
+
+### removeItem(Page item) {#removeItem-com.aspose.note.Page-}
+```
+public boolean removeItem(Page item)
+```
+
+
+`PageHistory`에서 페이지 버전을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| item | [Page](../../com.aspose.note/page) | 페이지 버전. |
+
+**Returns:**
+boolean - `bool`입니다.
+### removeRange(int index, int count) {#removeRange-int-int-}
+```
+public void removeRange(int index, int count)
+```
+
+
+`PageHistory`에서 페이지 버전 범위를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| index | int | 인덱스. |
+| count | int | 카운트입니다. |
+
+### set_Item(int index, Page value) {#set-Item-int-com.aspose.note.Page-}
+```
+public void set_Item(int index, Page value)
+```
+
+
+지정된 인덱스의 `PageHistory`에서 페이지 버전을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| index | int | 인덱스. |
+| value | [Page](../../com.aspose.note/page) |  |
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+페이지 기록에 있는 페이지 버전 수를 가져옵니다.
+
+**Returns:**
+int

--- a/korean/java/com.aspose.note/pagesavingargs/_index.md
+++ b/korean/java/com.aspose.note/pagesavingargs/_index.md
@@ -1,0 +1,31 @@
+---
+title: "PageSavingArgs"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "PageSaving 이벤트에 대한 데이터를 제공합니다."
+type: docs
+weight: 71
+url: /ko/java/com.aspose.note/pagesavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ResourceSavingArgs](../../com.aspose.note/resourcesavingargs)
+```
+public class PageSavingArgs extends ResourceSavingArgs
+```
+
+PageSaving 이벤트에 대한 데이터를 제공합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getPageIndex()](#getPageIndex--) | 현재 페이지 인덱스입니다. |
+### getPageIndex() {#getPageIndex--}
+```
+public final int getPageIndex()
+```
+
+
+현재 페이지 인덱스입니다.
+
+**Returns:**
+int

--- a/korean/java/com.aspose.note/pagesettings/_index.md
+++ b/korean/java/com.aspose.note/pagesettings/_index.md
@@ -1,0 +1,64 @@
+---
+title: "PageSettings"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "페이지에 대한 레이아웃 설정을 나타냅니다."
+type: docs
+weight: 72
+url: /ko/java/com.aspose.note/pagesettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSettings
+```
+
+페이지에 대한 레이아웃 설정을 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getA4()](#getA4--) | A4 형식 페이지에 대한 설정을 가져옵니다. |
+| [getA4NoHeightLimit()](#getA4NoHeightLimit--) | 무제한 높이의 A4 형식 페이지에 대한 설정을 가져옵니다. |
+| [getLetter()](#getLetter--) | Letter 형식 페이지에 대한 설정을 가져옵니다. |
+| [getLetterNoHeightLimit()](#getLetterNoHeightLimit--) | 무제한 높이의 Letter 형식 페이지에 대한 설정을 가져옵니다. |
+### getA4() {#getA4--}
+```
+public static PageSettings getA4()
+```
+
+
+A4 형식 페이지에 대한 설정을 가져옵니다.
+
+**Returns:**
+[PageSettings](../../com.aspose.note/pagesettings)
+### getA4NoHeightLimit() {#getA4NoHeightLimit--}
+```
+public static PageSettings getA4NoHeightLimit()
+```
+
+
+무제한 높이의 A4 형식 페이지에 대한 설정을 가져옵니다.
+
+**Returns:**
+[PageSettings](../../com.aspose.note/pagesettings)
+### getLetter() {#getLetter--}
+```
+public static PageSettings getLetter()
+```
+
+
+Letter 형식 페이지에 대한 설정을 가져옵니다.
+
+**Returns:**
+[PageSettings](../../com.aspose.note/pagesettings)
+### getLetterNoHeightLimit() {#getLetterNoHeightLimit--}
+```
+public static PageSettings getLetterNoHeightLimit()
+```
+
+
+무제한 높이의 Letter 형식 페이지에 대한 설정을 가져옵니다.
+
+**Returns:**
+[PageSettings](../../com.aspose.note/pagesettings)

--- a/korean/java/com.aspose.note/pagesizetype/_index.md
+++ b/korean/java/com.aspose.note/pagesizetype/_index.md
@@ -1,0 +1,164 @@
+---
+title: "PageSizeType"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "페이지 노드 유형의 크기를 지정합니다."
+type: docs
+weight: 73
+url: /ko/java/com.aspose.note/pagesizetype/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class PageSizeType extends System.Enum
+```
+
+페이지 노드 유형의 크기를 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ANSILetter](#ANSILetter) | ANSI 레터 (8.5\" x 11\"). |
+| [ANSITabloid](#ANSITabloid) | ANSI 타블로이드 (11\" x 17\"). |
+| [Billfold](#Billfold) | 빌폴드 (3.75\" x 6.75\"). |
+| [Custom](#Custom) | 사용자 정의 크기. |
+| [ISOA3](#ISOA3) | ISO A3 (297mm x 420mm). |
+| [ISOA4](#ISOA4) | ISO A4 (210mm x 297mm). |
+| [ISOA5](#ISOA5) | ISO A5 (148mm x 210mm). |
+| [ISOA6](#ISOA6) | ISO A6 (105mm x 148mm). |
+| [IndexCard](#IndexCard) | 인덱스 카드 (3\" x 5\"). |
+| [JISB4](#JISB4) | JIS B4 (257mm x 364mm). |
+| [JISB5](#JISB5) | JIS B5 (182mm x 257mm). |
+| [JISB6](#JISB6) | JIS B6 (128mm x 182mm). |
+| [JapanesePostcard](#JapanesePostcard) | 일본 엽서 (100mm x 148mm). |
+| [SizeByContent](#SizeByContent) | 페이지에 고정된 크기가 없습니다. |
+| [USLegal](#USLegal) | 미국. |
+| [USStatement](#USStatement) | 미국. |
+### ANSILetter {#ANSILetter}
+```
+public static final int ANSILetter
+```
+
+
+ANSI 레터 (8.5\" x 11\").
+
+### ANSITabloid {#ANSITabloid}
+```
+public static final int ANSITabloid
+```
+
+
+ANSI 타블로이드 (11\" x 17\").
+
+### Billfold {#Billfold}
+```
+public static final int Billfold
+```
+
+
+빌폴드 (3.75\" x 6.75\").
+
+### Custom {#Custom}
+```
+public static final int Custom
+```
+
+
+사용자 정의 크기.
+
+### ISOA3 {#ISOA3}
+```
+public static final int ISOA3
+```
+
+
+ISO A3 (297mm x 420mm).
+
+### ISOA4 {#ISOA4}
+```
+public static final int ISOA4
+```
+
+
+ISO A4 (210mm x 297mm).
+
+### ISOA5 {#ISOA5}
+```
+public static final int ISOA5
+```
+
+
+ISO A5 (148mm x 210mm).
+
+### ISOA6 {#ISOA6}
+```
+public static final int ISOA6
+```
+
+
+ISO A6 (105mm x 148mm).
+
+### IndexCard {#IndexCard}
+```
+public static final int IndexCard
+```
+
+
+인덱스 카드 (3\" x 5\").
+
+### JISB4 {#JISB4}
+```
+public static final int JISB4
+```
+
+
+JIS B4 (257mm x 364mm).
+
+### JISB5 {#JISB5}
+```
+public static final int JISB5
+```
+
+
+JIS B5 (182mm x 257mm).
+
+### JISB6 {#JISB6}
+```
+public static final int JISB6
+```
+
+
+JIS B6 (128mm x 182mm).
+
+### JapanesePostcard {#JapanesePostcard}
+```
+public static final int JapanesePostcard
+```
+
+
+일본 엽서 (100mm x 148mm).
+
+### SizeByContent {#SizeByContent}
+```
+public static final int SizeByContent
+```
+
+
+페이지에 고정된 크기가 없습니다. 페이지는 내부의 모든 콘텐츠에 맞게 자동으로 크기가 조정됩니다.
+
+### USLegal {#USLegal}
+```
+public static final int USLegal
+```
+
+
+미국 법정 (8.5\" x 14\").
+
+### USStatement {#USStatement}
+```
+public static final int USStatement
+```
+
+
+미국 스테이트먼트 (5.5\" x 8.5\").
+

--- a/korean/java/com.aspose.note/pagesplittingalgorithm/_index.md
+++ b/korean/java/com.aspose.note/pagesplittingalgorithm/_index.md
@@ -1,0 +1,27 @@
+---
+title: "PageSplittingAlgorithm"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "원본 페이지에 맞지 않을 경우 객체를 분할하기 위한 기본 클래스."
+type: docs
+weight: 74
+url: /ko/java/com.aspose.note/pagesplittingalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class PageSplittingAlgorithm
+```
+
+원본 페이지에 맞지 않을 경우 객체를 분할하기 위한 기본 클래스입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageSplittingAlgorithm()](#PageSplittingAlgorithm--) |  |
+### PageSplittingAlgorithm() {#PageSplittingAlgorithm--}
+```
+public PageSplittingAlgorithm()
+```
+
+

--- a/korean/java/com.aspose.note/paragraphstyle/_index.md
+++ b/korean/java/com.aspose.note/paragraphstyle/_index.md
@@ -1,0 +1,90 @@
+---
+title: "ParagraphStyle"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "일치하는 TextStyle 객체가 컬렉션에 없거나 이 객체가 필요한 설정을 지정하지 않은 경우 사용할 텍스트 스타일 설정입니다."
+type: docs
+weight: 75
+url: /ko/java/com.aspose.note/paragraphstyle/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.note.Style
+
+**All Implemented Interfaces:**
+com.aspose.ms.System.IEquatable, java.lang.Cloneable
+```
+public final class ParagraphStyle extends Style<ParagraphStyle> implements System.IEquatable<ParagraphStyle>, Cloneable
+```
+
+일치하는 TextStyle 객체가 [RichText.getStyles](../../com.aspose.note/richtext\#getStyles) 컬렉션에 없거나 이 객체가 필요한 설정을 지정하지 않은 경우 사용할 텍스트 스타일 설정입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ParagraphStyle()](#ParagraphStyle--) | 새로운 [ParagraphStyle](../../com.aspose.note/paragraphstyle) 클래스 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(ParagraphStyle other)](#equals-com.aspose.note.ParagraphStyle-) | 지정된 객체가 현재 객체와 같은지 여부를 결정합니다. |
+| [equals(Object obj)](#equals-java.lang.Object-) | 지정된 객체가 현재 객체와 같은지 여부를 결정합니다. |
+| [getDefault()](#getDefault--) | 기본 설정이 적용된 ParagraphStyle을 가져옵니다. |
+| [hashCode()](#hashCode--) | 해당 유형에 대한 해시 함수로 사용됩니다. |
+### ParagraphStyle() {#ParagraphStyle--}
+```
+public ParagraphStyle()
+```
+
+
+새로운 [ParagraphStyle](../../com.aspose.note/paragraphstyle) 클래스 인스턴스를 초기화합니다.
+
+### equals(ParagraphStyle other) {#equals-com.aspose.note.ParagraphStyle-}
+```
+public final boolean equals(ParagraphStyle other)
+```
+
+
+지정된 객체가 현재 객체와 같은지 여부를 결정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| other | [ParagraphStyle](../../com.aspose.note/paragraphstyle) | 객체입니다. |
+
+**Returns:**
+boolean - 그 `boolean`.
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+지정된 객체가 현재 객체와 같은지 여부를 결정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | java.lang.Object | 객체입니다. |
+
+**Returns:**
+boolean - 그 `boolean`.
+### getDefault() {#getDefault--}
+```
+public static ParagraphStyle getDefault()
+```
+
+
+기본 설정이 적용된 ParagraphStyle을 가져옵니다.
+
+**Returns:**
+[ParagraphStyle](../../com.aspose.note/paragraphstyle)
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+해당 유형에 대한 해시 함수로 사용됩니다.
+
+**Returns:**
+int - `int`입니다.

--- a/korean/java/com.aspose.note/pdfimagecompression/_index.md
+++ b/korean/java/com.aspose.note/pdfimagecompression/_index.md
@@ -1,0 +1,56 @@
+---
+title: "PdfImageCompression"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "PDF 파일의 이미지에 적용되는 압축 유형을 지정합니다."
+type: docs
+weight: 76
+url: /ko/java/com.aspose.note/pdfimagecompression/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class PdfImageCompression extends System.Enum
+```
+
+PDF 파일의 이미지에 적용되는 압축 유형을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Auto](#Auto) | 각 이미지에 가장 적합한 압축을 자동으로 선택합니다. |
+| [Flate](#Flate) | Flate 압축(무손실). |
+| [Jpeg](#Jpeg) | Jpeg 압축. |
+| [None](#None) | 이미지를 저장할 때 압축을 사용하지 않습니다. |
+### Auto {#Auto}
+```
+public static final int Auto
+```
+
+
+각 이미지에 가장 적합한 압축을 자동으로 선택합니다.
+
+### Flate {#Flate}
+```
+public static final int Flate
+```
+
+
+Flate 압축(무손실).
+
+### Jpeg {#Jpeg}
+```
+public static final int Jpeg
+```
+
+
+Jpeg 압축. 투명성을 지원하지 않습니다.
+
+### None {#None}
+```
+public static final int None
+```
+
+
+이미지를 저장할 때 압축을 사용하지 않습니다.
+

--- a/korean/java/com.aspose.note/pdfsaveoptions/_index.md
+++ b/korean/java/com.aspose.note/pdfsaveoptions/_index.md
@@ -1,0 +1,145 @@
+---
+title: "PdfSaveOptions"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "문서 페이지를 PDF로 렌더링할 때 추가 옵션을 지정할 수 있습니다."
+type: docs
+weight: 77
+url: /ko/java/com.aspose.note/pdfsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.SaveOptions](../../com.aspose.note/saveoptions)
+```
+public final class PdfSaveOptions extends SaveOptions
+```
+
+문서 페이지를 PDF로 렌더링할 때 추가 옵션을 지정할 수 있습니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PdfSaveOptions()](#PdfSaveOptions--) | 새 `PdfSaveOptions` 클래스 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getImageCompression()](#getImageCompression--) | PDF 파일의 이미지에 적용되는 압축 유형을 가져옵니다. |
+| [getJpegQuality()](#getJpegQuality--) | PDF 문서 내부 JPEG 이미지의 품질을 결정하는 값을 가져옵니다. |
+| [getPageSettings()](#getPageSettings--) | 문서의 각 페이지에 대한 페이지 설정을 가져오거나 설정합니다. |
+| [getPageSplittingAlgorithm()](#getPageSplittingAlgorithm--) | 페이지 분할에 사용되는 알고리즘을 가져오거나 설정합니다. |
+| [setImageCompression(int value)](#setImageCompression-int-) | PDF 파일의 이미지에 적용되는 압축 유형을 설정합니다. |
+| [setJpegQuality(int value)](#setJpegQuality-int-) | PDF 문서 내부 JPEG 이미지의 품질을 결정하는 값을 설정합니다. |
+| [setPageSettings(PageSettings value)](#setPageSettings-com.aspose.note.PageSettings-) | 문서의 각 페이지에 대한 페이지 설정을 가져오거나 설정합니다. |
+| [setPageSplittingAlgorithm(PageSplittingAlgorithm value)](#setPageSplittingAlgorithm-com.aspose.note.PageSplittingAlgorithm-) | 페이지 분할에 사용되는 알고리즘을 가져오거나 설정합니다. |
+### PdfSaveOptions() {#PdfSaveOptions--}
+```
+public PdfSaveOptions()
+```
+
+
+새 `PdfSaveOptions` 클래스 인스턴스를 초기화합니다.
+
+### getImageCompression() {#getImageCompression--}
+```
+public final int getImageCompression()
+```
+
+
+PDF 파일의 이미지에 적용되는 압축 유형을 가져옵니다.
+
+**Returns:**
+int
+### getJpegQuality() {#getJpegQuality--}
+```
+public final int getJpegQuality()
+```
+
+
+PDF 문서 내부 JPEG 이미지의 품질을 결정하는 값을 가져옵니다. 이 값은 0에서 100 사이이며, 0은 최악의 품질이지만 최대 압축을 의미하고 100은 최고의 품질이지만 최소 압축을 의미합니다.
+
+--------------------
+
+기본값은 90입니다.
+
+**Returns:**
+int
+### getPageSettings() {#getPageSettings--}
+```
+public PageSettings getPageSettings()
+```
+
+
+문서의 각 페이지에 대한 페이지 설정을 가져오거나 설정합니다. 기본값은 CurrentUICulture에 따라 달라지며, \*US 문화권은 레터 설정을, 다른 문화권은 A4 설정을 사용합니다.
+
+**Returns:**
+[PageSettings](../../com.aspose.note/pagesettings)
+### getPageSplittingAlgorithm() {#getPageSplittingAlgorithm--}
+```
+public PageSplittingAlgorithm getPageSplittingAlgorithm()
+```
+
+
+페이지 분할에 사용되는 알고리즘을 가져오거나 설정합니다.
+
+값: `PageSplittingAlgorithm`.
+
+**Returns:**
+[PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm)
+### setImageCompression(int value) {#setImageCompression-int-}
+```
+public final void setImageCompression(int value)
+```
+
+
+PDF 파일의 이미지에 적용되는 압축 유형을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setJpegQuality(int value) {#setJpegQuality-int-}
+```
+public final void setJpegQuality(int value)
+```
+
+
+PDF 문서 내부 JPEG 이미지의 품질을 결정하는 값을 설정합니다. 이 값은 0에서 100 사이이며, 0은 최악의 품질이지만 최대 압축을 의미하고 100은 최고의 품질이지만 최소 압축을 의미합니다.
+
+--------------------
+
+기본값은 90입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPageSettings(PageSettings value) {#setPageSettings-com.aspose.note.PageSettings-}
+```
+public void setPageSettings(PageSettings value)
+```
+
+
+문서의 각 페이지에 대한 페이지 설정을 가져오거나 설정합니다. 기본값은 CurrentUICulture에 따라 달라지며, \*US 문화권은 레터 설정을, 다른 문화권은 A4 설정을 사용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [PageSettings](../../com.aspose.note/pagesettings) |  |
+
+### setPageSplittingAlgorithm(PageSplittingAlgorithm value) {#setPageSplittingAlgorithm-com.aspose.note.PageSplittingAlgorithm-}
+```
+public void setPageSplittingAlgorithm(PageSplittingAlgorithm value)
+```
+
+
+페이지 분할에 사용되는 알고리즘을 가져오거나 설정합니다.
+
+값: `PageSplittingAlgorithm`.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm) |  |
+

--- a/korean/java/com.aspose.note/printoptions/_index.md
+++ b/korean/java/com.aspose.note/printoptions/_index.md
@@ -1,0 +1,145 @@
+---
+title: "PrintOptions"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "문서를 인쇄할 때 사용되는 옵션입니다."
+type: docs
+weight: 78
+url: /ko/java/com.aspose.note/printoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PrintOptions
+```
+
+문서를 인쇄할 때 사용되는 옵션입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PrintOptions()](#PrintOptions--) | `PrintOptions` 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getDocumentName()](#getDocumentName--) | 문서를 인쇄하는 동안 표시할 문서 이름을 가져오거나 설정합니다(예: 인쇄 상태 대화 상자 또는 프린터 대기열). |
+| [getPageSplittingAlgorithm()](#getPageSplittingAlgorithm--) | 페이지 분할에 사용되는 알고리즘을 가져오거나 설정합니다. |
+| [getPrinterSettings()](#getPrinterSettings--) | 프린터 설정을 가져오거나 설정합니다. |
+| [getResolution()](#getResolution--) | 생성된 이미지의 해상도를 인치당 도트 수(DPI)로 가져오거나 설정합니다. |
+| [setDocumentName(String value)](#setDocumentName-java.lang.String-) | 문서를 인쇄하는 동안 표시할 문서 이름을 가져오거나 설정합니다(예: 인쇄 상태 대화 상자 또는 프린터 대기열). |
+| [setPageSplittingAlgorithm(PageSplittingAlgorithm value)](#setPageSplittingAlgorithm-com.aspose.note.PageSplittingAlgorithm-) | 페이지 분할에 사용되는 알고리즘을 가져오거나 설정합니다. |
+| [setPrinterSettings(AttributeSet value)](#setPrinterSettings-javax.print.attribute.AttributeSet-) | 프린터 설정을 가져오거나 설정합니다. |
+| [setResolution(float value)](#setResolution-float-) | 생성된 이미지의 해상도를 인치당 도트 수(DPI)로 가져오거나 설정합니다. |
+### PrintOptions() {#PrintOptions--}
+```
+public PrintOptions()
+```
+
+
+`PrintOptions` 클래스의 새 인스턴스를 초기화합니다.
+
+### getDocumentName() {#getDocumentName--}
+```
+public String getDocumentName()
+```
+
+
+문서를 인쇄하는 동안 표시할 문서 이름을 가져오거나 설정합니다(예: 인쇄 상태 대화 상자 또는 프린터 대기열).
+
+**Returns:**
+java.lang.String
+### getPageSplittingAlgorithm() {#getPageSplittingAlgorithm--}
+```
+public PageSplittingAlgorithm getPageSplittingAlgorithm()
+```
+
+
+페이지 분할에 사용되는 알고리즘을 가져오거나 설정합니다.
+
+값: `PageSplittingAlgorithm`.
+
+**Returns:**
+[PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm)
+### getPrinterSettings() {#getPrinterSettings--}
+```
+public AttributeSet getPrinterSettings()
+```
+
+
+프린터 설정을 가져오거나 설정합니다.
+
+**Returns:**
+javax.print.attribute.AttributeSet
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+생성된 이미지의 해상도를 인치당 도트 수(DPI)로 가져오거나 설정합니다.
+
+--------------------
+
+기본값은 96입니다.
+
+**Returns:**
+float
+### setDocumentName(String value) {#setDocumentName-java.lang.String-}
+```
+public void setDocumentName(String value)
+```
+
+
+문서를 인쇄하는 동안 표시할 문서 이름을 가져오거나 설정합니다(예: 인쇄 상태 대화 상자 또는 프린터 대기열).
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setPageSplittingAlgorithm(PageSplittingAlgorithm value) {#setPageSplittingAlgorithm-com.aspose.note.PageSplittingAlgorithm-}
+```
+public void setPageSplittingAlgorithm(PageSplittingAlgorithm value)
+```
+
+
+페이지 분할에 사용되는 알고리즘을 가져오거나 설정합니다.
+
+값: `PageSplittingAlgorithm`.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm) |  |
+
+### setPrinterSettings(AttributeSet value) {#setPrinterSettings-javax.print.attribute.AttributeSet-}
+```
+public void setPrinterSettings(AttributeSet value)
+```
+
+
+프린터 설정을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | javax.print.attribute.AttributeSet |  |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+생성된 이미지의 해상도를 인치당 도트 수(DPI)로 가져오거나 설정합니다.
+
+--------------------
+
+기본값은 96입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+

--- a/korean/java/com.aspose.note/resourceexporttype/_index.md
+++ b/korean/java/com.aspose.note/resourceexporttype/_index.md
@@ -1,0 +1,39 @@
+---
+title: "ResourceExportType"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: 
+type: docs
+weight: 79
+url: /ko/java/com.aspose.note/resourceexporttype/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class ResourceExportType extends System.Enum
+```
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ExportAsStream](#ExportAsStream) |  |
+| [ExportEmbedded](#ExportEmbedded) |  |
+| [NoExport](#NoExport) |  |
+### ExportAsStream {#ExportAsStream}
+```
+public static final int ExportAsStream
+```
+
+
+### ExportEmbedded {#ExportEmbedded}
+```
+public static final int ExportEmbedded
+```
+
+
+### NoExport {#NoExport}
+```
+public static final int NoExport
+```
+
+

--- a/korean/java/com.aspose.note/resourcesavingargs/_index.md
+++ b/korean/java/com.aspose.note/resourcesavingargs/_index.md
@@ -1,0 +1,117 @@
+---
+title: "ResourceSavingArgs"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "ResourceSaving 이벤트에 대한 데이터를 제공합니다."
+type: docs
+weight: 80
+url: /ko/java/com.aspose.note/resourcesavingargs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ResourceSavingArgs
+```
+
+ResourceSaving 이벤트에 대한 데이터를 제공합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getDocument()](#getDocument--) | 저장 문서를 가져옵니다. |
+| [getFileName()](#getFileName--) | 파일 이름을 가져옵니다. |
+| [getKeepStreamOpen()](#getKeepStreamOpen--) | 스트림을 열어 둔 상태로 유지할지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [getStream()](#getStream--) | 리소스를 저장하는 데 사용되는 스트림을 가져오거나 설정합니다. |
+| [getUri()](#getUri--) | 저장된 리소스에 접근하기 위한 URI를 가져오거나 설정합니다. |
+| [setKeepStreamOpen(boolean value)](#setKeepStreamOpen-boolean-) | 스트림을 열어 둔 상태로 유지할지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [setStream(OutputStream value)](#setStream-java.io.OutputStream-) | 리소스를 저장하는 데 사용되는 스트림을 가져오거나 설정합니다. |
+| [setUri(String value)](#setUri-java.lang.String-) | 저장된 리소스에 접근하기 위한 URI를 가져오거나 설정합니다. |
+### getDocument() {#getDocument--}
+```
+public final Document getDocument()
+```
+
+
+저장 문서를 가져옵니다.
+
+**Returns:**
+[Document](../../com.aspose.note/document)
+### getFileName() {#getFileName--}
+```
+public final String getFileName()
+```
+
+
+파일 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getKeepStreamOpen() {#getKeepStreamOpen--}
+```
+public final boolean getKeepStreamOpen()
+```
+
+
+스트림을 열어 둔 상태로 유지할지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Returns:**
+boolean
+### getStream() {#getStream--}
+```
+public final OutputStream getStream()
+```
+
+
+리소스를 저장하는 데 사용되는 스트림을 가져오거나 설정합니다.
+
+**Returns:**
+java.io.OutputStream
+### getUri() {#getUri--}
+```
+public final String getUri()
+```
+
+
+저장된 리소스에 접근하기 위한 URI를 가져오거나 설정합니다.
+
+**Returns:**
+java.lang.String
+### setKeepStreamOpen(boolean value) {#setKeepStreamOpen-boolean-}
+```
+public final void setKeepStreamOpen(boolean value)
+```
+
+
+스트림을 열어 둔 상태로 유지할지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setStream(OutputStream value) {#setStream-java.io.OutputStream-}
+```
+public final void setStream(OutputStream value)
+```
+
+
+리소스를 저장하는 데 사용되는 스트림을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.io.OutputStream |  |
+
+### setUri(String value) {#setUri-java.lang.String-}
+```
+public final void setUri(String value)
+```
+
+
+저장된 리소스에 접근하기 위한 URI를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+

--- a/korean/java/com.aspose.note/revisionsummary/_index.md
+++ b/korean/java/com.aspose.note/revisionsummary/_index.md
@@ -1,0 +1,81 @@
+---
+title: "RevisionSummary"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "노드 수정에 대한 요약을 나타냅니다."
+type: docs
+weight: 81
+url: /ko/java/com.aspose.note/revisionsummary/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RevisionSummary
+```
+
+노드 수정에 대한 요약을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [RevisionSummary()](#RevisionSummary--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getAuthorMostRecent()](#getAuthorMostRecent--) | 가장 최근 작성자를 가져오거나 설정합니다. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 마지막 수정 시간을 가져오거나 설정합니다. |
+| [setAuthorMostRecent(String value)](#setAuthorMostRecent-java.lang.String-) | 가장 최근 작성자를 가져오거나 설정합니다. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 마지막 수정 시간을 가져오거나 설정합니다. |
+### RevisionSummary() {#RevisionSummary--}
+```
+public RevisionSummary()
+```
+
+
+### getAuthorMostRecent() {#getAuthorMostRecent--}
+```
+public String getAuthorMostRecent()
+```
+
+
+가장 최근 작성자를 가져오거나 설정합니다.
+
+**Returns:**
+java.lang.String
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+마지막 수정 시간을 가져오거나 설정합니다.
+
+**Returns:**
+java.util.Date
+### setAuthorMostRecent(String value) {#setAuthorMostRecent-java.lang.String-}
+```
+public void setAuthorMostRecent(String value)
+```
+
+
+가장 최근 작성자를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+마지막 수정 시간을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Date |  |
+

--- a/korean/java/com.aspose.note/richtext/_index.md
+++ b/korean/java/com.aspose.note/richtext/_index.md
@@ -1,0 +1,804 @@
+---
+title: "RichText"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "리치 텍스트를 나타냅니다."
+type: docs
+weight: 82
+url: /ko/java/com.aspose.note/richtext/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node)
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode), [com.aspose.note.ITaggable](../../com.aspose.note/itaggable), com.aspose.ms.System.Collections.Generic.IGenericEnumerable
+```
+public class RichText extends Node implements IOutlineElementChildNode, ITaggable, System.Collections.Generic.IGenericEnumerable<Character>
+```
+
+리치 텍스트를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [RichText()](#RichText--) | 새 [RichText](../../com.aspose.note/richtext) 클래스 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | 노드의 방문자를 수락합니다. |
+| [append(String value)](#append-java.lang.String-) | 마지막 텍스트 범위에 문자열을 추가합니다. |
+| [append(String value, TextStyle style)](#append-java.lang.String-com.aspose.note.TextStyle-) | 문자열을 끝에 추가합니다. |
+| [appendFront(String value)](#appendFront-java.lang.String-) | 첫 번째 텍스트 범위의 앞에 문자열을 추가합니다. |
+| [appendFront(String value, TextStyle style)](#appendFront-java.lang.String-com.aspose.note.TextStyle-) | 문자열을 앞에 추가합니다. |
+| [clear()](#clear--) | 이 인스턴스의 내용을 지웁니다. |
+| [getAlignment()](#getAlignment--) | 정렬을 가져옵니다. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 마지막 수정 시간을 가져옵니다. |
+| [getLength()](#getLength--) |  |
+| [getLineSpacing()](#getLineSpacing--) | 줄 간격을 가져옵니다. |
+| [getParagraphStyle()](#getParagraphStyle--) | 단락 스타일을 가져옵니다. |
+| [getSpaceAfter()](#getSpaceAfter--) | 뒤쪽 최소 간격을 가져옵니다. |
+| [getSpaceBefore()](#getSpaceBefore--) | 앞쪽 최소 간격을 가져옵니다. |
+| [getStyles()](#getStyles--) | 스타일을 가져옵니다. |
+| [getTags()](#getTags--) | 단락의 모든 태그 목록을 가져옵니다. |
+| [getText()](#getText--) | 텍스트를 가져옵니다. |
+| [getTextRuns()](#getTextRuns--) |  |
+| [indexOf(char value)](#indexOf-char-) | 이 문자열에서 지정된 유니코드 문자의 첫 번째 발생 위치의 0부터 시작하는 인덱스를 반환합니다. |
+| [indexOf(char value, int startIndex)](#indexOf-char-int-) | 이 문자열에서 지정된 유니코드 문자의 첫 번째 발생 위치의 0부터 시작하는 인덱스를 반환합니다. |
+| [indexOf(char value, int startIndex, int count)](#indexOf-char-int-int-) | 이 인스턴스에서 지정된 문자의 첫 번째 발생 위치의 0부터 시작하는 인덱스를 반환합니다. |
+| [indexOf(String value)](#indexOf-java.lang.String-) | 이 인스턴스에서 지정된 문자열의 첫 번째 발생 위치의 0부터 시작하는 인덱스를 반환합니다. |
+| [indexOf(String value, int startIndex)](#indexOf-java.lang.String-int-) | 이 인스턴스에서 지정된 문자열의 첫 번째 발생 위치의 0부터 시작하는 인덱스를 반환합니다. |
+| [indexOf(String value, int startIndex, int count)](#indexOf-java.lang.String-int-int-) | 이 인스턴스에서 지정된 문자열의 첫 번째 발생 위치의 0부터 시작하는 인덱스를 반환합니다. |
+| [indexOf(String value, int startIndex, int count, short comparisonType)](#indexOf-java.lang.String-int-int-short-) | 현재 인스턴스에서 지정된 문자열의 첫 번째 발생 위치의 0부터 시작하는 인덱스를 반환합니다. |
+| [indexOf(String value, short comparisonType)](#indexOf-java.lang.String-short-) | 현재 인스턴스에서 지정된 문자열의 첫 번째 발생 위치의 0부터 시작하는 인덱스를 반환합니다. |
+| [indexOf_Rename_Namesake(String value, int startIndex, short comparisonType)](#indexOf-Rename-Namesake-java.lang.String-int-short-) | 현재 인스턴스에서 지정된 문자열의 첫 번째 발생 위치의 0부터 시작하는 인덱스를 반환합니다. |
+| [insert(int startIndex, String value)](#insert-int-java.lang.String-) | 이 인스턴스의 지정된 인덱스 위치에 지정된 문자열을 삽입합니다. |
+| [insert(int startIndex, String value, TextStyle style)](#insert-int-java.lang.String-com.aspose.note.TextStyle-) | 이 인스턴스의 지정된 인덱스 위치에 지정된 스타일을 가진 문자열을 삽입합니다. |
+| [iterator()](#iterator--) |  |
+| [remove(int startIndex)](#remove-int-) | 현재 인스턴스에서 지정된 위치부터 마지막 위치까지 모든 문자를 제거합니다. |
+| [remove(int startIndex, int count)](#remove-int-int-) | 현재 인스턴스에서 지정된 위치부터 지정된 수만큼의 문자를 제거합니다. |
+| [replace(char oldChar, char newChar)](#replace-char-char-) | 이 인스턴스에서 지정된 유니코드 문자의 모든 발생을 다른 지정된 유니코드 문자로 교체합니다. |
+| [replace(String oldValue, String newValue)](#replace-java.lang.String-java.lang.String-) | 현재 인스턴스에서 지정된 문자열의 모든 발생을 다른 지정된 문자열로 교체합니다. |
+| [replace(String oldValue, String newValue, TextStyle style)](#replace-java.lang.String-java.lang.String-com.aspose.note.TextStyle-) | 현재 인스턴스에서 지정된 문자열의 모든 발생을 지정된 스타일의 다른 지정된 문자열로 교체합니다. |
+| [setAlignment(int value)](#setAlignment-int-) | 정렬을 설정합니다. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 마지막 수정 시간을 설정합니다. |
+| [setLineSpacing(float value)](#setLineSpacing-float-) |  |
+| [setLineSpacing(Float value)](#setLineSpacing-java.lang.Float-) | 줄 간격을 설정합니다. |
+| [setParagraphStyle(ParagraphStyle value)](#setParagraphStyle-com.aspose.note.ParagraphStyle-) | 단락 스타일을 설정합니다. |
+| [setSpaceAfter(float value)](#setSpaceAfter-float-) |  |
+| [setSpaceAfter(Float value)](#setSpaceAfter-java.lang.Float-) | 뒤쪽 최소 간격을 설정합니다. |
+| [setSpaceBefore(float value)](#setSpaceBefore-float-) |  |
+| [setSpaceBefore(Float value)](#setSpaceBefore-java.lang.Float-) | 앞에 최소 공간 양을 설정합니다. |
+| [setText(String value)](#setText-java.lang.String-) | 텍스트를 설정합니다. |
+| [trim()](#trim--) | 앞뒤의 모든 공백 문자를 제거합니다. |
+| [trim(char trimChar)](#trim-char-) | 문자의 앞뒤 모든 인스턴스를 제거합니다. |
+| [trim(char[] trimChars)](#trim-char...-) | 배열에 지정된 문자 집합의 앞뒤 모든 발생을 제거합니다. |
+| [trimEnd()](#trimEnd--) | 뒤쪽의 모든 공백 문자를 제거합니다. |
+| [trimEnd(char trimChar)](#trimEnd-char-) | 문자의 뒤쪽 모든 발생을 제거합니다. |
+| [trimEnd(char[] trimChars)](#trimEnd-char...-) | 배열에 지정된 문자 집합의 뒤쪽 모든 발생을 제거합니다. |
+| [trimStart()](#trimStart--) | 앞쪽의 모든 공백 문자를 제거합니다. |
+| [trimStart(char trimChar)](#trimStart-char-) | 지정된 문자의 앞쪽 모든 발생을 제거합니다. |
+| [trimStart(char[] trimChars)](#trimStart-char...-) | 배열에 지정된 문자 집합의 앞쪽 모든 발생을 제거합니다. |
+### RichText() {#RichText--}
+```
+public RichText()
+```
+
+
+새 [RichText](../../com.aspose.note/richtext) 클래스 인스턴스를 초기화합니다.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+노드의 방문자를 수락합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | 다음으로부터 파생된 클래스인 [DocumentVisitor](../../com.aspose.note/documentvisitor)의 객체. |
+
+### append(String value) {#append-java.lang.String-}
+```
+public RichText append(String value)
+```
+
+
+마지막 텍스트 범위에 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 추가된 값입니다. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### append(String value, TextStyle style) {#append-java.lang.String-com.aspose.note.TextStyle-}
+```
+public final RichText append(String value, TextStyle style)
+```
+
+
+문자열을 끝에 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 추가된 값입니다. |
+| style | [TextStyle](../../com.aspose.note/textstyle) | 추가된 문자열의 스타일입니다. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### appendFront(String value) {#appendFront-java.lang.String-}
+```
+public RichText appendFront(String value)
+```
+
+
+첫 번째 텍스트 범위의 앞에 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 추가된 값입니다. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### appendFront(String value, TextStyle style) {#appendFront-java.lang.String-com.aspose.note.TextStyle-}
+```
+public RichText appendFront(String value, TextStyle style)
+```
+
+
+문자열을 앞에 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 추가된 값입니다. |
+| style | [TextStyle](../../com.aspose.note/textstyle) | 추가된 문자열의 스타일입니다. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### clear() {#clear--}
+```
+public final RichText clear()
+```
+
+
+이 인스턴스의 내용을 지웁니다.
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+정렬을 가져옵니다.
+
+**Returns:**
+int
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+마지막 수정 시간을 가져옵니다.
+
+**Returns:**
+java.util.Date
+### getLength() {#getLength--}
+```
+public final int getLength()
+```
+
+
+
+
+**Returns:**
+int
+### getLineSpacing() {#getLineSpacing--}
+```
+public Float getLineSpacing()
+```
+
+
+줄 간격을 가져옵니다.
+
+**Returns:**
+java.lang.Float
+### getParagraphStyle() {#getParagraphStyle--}
+```
+public final ParagraphStyle getParagraphStyle()
+```
+
+
+단락 스타일을 가져옵니다. 이 설정은 [getStyles](../../com.aspose.note/richtext\#getStyles) 컬렉션에 일치하는 TextStyle 객체가 없거나 이 객체가 필요한 설정을 지정하지 않은 경우에 사용됩니다.
+
+**Returns:**
+[ParagraphStyle](../../com.aspose.note/paragraphstyle)
+### getSpaceAfter() {#getSpaceAfter--}
+```
+public Float getSpaceAfter()
+```
+
+
+뒤쪽 최소 간격을 가져옵니다.
+
+**Returns:**
+java.lang.Float
+### getSpaceBefore() {#getSpaceBefore--}
+```
+public Float getSpaceBefore()
+```
+
+
+앞쪽 최소 간격을 가져옵니다.
+
+**Returns:**
+java.lang.Float
+### getStyles() {#getStyles--}
+```
+public System.Collections.Generic.IGenericEnumerable<TextStyle> getStyles()
+```
+
+
+스타일을 가져옵니다.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerable&lt;com.aspose.note.TextStyle&gt;
+### getTags() {#getTags--}
+```
+public final System.Collections.Generic.List<ITag> getTags()
+```
+
+
+단락의 모든 태그 목록을 가져옵니다.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List&lt;com.aspose.note.ITag&gt;
+### getText() {#getText--}
+```
+public final String getText()
+```
+
+
+텍스트를 가져옵니다. 문자열에는 값 10(줄 바꿈) 문자가 포함되어서는 안 됩니다.
+
+**Returns:**
+java.lang.String
+### getTextRuns() {#getTextRuns--}
+```
+public final System.Collections.Generic.IGenericEnumerable<TextRun> getTextRuns()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerable&lt;com.aspose.note.TextRun&gt;
+### indexOf(char value) {#indexOf-char-}
+```
+public final int indexOf(char value)
+```
+
+
+이 문자열에서 지정된 유니코드 문자의 첫 번째 발생 위치의 0부터 시작하는 인덱스를 반환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | char | 값입니다. |
+
+**Returns:**
+int - `int`입니다.
+### indexOf(char value, int startIndex) {#indexOf-char-int-}
+```
+public final int indexOf(char value, int startIndex)
+```
+
+
+이 문자열에서 지정된 유니코드 문자의 첫 번째 발생 위치를 0부터 시작하는 인덱스로 반환합니다. 검색은 지정된 문자 위치에서 시작합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | char | 값입니다. |
+| startIndex | int | 시작 검색 위치 |
+
+**Returns:**
+int - `int`입니다.
+### indexOf(char value, int startIndex, int count) {#indexOf-char-int-int-}
+```
+public final int indexOf(char value, int startIndex, int count)
+```
+
+
+이 인스턴스에서 지정된 문자의 첫 번째 발생 위치를 0부터 시작하는 인덱스로 반환합니다. 검색은 지정된 문자 위치에서 시작하며 지정된 문자 수만큼 검사합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | char | 값입니다. |
+| startIndex | int | 시작 검색 위치 |
+| count | int | 카운트입니다. |
+
+**Returns:**
+int - `int`입니다.
+### indexOf(String value) {#indexOf-java.lang.String-}
+```
+public final int indexOf(String value)
+```
+
+
+이 인스턴스에서 지정된 문자열의 첫 번째 발생 위치의 0부터 시작하는 인덱스를 반환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 값입니다. |
+
+**Returns:**
+int - `int`입니다.
+### indexOf(String value, int startIndex) {#indexOf-java.lang.String-int-}
+```
+public final int indexOf(String value, int startIndex)
+```
+
+
+이 인스턴스에서 지정된 문자열이 처음 나타나는 위치의 0부터 시작하는 인덱스를 반환합니다. 검색은 지정된 문자 위치에서 시작합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 값입니다. |
+| startIndex | int | 시작 검색 위치 |
+
+**Returns:**
+int - `int`입니다.
+### indexOf(String value, int startIndex, int count) {#indexOf-java.lang.String-int-int-}
+```
+public final int indexOf(String value, int startIndex, int count)
+```
+
+
+이 인스턴스에서 지정된 문자열이 처음 나타나는 위치의 0부터 시작하는 인덱스를 반환합니다. 검색은 지정된 문자 위치에서 시작하고 지정된 문자 수만큼 검사합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 값입니다. |
+| startIndex | int | 시작 검색 위치 |
+| count | int | 카운트입니다. |
+
+**Returns:**
+int - `int`입니다.
+### indexOf(String value, int startIndex, int count, short comparisonType) {#indexOf-java.lang.String-int-int-short-}
+```
+public final int indexOf(String value, int startIndex, int count, short comparisonType)
+```
+
+
+현재 인스턴스에서 지정된 문자열의 첫 번째 발생 위치의 0부터 시작하는 인덱스를 반환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 값입니다. |
+| startIndex | int | 시작 검색 위치 |
+| count | int | 카운트입니다. |
+| comparisonType | short | 지정된 문자열에 사용할 검색 유형 |
+
+**Returns:**
+int - `int`입니다.
+### indexOf(String value, short comparisonType) {#indexOf-java.lang.String-short-}
+```
+public final int indexOf(String value, short comparisonType)
+```
+
+
+현재 인스턴스에서 지정된 문자열이 처음 나타나는 위치의 0부터 시작하는 인덱스를 반환합니다. 매개변수는 지정된 문자열에 사용할 검색 유형을 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 값입니다. |
+| comparisonType | short | 지정된 문자열에 사용할 검색 유형 |
+
+**Returns:**
+int - `int`입니다.
+### indexOf_Rename_Namesake(String value, int startIndex, short comparisonType) {#indexOf-Rename-Namesake-java.lang.String-int-short-}
+```
+public final int indexOf_Rename_Namesake(String value, int startIndex, short comparisonType)
+```
+
+
+현재 인스턴스에서 지정된 문자열이 처음 나타나는 위치의 0부터 시작하는 인덱스를 반환합니다. 매개변수는 현재 문자열에서 검색 시작 위치와 지정된 문자열에 사용할 검색 유형을 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 값입니다. |
+| startIndex | int | 시작 검색 위치 |
+| comparisonType | short | 지정된 문자열에 사용할 검색 유형 |
+
+**Returns:**
+int - `int`입니다.
+### insert(int startIndex, String value) {#insert-int-java.lang.String-}
+```
+public final RichText insert(int startIndex, String value)
+```
+
+
+이 인스턴스의 지정된 인덱스 위치에 지정된 문자열을 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| startIndex | int | 시작 인덱스. |
+| 값 | java.lang.String | 값입니다. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### insert(int startIndex, String value, TextStyle style) {#insert-int-java.lang.String-com.aspose.note.TextStyle-}
+```
+public final RichText insert(int startIndex, String value, TextStyle style)
+```
+
+
+이 인스턴스의 지정된 인덱스 위치에 지정된 스타일을 가진 문자열을 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| startIndex | int | 시작 인덱스. |
+| 값 | java.lang.String | 값입니다. |
+| style | [TextStyle](../../com.aspose.note/textstyle) | 스타일. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### iterator() {#iterator--}
+```
+public System.Collections.Generic.IGenericEnumerator<Character> iterator()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;java.lang.Character&gt;
+### remove(int startIndex) {#remove-int-}
+```
+public final RichText remove(int startIndex)
+```
+
+
+현재 인스턴스에서 지정된 위치부터 마지막 위치까지 모든 문자를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| startIndex | int | 시작 인덱스. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### remove(int startIndex, int count) {#remove-int-int-}
+```
+public final RichText remove(int startIndex, int count)
+```
+
+
+현재 인스턴스에서 지정된 위치부터 지정된 수만큼의 문자를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| startIndex | int | 시작 인덱스. |
+| count | int | 카운트입니다. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### replace(char oldChar, char newChar) {#replace-char-char-}
+```
+public final RichText replace(char oldChar, char newChar)
+```
+
+
+이 인스턴스에서 지정된 유니코드 문자의 모든 발생을 다른 지정된 유니코드 문자로 교체합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| oldChar | char | 이전 문자. |
+| newChar | char | 새 문자. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### replace(String oldValue, String newValue) {#replace-java.lang.String-java.lang.String-}
+```
+public final RichText replace(String oldValue, String newValue)
+```
+
+
+현재 인스턴스에서 지정된 문자열의 모든 발생을 다른 지정된 문자열로 교체합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| oldValue | java.lang.String | 이전 값. |
+| newValue | java.lang.String | 새 값. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### replace(String oldValue, String newValue, TextStyle style) {#replace-java.lang.String-java.lang.String-com.aspose.note.TextStyle-}
+```
+public final RichText replace(String oldValue, String newValue, TextStyle style)
+```
+
+
+현재 인스턴스에서 지정된 문자열의 모든 발생을 지정된 스타일의 다른 지정된 문자열로 교체합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| oldValue | java.lang.String | 이전 값. |
+| newValue | java.lang.String | 새 값. |
+| style | [TextStyle](../../com.aspose.note/textstyle) | 새 값의 스타일. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+정렬을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+마지막 수정 시간을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Date |  |
+
+### setLineSpacing(float value) {#setLineSpacing-float-}
+```
+public void setLineSpacing(float value)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setLineSpacing(Float value) {#setLineSpacing-java.lang.Float-}
+```
+public void setLineSpacing(Float value)
+```
+
+
+줄 간격을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Float |  |
+
+### setParagraphStyle(ParagraphStyle value) {#setParagraphStyle-com.aspose.note.ParagraphStyle-}
+```
+public final void setParagraphStyle(ParagraphStyle value)
+```
+
+
+단락 스타일을 설정합니다. 이 설정은 [getStyles](../../com.aspose.note/richtext\#getStyles) 컬렉션에 일치하는 TextStyle 객체가 없거나, 해당 객체가 필요한 설정을 지정하지 않은 경우에 사용됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [ParagraphStyle](../../com.aspose.note/paragraphstyle) |  |
+
+### setSpaceAfter(float value) {#setSpaceAfter-float-}
+```
+public void setSpaceAfter(float value)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setSpaceAfter(Float value) {#setSpaceAfter-java.lang.Float-}
+```
+public void setSpaceAfter(Float value)
+```
+
+
+뒤쪽 최소 간격을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Float |  |
+
+### setSpaceBefore(float value) {#setSpaceBefore-float-}
+```
+public void setSpaceBefore(float value)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setSpaceBefore(Float value) {#setSpaceBefore-java.lang.Float-}
+```
+public void setSpaceBefore(Float value)
+```
+
+
+앞에 최소 공간 양을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Float |  |
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public final void setText(String value)
+```
+
+
+텍스트를 설정합니다. 문자열에는 값 10(줄 바꿈) 문자가 포함되어서는 안 됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### trim() {#trim--}
+```
+public final RichText trim()
+```
+
+
+앞뒤의 모든 공백 문자를 제거합니다.
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trim(char trimChar) {#trim-char-}
+```
+public final RichText trim(char trimChar)
+```
+
+
+문자의 앞뒤 모든 인스턴스를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| trimChar | char | 잘라낼 문자. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trim(char[] trimChars) {#trim-char...-}
+```
+public final RichText trim(char[] trimChars)
+```
+
+
+배열에 지정된 문자 집합의 앞뒤 모든 발생을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| trimChars | char[] | 잘라내기 문자. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trimEnd() {#trimEnd--}
+```
+public final RichText trimEnd()
+```
+
+
+뒤쪽의 모든 공백 문자를 제거합니다.
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trimEnd(char trimChar) {#trimEnd-char-}
+```
+public final RichText trimEnd(char trimChar)
+```
+
+
+문자의 뒤쪽 모든 발생을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| trimChar | char | 잘라낼 문자. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trimEnd(char[] trimChars) {#trimEnd-char...-}
+```
+public final RichText trimEnd(char[] trimChars)
+```
+
+
+배열에 지정된 문자 집합의 뒤쪽 모든 발생을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| trimChars | char[] | 잘라내기 문자. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trimStart() {#trimStart--}
+```
+public final RichText trimStart()
+```
+
+
+앞쪽의 모든 공백 문자를 제거합니다.
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trimStart(char trimChar) {#trimStart-char-}
+```
+public final RichText trimStart(char trimChar)
+```
+
+
+지정된 문자의 앞쪽 모든 발생을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| trimChar | char | 잘라낼 문자. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trimStart(char[] trimChars) {#trimStart-char...-}
+```
+public final RichText trimStart(char[] trimChars)
+```
+
+
+배열에 지정된 문자 집합의 앞쪽 모든 발생을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| trimChars | char[] | 잘라내기 문자. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).

--- a/korean/java/com.aspose.note/saveformat/_index.md
+++ b/korean/java/com.aspose.note/saveformat/_index.md
@@ -1,0 +1,92 @@
+---
+title: "SaveFormat"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "문서가 저장되는 형식을 나타냅니다."
+type: docs
+weight: 83
+url: /ko/java/com.aspose.note/saveformat/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class SaveFormat extends System.Enum
+```
+
+문서가 저장되는 형식을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Bmp](#Bmp) | 출력이 BMP 파일임을 지정합니다. |
+| [Gif](#Gif) | 출력이 GIF 파일임을 지정합니다. |
+| [Html](#Html) | 출력이 HTML 파일임을 지정합니다. |
+| [Jpeg](#Jpeg) | 출력이 JPEG 파일임을 지정합니다. |
+| [One](#One) | 출력이 OneNote 파일임을 지정합니다. |
+| [Pdf](#Pdf) | 출력이 PDF 파일임을 지정합니다. |
+| [Png](#Png) | 출력이 PNG 파일임을 지정합니다. |
+| [Tiff](#Tiff) | 출력 파일이 TIFF 파일임을 지정합니다. |
+### Bmp {#Bmp}
+```
+public static final int Bmp
+```
+
+
+출력이 BMP 파일임을 지정합니다.
+
+### Gif {#Gif}
+```
+public static final int Gif
+```
+
+
+출력이 GIF 파일임을 지정합니다.
+
+### Html {#Html}
+```
+public static final int Html
+```
+
+
+출력이 HTML 파일임을 지정합니다.
+
+### Jpeg {#Jpeg}
+```
+public static final int Jpeg
+```
+
+
+출력이 JPEG 파일임을 지정합니다.
+
+### One {#One}
+```
+public static final int One
+```
+
+
+출력이 OneNote 파일임을 지정합니다.
+
+### Pdf {#Pdf}
+```
+public static final int Pdf
+```
+
+
+출력이 PDF 파일임을 지정합니다.
+
+### Png {#Png}
+```
+public static final int Png
+```
+
+
+출력이 PNG 파일임을 지정합니다.
+
+### Tiff {#Tiff}
+```
+public static final int Tiff
+```
+
+
+출력 파일이 TIFF 파일임을 지정합니다.
+

--- a/korean/java/com.aspose.note/saveformatconverter/_index.md
+++ b/korean/java/com.aspose.note/saveformatconverter/_index.md
@@ -1,0 +1,79 @@
+---
+title: "SaveFormatConverter"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "저장 형식 변환기입니다."
+type: docs
+weight: 84
+url: /ko/java/com.aspose.note/saveformatconverter/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SaveFormatConverter
+```
+
+저장 형식 변환기입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [SaveFormatConverter()](#SaveFormatConverter--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [convert(String value)](#convert-java.lang.String-) | 변환입니다. |
+| [deduceDocumentFileExtension(int format)](#deduceDocumentFileExtension-int-) |  |
+| [deduceNotebookFileExtension(int format)](#deduceNotebookFileExtension-int-) |  |
+### SaveFormatConverter() {#SaveFormatConverter--}
+```
+public SaveFormatConverter()
+```
+
+
+### convert(String value) {#convert-java.lang.String-}
+```
+public static int convert(String value)
+```
+
+
+변환입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 값입니다. |
+
+**Returns:**
+int - `SaveFormat`입니다.
+### deduceDocumentFileExtension(int format) {#deduceDocumentFileExtension-int-}
+```
+public static String deduceDocumentFileExtension(int format)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| format | int |  |
+
+**Returns:**
+java.lang.String
+### deduceNotebookFileExtension(int format) {#deduceNotebookFileExtension-int-}
+```
+public static String deduceNotebookFileExtension(int format)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| format | int |  |
+
+**Returns:**
+java.lang.String

--- a/korean/java/com.aspose.note/saveoptions/_index.md
+++ b/korean/java/com.aspose.note/saveoptions/_index.md
@@ -1,0 +1,106 @@
+---
+title: "SaveOptions"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "특정 형식에 대한 문서 저장 옵션을 나타내는 추상 기본 클래스입니다."
+type: docs
+weight: 85
+url: /ko/java/com.aspose.note/saveoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class SaveOptions
+```
+
+특정 형식에 대한 문서 저장 옵션을 나타내는 추상 기본 클래스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getFontsSubsystem()](#getFontsSubsystem--) | 저장 시 사용할 글꼴 설정을 가져오거나 설정합니다. |
+| [getPageCount()](#getPageCount--) | 저장할 페이지 수를 가져오거나 설정합니다. |
+| [getPageIndex()](#getPageIndex--) | 저장할 첫 번째 페이지의 인덱스를 가져오거나 설정합니다. |
+| [getSaveFormat()](#getSaveFormat--) | 문서가 저장되는 형식을 가져오거나 설정합니다. |
+| [setFontsSubsystem(FontsSubsystem value)](#setFontsSubsystem-com.aspose.note.fonts.FontsSubsystem-) | 저장 시 사용할 글꼴 설정을 가져오거나 설정합니다. |
+| [setPageCount(int value)](#setPageCount-int-) | 저장할 페이지 수를 가져오거나 설정합니다. |
+| [setPageIndex(int value)](#setPageIndex-int-) | 저장할 첫 번째 페이지의 인덱스를 가져오거나 설정합니다. |
+### getFontsSubsystem() {#getFontsSubsystem--}
+```
+public final FontsSubsystem getFontsSubsystem()
+```
+
+
+저장 시 사용할 글꼴 설정을 가져오거나 설정합니다.
+
+**Returns:**
+[FontsSubsystem](../../com.aspose.note.fonts/fontssubsystem)
+### getPageCount() {#getPageCount--}
+```
+public final int getPageCount()
+```
+
+
+저장할 페이지 수를 가져오거나 설정합니다. 기본값은 \{@link int\#Int32Extensions.MaxValue\}이며, 이는 문서의 모든 페이지가 렌더링됨을 의미합니다.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public final int getPageIndex()
+```
+
+
+저장할 첫 번째 페이지의 인덱스를 가져오거나 설정합니다. 기본값은 0입니다.
+
+**Returns:**
+int
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+문서가 저장되는 형식을 가져오거나 설정합니다.
+
+**Returns:**
+int
+### setFontsSubsystem(FontsSubsystem value) {#setFontsSubsystem-com.aspose.note.fonts.FontsSubsystem-}
+```
+public final void setFontsSubsystem(FontsSubsystem value)
+```
+
+
+저장 시 사용할 글꼴 설정을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [FontsSubsystem](../../com.aspose.note.fonts/fontssubsystem) |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public final void setPageCount(int value)
+```
+
+
+저장할 페이지 수를 가져오거나 설정합니다. 기본값은 \{@link int\#Int32Extensions.MaxValue\}이며, 이는 문서의 모든 페이지가 렌더링됨을 의미합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public final void setPageIndex(int value)
+```
+
+
+저장할 첫 번째 페이지의 인덱스를 가져오거나 설정합니다. 기본값은 0입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+

--- a/korean/java/com.aspose.note/style/_index.md
+++ b/korean/java/com.aspose.note/style/_index.md
@@ -1,0 +1,325 @@
+---
+title: "Style"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "이 클래스는  및  클래스의 공통 속성을 포함합니다."
+type: docs
+weight: 86
+url: /ko/java/com.aspose.note/style/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Style<T>
+```
+
+이 클래스는 [ParagraphStyle](../../com.aspose.note/paragraphstyle) 및 [TextStyle](../../com.aspose.note/textstyle) 클래스의 공통 속성을 포함합니다.
+
+T :
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Style()](#Style--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getFontColor()](#getFontColor--) | 글꼴 색상을 가져오거나 설정합니다. |
+| [getFontName()](#getFontName--) | 글꼴 이름을 가져오거나 설정합니다. |
+| [getFontSize()](#getFontSize--) | 글꼴 크기를 가져오거나 설정합니다. |
+| [getFontStyle()](#getFontStyle--) | 글꼴 스타일을 가져옵니다. |
+| [getHighlight()](#getHighlight--) | 하이라이트 색상을 가져오거나 설정합니다. |
+| [hashCode()](#hashCode--) | 해당 유형에 대한 해시 함수로 사용됩니다. |
+| [isBold()](#isBold--) | 텍스트 스타일이 굵게인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [isItalic()](#isItalic--) | 텍스트 스타일이 이탤릭인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [isStrikethrough()](#isStrikethrough--) | 텍스트 스타일이 취소선인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [isSubscript()](#isSubscript--) | 텍스트 스타일이 아래 첨자인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [isSuperscript()](#isSuperscript--) | 텍스트 스타일이 위 첨자인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [isUnderline()](#isUnderline--) | 텍스트 스타일이 밑줄인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [setBold(boolean value)](#setBold-boolean-) | 텍스트 스타일이 굵게인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [setFontColor(Color value)](#setFontColor-java.awt.Color-) | 글꼴 색상을 가져오거나 설정합니다. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | 글꼴 이름을 가져오거나 설정합니다. |
+| [setFontSize(Integer value)](#setFontSize-java.lang.Integer-) | 글꼴 크기를 가져오거나 설정합니다. |
+| [setHighlight(Color value)](#setHighlight-java.awt.Color-) | 하이라이트 색상을 가져오거나 설정합니다. |
+| [setItalic(boolean value)](#setItalic-boolean-) | 텍스트 스타일이 이탤릭인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [setStrikethrough(boolean value)](#setStrikethrough-boolean-) | 텍스트 스타일이 취소선인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [setSubscript(boolean value)](#setSubscript-boolean-) | 텍스트 스타일이 아래 첨자인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [setSuperscript(boolean value)](#setSuperscript-boolean-) | 텍스트 스타일이 위 첨자인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [setUnderline(boolean value)](#setUnderline-boolean-) | 텍스트 스타일이 밑줄인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+### Style() {#Style--}
+```
+public Style()
+```
+
+
+### getFontColor() {#getFontColor--}
+```
+public final Color getFontColor()
+```
+
+
+글꼴 색상을 가져오거나 설정합니다.
+
+**Returns:**
+java.awt.Color
+### getFontName() {#getFontName--}
+```
+public final String getFontName()
+```
+
+
+글꼴 이름을 가져오거나 설정합니다.
+
+**Returns:**
+java.lang.String
+### getFontSize() {#getFontSize--}
+```
+public final Integer getFontSize()
+```
+
+
+글꼴 크기를 가져오거나 설정합니다.
+
+**Returns:**
+java.lang.Integer
+### getFontStyle() {#getFontStyle--}
+```
+public final int getFontStyle()
+```
+
+
+글꼴 스타일을 가져옵니다.
+
+**Returns:**
+int
+### getHighlight() {#getHighlight--}
+```
+public final Color getHighlight()
+```
+
+
+하이라이트 색상을 가져오거나 설정합니다.
+
+**Returns:**
+java.awt.Color
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+해당 유형에 대한 해시 함수로 사용됩니다.
+
+**Returns:**
+int - `int`입니다.
+### isBold() {#isBold--}
+```
+public final boolean isBold()
+```
+
+
+텍스트 스타일이 굵게인지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Returns:**
+boolean
+### isItalic() {#isItalic--}
+```
+public final boolean isItalic()
+```
+
+
+텍스트 스타일이 이탤릭인지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Returns:**
+boolean
+### isStrikethrough() {#isStrikethrough--}
+```
+public final boolean isStrikethrough()
+```
+
+
+텍스트 스타일이 취소선인지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Returns:**
+boolean
+### isSubscript() {#isSubscript--}
+```
+public final boolean isSubscript()
+```
+
+
+텍스트 스타일이 아래 첨자인지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Returns:**
+boolean
+### isSuperscript() {#isSuperscript--}
+```
+public final boolean isSuperscript()
+```
+
+
+텍스트 스타일이 위 첨자인지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Returns:**
+boolean
+### isUnderline() {#isUnderline--}
+```
+public final boolean isUnderline()
+```
+
+
+텍스트 스타일이 밑줄인지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Returns:**
+boolean
+### setBold(boolean value) {#setBold-boolean-}
+```
+public final T setBold(boolean value)
+```
+
+
+텍스트 스타일이 굵게인지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+**Returns:**
+T
+### setFontColor(Color value) {#setFontColor-java.awt.Color-}
+```
+public final T setFontColor(Color value)
+```
+
+
+글꼴 색상을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.Color |  |
+
+**Returns:**
+T
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public final T setFontName(String value)
+```
+
+
+글꼴 이름을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+**Returns:**
+T
+### setFontSize(Integer value) {#setFontSize-java.lang.Integer-}
+```
+public final T setFontSize(Integer value)
+```
+
+
+글꼴 크기를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Integer |  |
+
+**Returns:**
+T
+### setHighlight(Color value) {#setHighlight-java.awt.Color-}
+```
+public final T setHighlight(Color value)
+```
+
+
+하이라이트 색상을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.Color |  |
+
+**Returns:**
+T
+### setItalic(boolean value) {#setItalic-boolean-}
+```
+public final T setItalic(boolean value)
+```
+
+
+텍스트 스타일이 이탤릭인지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+**Returns:**
+T
+### setStrikethrough(boolean value) {#setStrikethrough-boolean-}
+```
+public final T setStrikethrough(boolean value)
+```
+
+
+텍스트 스타일이 취소선인지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+**Returns:**
+T
+### setSubscript(boolean value) {#setSubscript-boolean-}
+```
+public final T setSubscript(boolean value)
+```
+
+
+텍스트 스타일이 아래 첨자인지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+**Returns:**
+T
+### setSuperscript(boolean value) {#setSuperscript-boolean-}
+```
+public final T setSuperscript(boolean value)
+```
+
+
+텍스트 스타일이 위 첨자인지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+**Returns:**
+T
+### setUnderline(boolean value) {#setUnderline-boolean-}
+```
+public final T setUnderline(boolean value)
+```
+
+
+텍스트 스타일이 밑줄인지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+**Returns:**
+T

--- a/korean/java/com.aspose.note/table/_index.md
+++ b/korean/java/com.aspose.note/table/_index.md
@@ -1,0 +1,122 @@
+---
+title: "Table"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "표를 나타냅니다."
+type: docs
+weight: 87
+url: /ko/java/com.aspose.note/table/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode), [com.aspose.note.ITaggable](../../com.aspose.note/itaggable)
+```
+public final class Table extends CompositeNode<TableRow> implements IOutlineElementChildNode, ITaggable
+```
+
+표를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Table()](#Table--) | `Table` 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | 노드의 방문자를 수락합니다. |
+| [getColumns()](#getColumns--) | 테이블의 열을 가져옵니다. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 마지막 수정 시간을 가져오거나 설정합니다. |
+| [getTags()](#getTags--) | 테이블의 모든 태그 목록을 가져옵니다. |
+| [isBordersVisible()](#isBordersVisible--) | 테이블 테두리가 표시되는지 여부를 나타내는 값을 가져옵니다. |
+| [setBordersVisible(boolean value)](#setBordersVisible-boolean-) | 테이블 테두리가 표시되는지 여부를 나타내는 값을 설정합니다. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 마지막 수정 시간을 가져오거나 설정합니다. |
+### Table() {#Table--}
+```
+public Table()
+```
+
+
+`Table` 클래스의 새 인스턴스를 초기화합니다.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+노드의 방문자를 수락합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor`에서 파생된 클래스의 객체. |
+
+### getColumns() {#getColumns--}
+```
+public System.Collections.Generic.IGenericList<TableColumn> getColumns()
+```
+
+
+테이블의 열을 가져옵니다.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericList&lt;com.aspose.note.TableColumn&gt;
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+마지막 수정 시간을 가져오거나 설정합니다.
+
+**Returns:**
+java.util.Date
+### getTags() {#getTags--}
+```
+public final System.Collections.Generic.List<ITag> getTags()
+```
+
+
+테이블의 모든 태그 목록을 가져옵니다.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List&lt;com.aspose.note.ITag&gt;
+### isBordersVisible() {#isBordersVisible--}
+```
+public boolean isBordersVisible()
+```
+
+
+테이블 테두리가 표시되는지 여부를 나타내는 값을 가져옵니다.
+
+**Returns:**
+boolean
+### setBordersVisible(boolean value) {#setBordersVisible-boolean-}
+```
+public void setBordersVisible(boolean value)
+```
+
+
+테이블 테두리가 표시되는지 여부를 나타내는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+마지막 수정 시간을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Date |  |
+

--- a/korean/java/com.aspose.note/tablecell/_index.md
+++ b/korean/java/com.aspose.note/tablecell/_index.md
@@ -1,0 +1,119 @@
+---
+title: "TableCell"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "표 셀을 나타냅니다."
+type: docs
+weight: 88
+url: /ko/java/com.aspose.note/tablecell/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode, com.aspose.note.IndentatedNode
+```
+public final class TableCell extends IndentatedNode<IOutlineChildNode,TableCell>
+```
+
+표 셀을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [TableCell()](#TableCell--) | `TableCell` 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | 노드의 방문자를 수락합니다. |
+| [getBackgroundColor()](#getBackgroundColor--) | 배경 색상을 가져옵니다. |
+| [getInternalIndentPosition()](#getInternalIndentPosition--) |  |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 마지막 수정 시간을 가져오거나 설정합니다. |
+| [getMaxWidth()](#getMaxWidth--) | 최대 너비를 가져옵니다. |
+| [setBackgroundColor(Color value)](#setBackgroundColor-java.awt.Color-) | 배경 색상을 설정합니다. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 마지막 수정 시간을 가져오거나 설정합니다. |
+### TableCell() {#TableCell--}
+```
+public TableCell()
+```
+
+
+`TableCell` 클래스의 새 인스턴스를 초기화합니다.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+노드의 방문자를 수락합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor`에서 파생된 클래스의 객체. |
+
+### getBackgroundColor() {#getBackgroundColor--}
+```
+public Color getBackgroundColor()
+```
+
+
+배경 색상을 가져옵니다.
+
+**Returns:**
+java.awt.Color
+### getInternalIndentPosition() {#getInternalIndentPosition--}
+```
+public int getInternalIndentPosition()
+```
+
+
+들여쓰기 크기를 얻기 위해 RgOutlineIndentDistance 배열에서 합산할 항목 수를 가져옵니다.
+
+**Returns:**
+int
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+마지막 수정 시간을 가져오거나 설정합니다.
+
+**Returns:**
+java.util.Date
+### getMaxWidth() {#getMaxWidth--}
+```
+public float getMaxWidth()
+```
+
+
+최대 너비를 가져옵니다.
+
+**Returns:**
+float
+### setBackgroundColor(Color value) {#setBackgroundColor-java.awt.Color-}
+```
+public void setBackgroundColor(Color value)
+```
+
+
+배경 색상을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.Color |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+마지막 수정 시간을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Date |  |
+

--- a/korean/java/com.aspose.note/tablecolumn/_index.md
+++ b/korean/java/com.aspose.note/tablecolumn/_index.md
@@ -1,0 +1,81 @@
+---
+title: "TableColumn"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "표 열을 나타냅니다."
+type: docs
+weight: 89
+url: /ko/java/com.aspose.note/tablecolumn/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TableColumn
+```
+
+표 열을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [TableColumn()](#TableColumn--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getLockedWidth()](#getLockedWidth--) | 테이블 열이 고정된 너비를 가지고 있으며 테이블 내용에 맞게 자동으로 크기가 조정되지 않는지를 나타내는 값을 가져옵니다. |
+| [getWidth()](#getWidth--) | 너비를 가져옵니다. |
+| [setLockedWidth(boolean value)](#setLockedWidth-boolean-) | 테이블 열이 고정된 너비를 가지고 있으며 테이블 내용에 맞게 자동으로 크기가 조정되지 않는지를 나타내는 값을 설정합니다. |
+| [setWidth(float value)](#setWidth-float-) | 너비를 설정합니다. |
+### TableColumn() {#TableColumn--}
+```
+public TableColumn()
+```
+
+
+### getLockedWidth() {#getLockedWidth--}
+```
+public boolean getLockedWidth()
+```
+
+
+테이블 열이 고정된 너비를 가지고 있으며 테이블 내용에 맞게 자동으로 크기가 조정되지 않는지를 나타내는 값을 가져옵니다. 기본적으로 열 너비는 고정되지 않습니다.
+
+**Returns:**
+boolean
+### getWidth() {#getWidth--}
+```
+public float getWidth()
+```
+
+
+너비를 가져옵니다.
+
+**Returns:**
+float
+### setLockedWidth(boolean value) {#setLockedWidth-boolean-}
+```
+public void setLockedWidth(boolean value)
+```
+
+
+테이블 열이 고정된 너비를 가지고 있으며 테이블 내용에 맞게 자동으로 크기가 조정되지 않는지를 나타내는 값을 설정합니다. 기본적으로 열 너비는 고정되지 않습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setWidth(float value) {#setWidth-float-}
+```
+public void setWidth(float value)
+```
+
+
+너비를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+

--- a/korean/java/com.aspose.note/tablerow/_index.md
+++ b/korean/java/com.aspose.note/tablerow/_index.md
@@ -1,0 +1,72 @@
+---
+title: "TableRow"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "표 행을 나타냅니다."
+type: docs
+weight: 90
+url: /ko/java/com.aspose.note/tablerow/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode
+```
+public final class TableRow extends CompositeNode<TableCell>
+```
+
+표 행을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [TableRow()](#TableRow--) | `TableRow` 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | 노드의 방문자를 수락합니다. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 마지막 수정 시간을 가져오거나 설정합니다. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 마지막 수정 시간을 가져오거나 설정합니다. |
+### TableRow() {#TableRow--}
+```
+public TableRow()
+```
+
+
+`TableRow` 클래스의 새 인스턴스를 초기화합니다.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+노드의 방문자를 수락합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor`에서 파생된 클래스의 객체. |
+
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+마지막 수정 시간을 가져오거나 설정합니다.
+
+**Returns:**
+java.util.Date
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+마지막 수정 시간을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Date |  |
+

--- a/korean/java/com.aspose.note/tagstatus/_index.md
+++ b/korean/java/com.aspose.note/tagstatus/_index.md
@@ -1,0 +1,47 @@
+---
+title: "TagStatus"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "노트 태그 노드의 상태를 지정합니다."
+type: docs
+weight: 91
+url: /ko/java/com.aspose.note/tagstatus/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class TagStatus extends System.Enum
+```
+
+노트 태그 노드의 상태를 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Completed](#Completed) | 노트 태그가 완료되었습니다. |
+| [Disabled](#Disabled) | 노트 태그가 비활성화되었습니다. |
+| [Open](#Open) | 노트 태그가 열려 있습니다. |
+### Completed {#Completed}
+```
+public static final int Completed
+```
+
+
+노트 태그가 완료되었습니다.
+
+### Disabled {#Disabled}
+```
+public static final int Disabled
+```
+
+
+노트 태그가 비활성화되었습니다.
+
+### Open {#Open}
+```
+public static final int Open
+```
+
+
+노트 태그가 열려 있습니다.
+

--- a/korean/java/com.aspose.note/textrun/_index.md
+++ b/korean/java/com.aspose.note/textrun/_index.md
@@ -1,0 +1,137 @@
+---
+title: "TextRun"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "연관된 스타일이 있는 텍스트 조각을 나타내는 클래스입니다."
+type: docs
+weight: 92
+url: /ko/java/com.aspose.note/textrun/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextRun
+```
+
+연관된 스타일이 있는 텍스트 조각을 나타내는 클래스입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [TextRun(String text, TextStyle style)](#TextRun-java.lang.String-com.aspose.note.TextStyle-) | 새로운 [TextRun](../../com.aspose.note/textrun) 클래스 인스턴스를 초기화합니다. |
+| [TextRun(String text)](#TextRun-java.lang.String-) | 기본 스타일을 사용하여 새로운 [TextRun](../../com.aspose.note/textrun) 클래스 인스턴스를 초기화합니다. |
+| [TextRun(TextStyle style)](#TextRun-com.aspose.note.TextStyle-) | 빈 텍스트로 새로운 [TextRun](../../com.aspose.note/textrun) 클래스 인스턴스를 초기화합니다. |
+| [TextRun()](#TextRun--) | 빈 텍스트와 기본 스타일로 새로운 [TextRun](../../com.aspose.note/textrun) 클래스 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [getLength()](#getLength--) | 연관된 텍스트의 길이를 가져옵니다. |
+| [getStyle()](#getStyle--) | 스타일을 가져옵니다. |
+| [getText()](#getText--) | 텍스트를 가져옵니다. |
+| [setStyle(TextStyle value)](#setStyle-com.aspose.note.TextStyle-) | 스타일을 설정합니다. |
+| [setText(String value)](#setText-java.lang.String-) | 텍스트를 설정합니다. |
+### TextRun(String text, TextStyle style) {#TextRun-java.lang.String-com.aspose.note.TextStyle-}
+```
+public TextRun(String text, TextStyle style)
+```
+
+
+새로운 [TextRun](../../com.aspose.note/textrun) 클래스 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 텍스트 | java.lang.String | 연관된 텍스트. |
+| style | [TextStyle](../../com.aspose.note/textstyle) | 스타일. |
+
+### TextRun(String text) {#TextRun-java.lang.String-}
+```
+public TextRun(String text)
+```
+
+
+기본 스타일을 사용하여 새로운 [TextRun](../../com.aspose.note/textrun) 클래스 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 텍스트 | java.lang.String | 연관된 텍스트. |
+
+### TextRun(TextStyle style) {#TextRun-com.aspose.note.TextStyle-}
+```
+public TextRun(TextStyle style)
+```
+
+
+빈 텍스트로 새로운 [TextRun](../../com.aspose.note/textrun) 클래스 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| style | [TextStyle](../../com.aspose.note/textstyle) | 스타일. |
+
+### TextRun() {#TextRun--}
+```
+public TextRun()
+```
+
+
+빈 텍스트와 기본 스타일로 새로운 [TextRun](../../com.aspose.note/textrun) 클래스 인스턴스를 초기화합니다.
+
+### getLength() {#getLength--}
+```
+public final int getLength()
+```
+
+
+연관된 텍스트의 길이를 가져옵니다.
+
+**Returns:**
+int
+### getStyle() {#getStyle--}
+```
+public final TextStyle getStyle()
+```
+
+
+스타일을 가져옵니다.
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### getText() {#getText--}
+```
+public final String getText()
+```
+
+
+텍스트를 가져옵니다.
+
+**Returns:**
+java.lang.String
+### setStyle(TextStyle value) {#setStyle-com.aspose.note.TextStyle-}
+```
+public final void setStyle(TextStyle value)
+```
+
+
+스타일을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [TextStyle](../../com.aspose.note/textstyle) |  |
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public final void setText(String value)
+```
+
+
+텍스트를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+

--- a/korean/java/com.aspose.note/textstyle/_index.md
+++ b/korean/java/com.aspose.note/textstyle/_index.md
@@ -1,0 +1,255 @@
+---
+title: "TextStyle"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "텍스트 스타일을 지정합니다."
+type: docs
+weight: 93
+url: /ko/java/com.aspose.note/textstyle/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.note.Style
+```
+public final class TextStyle extends Style<TextStyle>
+```
+
+텍스트 스타일을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [TextStyle()](#TextStyle--) | 새 인스턴스를 초기화합니다 `TextStyle` 클래스. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(TextStyle other)](#equals-com.aspose.note.TextStyle-) | 지정된 객체가 현재 객체와 같은지 여부를 결정합니다. |
+| [equals(Object obj)](#equals-java.lang.Object-) | 지정된 객체가 현재 객체와 같은지 여부를 결정합니다. |
+| [getDefault()](#getDefault--) | "en-US" 문화권의 스타일을 가져옵니다. |
+| [getDefaultMsOneNoteTitleDateStyle()](#getDefaultMsOneNoteTitleDateStyle--) | MS OneNote에서 제목 날짜에 대한 기본 스타일을 가져옵니다. |
+| [getDefaultMsOneNoteTitleTextStyle()](#getDefaultMsOneNoteTitleTextStyle--) | MS OneNote에서 제목 텍스트에 대한 기본 스타일을 가져옵니다. |
+| [getDefaultMsOneNoteTitleTimeStyle()](#getDefaultMsOneNoteTitleTimeStyle--) | MS OneNote에서 제목 시간에 대한 기본 스타일을 가져옵니다. |
+| [getHyperlinkAddress()](#getHyperlinkAddress--) | 하이퍼링크 주소를 가져옵니다. |
+| [getLanguage()](#getLanguage--) | 텍스트의 언어를 가져옵니다. |
+| [hashCode()](#hashCode--) | 해당 유형에 대한 해시 함수로 사용됩니다. |
+| [isHidden()](#isHidden--) | 텍스트 스타일이 숨겨져 있는지 여부를 나타내는 값을 가져옵니다. |
+| [isHyperlink()](#isHyperlink--) | 텍스트 스타일이 하이퍼링크인지 여부를 나타내는 값을 가져옵니다. |
+| [isMathFormatting()](#isMathFormatting--) | 텍스트 스타일이 수학 형식인지 여부를 나타내는 값을 가져오거나 설정합니다. |
+| [setHidden(boolean value)](#setHidden-boolean-) | 텍스트 스타일이 숨겨져 있는지 여부를 나타내는 값을 설정합니다. |
+| [setHyperlink(boolean value)](#setHyperlink-boolean-) | 텍스트 스타일이 하이퍼링크인지 여부를 나타내는 값을 설정합니다. |
+| [setHyperlinkAddress(String value)](#setHyperlinkAddress-java.lang.String-) | 하이퍼링크 주소를 설정합니다. |
+| [setLanguage(Locale value)](#setLanguage-java.util.Locale-) | 텍스트의 언어를 설정합니다. |
+| [setMathFormatting(boolean value)](#setMathFormatting-boolean-) | 텍스트 스타일이 수학 형식인지 여부를 나타내는 값을 설정합니다. |
+### TextStyle() {#TextStyle--}
+```
+public TextStyle()
+```
+
+
+새 인스턴스를 초기화합니다 `TextStyle` 클래스.
+
+### equals(TextStyle other) {#equals-com.aspose.note.TextStyle-}
+```
+public boolean equals(TextStyle other)
+```
+
+
+지정된 객체가 현재 객체와 같은지 여부를 결정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| other | [TextStyle](../../com.aspose.note/textstyle) | 객체입니다. |
+
+**Returns:**
+boolean - `bool`입니다.
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+지정된 객체가 현재 객체와 같은지 여부를 결정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | java.lang.Object | 객체입니다. |
+
+**Returns:**
+boolean - `bool`입니다.
+### getDefault() {#getDefault--}
+```
+public static TextStyle getDefault()
+```
+
+
+"en-US" 문화권의 스타일을 가져옵니다.
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### getDefaultMsOneNoteTitleDateStyle() {#getDefaultMsOneNoteTitleDateStyle--}
+```
+public static TextStyle getDefaultMsOneNoteTitleDateStyle()
+```
+
+
+MS OneNote에서 제목 날짜에 대한 기본 스타일을 가져옵니다.
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### getDefaultMsOneNoteTitleTextStyle() {#getDefaultMsOneNoteTitleTextStyle--}
+```
+public static TextStyle getDefaultMsOneNoteTitleTextStyle()
+```
+
+
+MS OneNote에서 제목 텍스트에 대한 기본 스타일을 가져옵니다.
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### getDefaultMsOneNoteTitleTimeStyle() {#getDefaultMsOneNoteTitleTimeStyle--}
+```
+public static TextStyle getDefaultMsOneNoteTitleTimeStyle()
+```
+
+
+MS OneNote에서 제목 시간에 대한 기본 스타일을 가져옵니다.
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### getHyperlinkAddress() {#getHyperlinkAddress--}
+```
+public String getHyperlinkAddress()
+```
+
+
+하이퍼링크 주소를 가져옵니다. [isHyperlink](../../com.aspose.note/textstyle\#isHyperlink--) 속성의 값이 true인 경우 설정해야 합니다.
+
+**Returns:**
+java.lang.String
+### getLanguage() {#getLanguage--}
+```
+public Locale getLanguage()
+```
+
+
+텍스트의 언어를 가져옵니다.
+
+**Returns:**
+java.util.Locale
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+해당 유형에 대한 해시 함수로 사용됩니다.
+
+**Returns:**
+int - `int`입니다.
+### isHidden() {#isHidden--}
+```
+public boolean isHidden()
+```
+
+
+텍스트 스타일이 숨겨져 있는지 여부를 나타내는 값을 가져옵니다.
+
+**Returns:**
+boolean
+### isHyperlink() {#isHyperlink--}
+```
+public boolean isHyperlink()
+```
+
+
+텍스트 스타일이 하이퍼링크인지 여부를 나타내는 값을 가져옵니다.
+
+**Returns:**
+boolean
+### isMathFormatting() {#isMathFormatting--}
+```
+public boolean isMathFormatting()
+```
+
+
+텍스트 스타일이 수학 형식인지 여부를 나타내는 값을 가져오거나 설정합니다.
+
+**Returns:**
+boolean
+### setHidden(boolean value) {#setHidden-boolean-}
+```
+public TextStyle setHidden(boolean value)
+```
+
+
+텍스트 스타일이 숨겨져 있는지 여부를 나타내는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### setHyperlink(boolean value) {#setHyperlink-boolean-}
+```
+public TextStyle setHyperlink(boolean value)
+```
+
+
+텍스트 스타일이 하이퍼링크인지 여부를 나타내는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### setHyperlinkAddress(String value) {#setHyperlinkAddress-java.lang.String-}
+```
+public TextStyle setHyperlinkAddress(String value)
+```
+
+
+하이퍼링크 주소를 설정합니다. [isHyperlink](../../com.aspose.note/textstyle\#isHyperlink--) 속성의 값이 true인 경우 설정해야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### setLanguage(Locale value) {#setLanguage-java.util.Locale-}
+```
+public TextStyle setLanguage(Locale value)
+```
+
+
+텍스트의 언어를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Locale |  |
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### setMathFormatting(boolean value) {#setMathFormatting-boolean-}
+```
+public TextStyle setMathFormatting(boolean value)
+```
+
+
+텍스트 스타일이 수학 형식인지 여부를 나타내는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)

--- a/korean/java/com.aspose.note/tiffcompression/_index.md
+++ b/korean/java/com.aspose.note/tiffcompression/_index.md
@@ -1,0 +1,83 @@
+---
+title: "TiffCompression"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "TIFF 형식으로 문서를 저장할 때 사용할 압축 유형을 지정합니다."
+type: docs
+weight: 94
+url: /ko/java/com.aspose.note/tiffcompression/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class TiffCompression extends System.Enum
+```
+
+TIFF 형식으로 문서를 저장할 때 사용할 압축 유형을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Ccitt3](#Ccitt3) | CCITT Group 3 팩스 인코딩을 지정합니다. |
+| [Ccitt4](#Ccitt4) | CCITT Group 4 팩스 인코딩을 지정합니다. |
+| [Jpeg](#Jpeg) | JPEG DCT 압축을 지정합니다. |
+| [Lzw](#Lzw) | LZW 압축을 지정합니다. |
+| [None](#None) | 압축을 사용하지 않음을 지정합니다. |
+| [PackBits](#PackBits) | Macintosh RLE 압축을 지정합니다. |
+| [Rle](#Rle) | RLE 압축을 지정합니다. |
+### Ccitt3 {#Ccitt3}
+```
+public static final int Ccitt3
+```
+
+
+CCITT Group 3 팩스 인코딩을 지정합니다.
+
+### Ccitt4 {#Ccitt4}
+```
+public static final int Ccitt4
+```
+
+
+CCITT Group 4 팩스 인코딩을 지정합니다.
+
+### Jpeg {#Jpeg}
+```
+public static final int Jpeg
+```
+
+
+JPEG DCT 압축을 지정합니다.
+
+### Lzw {#Lzw}
+```
+public static final int Lzw
+```
+
+
+LZW 압축을 지정합니다.
+
+### None {#None}
+```
+public static final int None
+```
+
+
+압축을 사용하지 않음을 지정합니다.
+
+### PackBits {#PackBits}
+```
+public static final int PackBits
+```
+
+
+Macintosh RLE 압축을 지정합니다.
+
+### Rle {#Rle}
+```
+public static final int Rle
+```
+
+
+RLE 압축을 지정합니다.
+

--- a/korean/java/com.aspose.note/title/_index.md
+++ b/korean/java/com.aspose.note/title/_index.md
@@ -1,0 +1,256 @@
+---
+title: "Title"
+second_title: "Java용 Aspose.Note API 레퍼런스"
+description: "제목을 나타냅니다."
+type: docs
+weight: 95
+url: /ko/java/com.aspose.note/title/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase)
+
+**All Implemented Interfaces:**
+com.aspose.note.ICompositeNodeT, [com.aspose.note.IPageChildNode](../../com.aspose.note/ipagechildnode)
+```
+public final class Title extends CompositeNodeBase implements ICompositeNodeT<RichText>, IPageChildNode
+```
+
+제목을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Title()](#Title--) | `Title` 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [&lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass)](#-T1-getChildNodes-java.lang.Class-T1--) | 노드 유형별로 모든 자식 노드를 가져옵니다. |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | 노드의 방문자를 수락합니다. |
+| [getChildNodes(int type)](#getChildNodes-int-) |  |
+| [getHorizontalOffset()](#getHorizontalOffset--) | 수평 오프셋을 가져오거나 설정합니다. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | 마지막 수정 시간을 가져오거나 설정합니다. |
+| [getTitleDate()](#getTitleDate--) | 제목에 표시되는 날짜의 문자열 표현을 가져오거나 설정합니다. |
+| [getTitleText()](#getTitleText--) | 제목의 텍스트를 가져오거나 설정합니다. |
+| [getTitleTime()](#getTitleTime--) | 제목에 표시되는 시간의 문자열 표현을 가져오거나 설정합니다. |
+| [getVerticalOffset()](#getVerticalOffset--) | 수직 오프셋을 가져오거나 설정합니다. |
+| [isComposite()](#isComposite--) | 이 노드가 복합 노드인지 여부를 나타내는 값을 가져옵니다. |
+| [iterator()](#iterator--) | [Title](../../com.aspose.note/title) 의 자식 노드를 순회하는 열거자를 반환합니다. |
+| [setHorizontalOffset(float value)](#setHorizontalOffset-float-) | 수평 오프셋을 가져오거나 설정합니다. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | 마지막 수정 시간을 가져오거나 설정합니다. |
+| [setTitleDate(RichText value)](#setTitleDate-com.aspose.note.RichText-) | 제목에 표시되는 날짜의 문자열 표현을 가져오거나 설정합니다. |
+| [setTitleText(RichText value)](#setTitleText-com.aspose.note.RichText-) | 제목의 텍스트를 가져오거나 설정합니다. |
+| [setTitleTime(RichText value)](#setTitleTime-com.aspose.note.RichText-) | 제목에 표시되는 시간의 문자열 표현을 가져오거나 설정합니다. |
+| [setVerticalOffset(float value)](#setVerticalOffset-float-) | 수직 오프셋을 가져오거나 설정합니다. |
+### Title() {#Title--}
+```
+public Title()
+```
+
+
+`Title` 클래스의 새 인스턴스를 초기화합니다.
+
+### &lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass) {#-T1-getChildNodes-java.lang.Class-T1--}
+```
+public List<T1> <T1>getChildNodes(Class<T1> typeParameterClass)
+```
+
+
+노드 유형별로 모든 자식 노드를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| typeParameterClass | java.lang.Class&lt;T1&gt; |  |
+
+**Returns:**
+java.util.List&lt;T1&gt; - 자식 노드의 목록입니다.
+
+`T1`: 반환된 목록에 있는 요소의 유형입니다.
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+노드의 방문자를 수락합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | `DocumentVisitor`에서 파생된 클래스의 객체. |
+
+### getChildNodes(int type) {#getChildNodes-int-}
+```
+public List<INode> getChildNodes(int type)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 유형 | int |  |
+
+**Returns:**
+java.util.List&lt;com.aspose.note.INode&gt;
+### getHorizontalOffset() {#getHorizontalOffset--}
+```
+public final float getHorizontalOffset()
+```
+
+
+수평 오프셋을 가져오거나 설정합니다.
+
+**Returns:**
+float
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+마지막 수정 시간을 가져오거나 설정합니다.
+
+**Returns:**
+java.util.Date
+### getTitleDate() {#getTitleDate--}
+```
+public final RichText getTitleDate()
+```
+
+
+제목에 표시되는 날짜의 문자열 표현을 가져오거나 설정합니다.
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext)
+### getTitleText() {#getTitleText--}
+```
+public RichText getTitleText()
+```
+
+
+제목의 텍스트를 가져오거나 설정합니다.
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext)
+### getTitleTime() {#getTitleTime--}
+```
+public final RichText getTitleTime()
+```
+
+
+제목에 표시되는 시간의 문자열 표현을 가져오거나 설정합니다.
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext)
+### getVerticalOffset() {#getVerticalOffset--}
+```
+public final float getVerticalOffset()
+```
+
+
+수직 오프셋을 가져오거나 설정합니다.
+
+**Returns:**
+float
+### isComposite() {#isComposite--}
+```
+public boolean isComposite()
+```
+
+
+이 노드가 복합 노드인지 여부를 나타내는 값을 가져옵니다. true인 경우 노드는 자식 노드를 가질 수 있습니다.
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public final System.Collections.Generic.IGenericEnumerator<RichText> iterator()
+```
+
+
+[Title](../../com.aspose.note/title) 의 자식 노드를 순회하는 열거자를 반환합니다.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;com.aspose.note.RichText&gt; - IEnumerator.
+### setHorizontalOffset(float value) {#setHorizontalOffset-float-}
+```
+public final void setHorizontalOffset(float value)
+```
+
+
+수평 오프셋을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+마지막 수정 시간을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Date |  |
+
+### setTitleDate(RichText value) {#setTitleDate-com.aspose.note.RichText-}
+```
+public final void setTitleDate(RichText value)
+```
+
+
+제목에 표시되는 날짜의 문자열 표현을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [RichText](../../com.aspose.note/richtext) |  |
+
+### setTitleText(RichText value) {#setTitleText-com.aspose.note.RichText-}
+```
+public final void setTitleText(RichText value)
+```
+
+
+제목의 텍스트를 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [RichText](../../com.aspose.note/richtext) |  |
+
+### setTitleTime(RichText value) {#setTitleTime-com.aspose.note.RichText-}
+```
+public final void setTitleTime(RichText value)
+```
+
+
+제목에 표시되는 시간의 문자열 표현을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [RichText](../../com.aspose.note/richtext) |  |
+
+### setVerticalOffset(float value) {#setVerticalOffset-float-}
+```
+public final void setVerticalOffset(float value)
+```
+
+
+수직 오프셋을 가져오거나 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+


### PR DESCRIPTION
Automated translation of the JAVA API Reference to **Korean** (`ko`) generated by RDA.

- Pages translated: 107/107
- Errors: 0
- Source: `english/java`
- Output: `korean/java`

🤖 Generated by RDA