### PR TITLE
[auto] Translate JAVA API Reference to Netherlands

### DIFF
--- a/netherlands/java/_index.md
+++ b/netherlands/java/_index.md
@@ -1,0 +1,14 @@
+---
+title: "Aspose.Note for Java"
+type: docs
+weight: 11
+url: /nl/java/
+description: "Aspose.Note for Java API-referenties bevatten voorbeelden, codefragmenten en API-documentatie. Het biedt pakketten, klassen, interfaces en andere API-details."
+is_root: true
+---
+
+## Packages
+| Pakket | Beschrijving |
+| --- | --- |
+| [com.aspose.note](./com.aspose.note) | De \`\`\` com.aspose.note \`\`\` namespace bevat klassen die de documentstructuur vertegenwoordigen. |
+| [com.aspose.note.fonts](./com.aspose.note.fonts) | De \`\`\` com.aspose.note.fonts \`\`\` namespace bevat klassen die functionaliteit bieden om de lettertype‑omgeving van een document te manipuleren. |

--- a/netherlands/java/com.aspose.note.fonts/_index.md
+++ b/netherlands/java/com.aspose.note.fonts/_index.md
@@ -1,0 +1,25 @@
+---
+title: "com.aspose.note.fonts"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De com.aspose.note.fonts namespace bevat klassen die functionaliteit bieden om de lettertype‑omgeving van een document te manipuleren."
+type: docs
+weight: 27
+url: /nl/java/com.aspose.note.fonts/
+---
+
+
+De `com.aspose.note.fonts` namespace bevat klassen die functionaliteit bieden om de lettertype‑omgeving van een document te manipuleren.
+
+
+## Klassen
+
+| Klasse | Beschrijving |
+| --- | --- |
+| [DocumentFontsSubsystem](../com.aspose.note.fonts/documentfontssubsystem) | Eenvoudige implementatie van Aspose.Note.Fonts.FontsSubsystem. |
+| [FontsSubsystem](../com.aspose.note.fonts/fontssubsystem) | Basisklasse die de interface com.aspose.note.IFontsSubsystem implementeert. |
+
+## Interfaces
+
+| Interface | Beschrijving |
+| --- | --- |
+| [IFontsSubsystem](../com.aspose.note.fonts/ifontssubsystem) | Implementeer deze interface als je wilt bepalen hoe Aspose.Note lettertypen ophaalt bij het opslaan van een document. |

--- a/netherlands/java/com.aspose.note.fonts/documentfontssubsystem/_index.md
+++ b/netherlands/java/com.aspose.note.fonts/documentfontssubsystem/_index.md
@@ -1,0 +1,229 @@
+---
+title: "DocumentFontsSubsystem"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Eenvoudige implementatie van Aspose.Note.Fonts.FontsSubsystem."
+type: docs
+weight: 10
+url: /nl/java/com.aspose.note.fonts/documentfontssubsystem/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.fonts.FontsSubsystem](../../com.aspose.note.fonts/fontssubsystem)
+```
+public class DocumentFontsSubsystem extends FontsSubsystem
+```
+
+Eenvoudige implementatie van Aspose.Note.Fonts.FontsSubsystem. Haalt FontFamily‑object op uit het besturingssysteem.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [DocumentFontsSubsystem(InputStream defaultFontStream, Map&lt;String,String&gt; fontsSubstitutions)](#DocumentFontsSubsystem-java.io.InputStream-java.util.Map-java.lang.String-java.lang.String--) | Initialiseert een nieuw exemplaar van de klasse [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem). |
+| [DocumentFontsSubsystem(InputStream defaultFontStream)](#DocumentFontsSubsystem-java.io.InputStream-) | Initialiseert een nieuw exemplaar van de klasse [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem). |
+| [DocumentFontsSubsystem(String defaultFontFile, Map&lt;String,String&gt; fontsSubstitutions)](#DocumentFontsSubsystem-java.lang.String-java.util.Map-java.lang.String-java.lang.String--) | Initialiseert een nieuw exemplaar van de klasse [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem). |
+| [DocumentFontsSubsystem(String defaultFontFile)](#DocumentFontsSubsystem-java.lang.String-) | Initialiseert een nieuw exemplaar van de klasse [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem). |
+| [DocumentFontsSubsystem(Map&lt;String,String&gt; fontsSubstitutions)](#DocumentFontsSubsystem-java.util.Map-java.lang.String-java.lang.String--) | Initialiseert een nieuw exemplaar van de klasse [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem). |
+| [DocumentFontsSubsystem()](#DocumentFontsSubsystem--) | Initialiseert een nieuw exemplaar van de klasse [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem). |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getDefault()](#getDefault--) | Haalt op of stelt de statische standaardinstantie in. |
+| [setDefault(DocumentFontsSubsystem value)](#setDefault-com.aspose.note.fonts.DocumentFontsSubsystem-) | Haalt op of stelt de statische standaardinstantie in. |
+| [usingDefaultFont(String defaultFontName)](#usingDefaultFont-java.lang.String-) | Maak een nieuwe DocumentFontsSubsystem‑instantie aan met de opgegeven standaardlettertype‑naam. |
+| [usingDefaultFont(String defaultFontName, Map&lt;String,String&gt; fontsSubstitutions)](#usingDefaultFont-java.lang.String-java.util.Map-java.lang.String-java.lang.String--) | Maak een nieuwe DocumentFontsSubsystem‑instantie aan met de opgegeven standaardlettertype‑naam. |
+| [usingDefaultFontFromFile(String filePath)](#usingDefaultFontFromFile-java.lang.String-) | Maak een nieuwe DocumentFontsSubsystem‑instantie aan met de opgegeven standaardlettertype‑naam. |
+| [usingDefaultFontFromFile(String filePath, Map&lt;String,String&gt; fontsSubstitutions)](#usingDefaultFontFromFile-java.lang.String-java.util.Map-java.lang.String-java.lang.String--) | Maak een nieuwe DocumentFontsSubsystem‑instantie aan met een lettertype uit het opgegeven bestand als standaard. |
+| [usingDefaultFontFromStream(InputStream defaultFontStream)](#usingDefaultFontFromStream-java.io.InputStream-) | Maak een nieuwe DocumentFontsSubsystem‑instantie aan met een lettertype uit de opgegeven stream als standaard. |
+| [usingDefaultFontFromStream(InputStream defaultFontStream, Map&lt;String,String&gt; fontsSubstitutions)](#usingDefaultFontFromStream-java.io.InputStream-java.util.Map-java.lang.String-java.lang.String--) | Maak een nieuwe DocumentFontsSubsystem‑instantie aan met een lettertype uit de opgegeven stream als standaard. |
+### DocumentFontsSubsystem(InputStream defaultFontStream, Map&lt;String,String&gt; fontsSubstitutions) {#DocumentFontsSubsystem-java.io.InputStream-java.util.Map-java.lang.String-java.lang.String--}
+```
+public DocumentFontsSubsystem(InputStream defaultFontStream, Map<String,String> fontsSubstitutions)
+```
+
+
+Initialiseert een nieuw exemplaar van de klasse [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| defaultFontStream | java.io.InputStream | De stream die het standaardlettertype bevat. |
+| fontsSubstitutions | java.util.Map&lt;java.lang.String,java.lang.String&gt; | De lettertype‑substituties. |
+
+### DocumentFontsSubsystem(InputStream defaultFontStream) {#DocumentFontsSubsystem-java.io.InputStream-}
+```
+public DocumentFontsSubsystem(InputStream defaultFontStream)
+```
+
+
+Initialiseert een nieuw exemplaar van de klasse [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| defaultFontStream | java.io.InputStream | De stream die het standaardlettertype bevat. |
+
+### DocumentFontsSubsystem(String defaultFontFile, Map&lt;String,String&gt; fontsSubstitutions) {#DocumentFontsSubsystem-java.lang.String-java.util.Map-java.lang.String-java.lang.String--}
+```
+public DocumentFontsSubsystem(String defaultFontFile, Map<String,String> fontsSubstitutions)
+```
+
+
+Initialiseert een nieuw exemplaar van de klasse [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| defaultFontFile | java.lang.String | Het pad naar het bestand dat het standaardlettertype bevat. |
+| fontsSubstitutions | java.util.Map&lt;java.lang.String,java.lang.String&gt; | De lettertype‑substituties. |
+
+### DocumentFontsSubsystem(String defaultFontFile) {#DocumentFontsSubsystem-java.lang.String-}
+```
+public DocumentFontsSubsystem(String defaultFontFile)
+```
+
+
+Initialiseert een nieuw exemplaar van de klasse [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| defaultFontFile | java.lang.String | Het pad naar het bestand dat het standaardlettertype bevat. |
+
+### DocumentFontsSubsystem(Map&lt;String,String&gt; fontsSubstitutions) {#DocumentFontsSubsystem-java.util.Map-java.lang.String-java.lang.String--}
+```
+public DocumentFontsSubsystem(Map<String,String> fontsSubstitutions)
+```
+
+
+Initialiseert een nieuw exemplaar van de klasse [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| fontsSubstitutions | java.util.Map&lt;java.lang.String,java.lang.String&gt; | De lettertype‑substituties. |
+
+### DocumentFontsSubsystem() {#DocumentFontsSubsystem--}
+```
+public DocumentFontsSubsystem()
+```
+
+
+Initialiseert een nieuw exemplaar van de klasse [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+
+### getDefault() {#getDefault--}
+```
+public static DocumentFontsSubsystem getDefault()
+```
+
+
+Haalt op of stelt de statische standaardinstantie in.
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem)
+### setDefault(DocumentFontsSubsystem value) {#setDefault-com.aspose.note.fonts.DocumentFontsSubsystem-}
+```
+public static void setDefault(DocumentFontsSubsystem value)
+```
+
+
+Haalt op of stelt de statische standaardinstantie in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| value | [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) |  |
+
+### usingDefaultFont(String defaultFontName) {#usingDefaultFont-java.lang.String-}
+```
+public static DocumentFontsSubsystem usingDefaultFont(String defaultFontName)
+```
+
+
+Maak een nieuwe DocumentFontsSubsystem‑instantie aan met de opgegeven standaardlettertype‑naam.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| defaultFontName | java.lang.String | De standaardlettertype‑naam. |
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) - [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+### usingDefaultFont(String defaultFontName, Map&lt;String,String&gt; fontsSubstitutions) {#usingDefaultFont-java.lang.String-java.util.Map-java.lang.String-java.lang.String--}
+```
+public static DocumentFontsSubsystem usingDefaultFont(String defaultFontName, Map<String,String> fontsSubstitutions)
+```
+
+
+Maak een nieuwe DocumentFontsSubsystem‑instantie aan met de opgegeven standaardlettertype‑naam.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| defaultFontName | java.lang.String | De standaardlettertype‑naam. |
+| fontsSubstitutions | java.util.Map&lt;java.lang.String,java.lang.String&gt; | De lettertype‑substituties. |
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) - [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+### usingDefaultFontFromFile(String filePath) {#usingDefaultFontFromFile-java.lang.String-}
+```
+public static DocumentFontsSubsystem usingDefaultFontFromFile(String filePath)
+```
+
+
+Maak een nieuwe DocumentFontsSubsystem‑instantie aan met de opgegeven standaardlettertype‑naam.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| filePath | java.lang.String | Het bestand dat de standaardlettertype‑naam bevat. |
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) - [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+### usingDefaultFontFromFile(String filePath, Map&lt;String,String&gt; fontsSubstitutions) {#usingDefaultFontFromFile-java.lang.String-java.util.Map-java.lang.String-java.lang.String--}
+```
+public static DocumentFontsSubsystem usingDefaultFontFromFile(String filePath, Map<String,String> fontsSubstitutions)
+```
+
+
+Maak een nieuwe DocumentFontsSubsystem‑instantie aan met een lettertype uit het opgegeven bestand als standaard.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| filePath | java.lang.String | Het bestand dat de standaardlettertype‑naam bevat. |
+| fontsSubstitutions | java.util.Map&lt;java.lang.String,java.lang.String&gt; | De lettertype‑substituties. |
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) - [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+### usingDefaultFontFromStream(InputStream defaultFontStream) {#usingDefaultFontFromStream-java.io.InputStream-}
+```
+public static DocumentFontsSubsystem usingDefaultFontFromStream(InputStream defaultFontStream)
+```
+
+
+Maak een nieuwe DocumentFontsSubsystem‑instantie aan met een lettertype uit de opgegeven stream als standaard.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| defaultFontStream | java.io.InputStream | De stream die de standaardlettertype‑naam bevat. |
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) - [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).
+### usingDefaultFontFromStream(InputStream defaultFontStream, Map&lt;String,String&gt; fontsSubstitutions) {#usingDefaultFontFromStream-java.io.InputStream-java.util.Map-java.lang.String-java.lang.String--}
+```
+public static DocumentFontsSubsystem usingDefaultFontFromStream(InputStream defaultFontStream, Map<String,String> fontsSubstitutions)
+```
+
+
+Maak een nieuwe DocumentFontsSubsystem‑instantie aan met een lettertype uit de opgegeven stream als standaard.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| defaultFontStream | java.io.InputStream | De stream die de standaardlettertype‑naam bevat. |
+| fontsSubstitutions | java.util.Map&lt;java.lang.String,java.lang.String&gt; | De lettertype‑substituties. |
+
+**Returns:**
+[DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem) - [DocumentFontsSubsystem](../../com.aspose.note.fonts/documentfontssubsystem).

--- a/netherlands/java/com.aspose.note.fonts/fontssubsystem/_index.md
+++ b/netherlands/java/com.aspose.note.fonts/fontssubsystem/_index.md
@@ -1,0 +1,107 @@
+---
+title: "FontsSubsystem"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Basisklasse die de interface com.aspose.note.IFontsSubsystem implementeert."
+type: docs
+weight: 11
+url: /nl/java/com.aspose.note.fonts/fontssubsystem/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.note.fonts.IFontsSubsystem](../../com.aspose.note.fonts/ifontssubsystem)
+```
+public abstract class FontsSubsystem implements IFontsSubsystem
+```
+
+Basis klasse die de interface com.aspose.note.IFontsSubsystem implementeert. Biedt functionaliteit voor het standaardlettertype en de substituties van lettertypen. Overschrijf de beschermde ledenfunctie com.aspose.note.FontsSubsystem.fetchFontFamily in een afgeleide klasse om de logica voor het ophalen van een Font-object te implementeren.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [addFont(InputStream stream)](#addFont-java.io.InputStream-) | Voegt het lettertype toe. |
+| [addFont(String file)](#addFont-java.lang.String-) | Voegt het lettertype toe. |
+| [addFontSubstitution(String substituted, String substitution)](#addFontSubstitution-java.lang.String-java.lang.String-) | Voegt lettertype-substitutie toe. |
+| [getDefaultFont()](#getDefaultFont--) | Haalt het standaardlettertype op. |
+| [getFontFamily(String fontName)](#getFontFamily-java.lang.String-) | Haalt lettertype op. |
+| [loadFontsFromFolder(String folder)](#loadFontsFromFolder-java.lang.String-) | Laadt alle TrueType-lettertypen uit de opgegeven map in de interne collectie. |
+### addFont(InputStream stream) {#addFont-java.io.InputStream-}
+```
+public final void addFont(InputStream stream)
+```
+
+
+Voegt het lettertype toe.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| stroom | java.io.InputStream | De stroom die het lettertype bevat. |
+
+### addFont(String file) {#addFont-java.lang.String-}
+```
+public final void addFont(String file)
+```
+
+
+Voegt het lettertype toe.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| bestand | java.lang.String | Het pad naar het bestand dat het lettertype bevat. |
+
+### addFontSubstitution(String substituted, String substitution) {#addFontSubstitution-java.lang.String-java.lang.String-}
+```
+public final void addFontSubstitution(String substituted, String substitution)
+```
+
+
+Voegt lettertype-substitutie toe.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| vervangen | java.lang.String | De naam van het vervangen lettertype. |
+| substitutie | java.lang.String | De naam van het substitutie-lettertype. |
+
+### getDefaultFont() {#getDefaultFont--}
+```
+public Font getDefaultFont()
+```
+
+
+Haalt het standaardlettertype op.
+
+**Returns:**
+java.awt.Font
+### getFontFamily(String fontName) {#getFontFamily-java.lang.String-}
+```
+public Font getFontFamily(String fontName)
+```
+
+
+Haalt lettertype op.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| fontName | java.lang.String | De lettertype‑naam. |
+
+**Returns:**
+java.awt.Font - Het lettertype.
+### loadFontsFromFolder(String folder) {#loadFontsFromFolder-java.lang.String-}
+```
+public final void loadFontsFromFolder(String folder)
+```
+
+
+Laadt alle TrueType-lettertypen uit de opgegeven map in de interne collectie.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| map | java.lang.String | De map die lettertypen bevat. |
+

--- a/netherlands/java/com.aspose.note.fonts/ifontssubsystem/_index.md
+++ b/netherlands/java/com.aspose.note.fonts/ifontssubsystem/_index.md
@@ -1,0 +1,33 @@
+---
+title: "IFontsSubsystem"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Implementeer deze interface als je wilt bepalen hoe Aspose.Note lettertypen ophaalt bij het opslaan van een document."
+type: docs
+weight: 12
+url: /nl/java/com.aspose.note.fonts/ifontssubsystem/
+---
+```
+public interface IFontsSubsystem
+```
+
+Implementeer deze interface als je wilt bepalen hoe Aspose.Note lettertypen ophaalt bij het opslaan van een document.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getFontFamily(String fontName)](#getFontFamily-java.lang.String-) | Haalt lettertype op. |
+### getFontFamily(String fontName) {#getFontFamily-java.lang.String-}
+```
+public abstract Font getFontFamily(String fontName)
+```
+
+
+Haalt lettertype op.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| fontName | java.lang.String | De lettertype‑naam. |
+
+**Returns:**
+java.awt.Font - Het lettertype.

--- a/netherlands/java/com.aspose.note/_index.md
+++ b/netherlands/java/com.aspose.note/_index.md
@@ -1,0 +1,123 @@
+---
+title: "com.aspose.note"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De com.aspose.note namespace bevat klassen die de documentstructuur vertegenwoordigen."
+type: docs
+weight: 10
+url: /nl/java/com.aspose.note/
+---
+
+
+De `com.aspose.note` namespace bevat klassen die de documentstructuur vertegenwoordigen.
+
+
+## Klassen
+
+| Klasse | Beschrijving |
+| --- | --- |
+| [AlwaysSplitObjectsAlgorithm](../com.aspose.note/alwayssplitobjectsalgorithm) | Split een object in meerdere delen als het niet op de oorspronkelijke pagina past. |
+| [AttachedFile](../com.aspose.note/attachedfile) | Stelt een bijgevoegd bestand voor. |
+| [BinarizationMethod](../com.aspose.note/binarizationmethod) | Specificeert de binarisatiemethode voor een afbeelding. |
+| [CheckBox](../com.aspose.note/checkbox) | De basisklasse voor tags die hun status kunnen schakelen tussen voltooid en onvoltooid. |
+| [ColorMode](../com.aspose.note/colormode) | De kleermodus van de afbeelding. |
+| [CompositeNode&lt;T&gt;](../com.aspose.note/compositenode) | De basisgenerieke klasse voor knooppunten die andere knooppunten kunnen bevatten. |
+| [CompositeNodeBase](../com.aspose.note/compositenodebase) | De niet-generieke klasse voor knooppunten die andere knooppunten kunnen bevatten. |
+| [CssSavingArgs](../com.aspose.note/csssavingargs) | Levert gegevens voor het CssSaving evenement. |
+| [DefaultMsOneNoteValuesAccessor](../com.aspose.note/defaultmsonenotevaluesaccessor) |  |
+| [DisplayUnitsConverter](../com.aspose.note/displayunitsconverter) | De klasse bevat de methoden voor het converteren van waarden. |
+| [Document](../com.aspose.note/document) | Stelt een Aspose.Note-document voor. |
+| [DocumentPrintAttributeSet](../com.aspose.note/documentprintattributeset) | Stelt een hulpprogrammaklasse met een gebruiksvriendelijke interface naar AttributeSet voor. |
+| [DocumentVisitor](../com.aspose.note/documentvisitor) | De abstracte klasse voor het itereren door een subboom met wortel op het opgegeven knooppunt. |
+| [ExtendedApsDocument](../com.aspose.note/extendedapsdocument) | Stelt een volledig OneNote-document voor, bestaande uit Pagina's die zijn vertaald naar pagina-sets. |
+| [ExtendedApsGlyphs](../com.aspose.note/extendedapsglyphs) | Stelt een wrapper voor standaard ApsGlyphs voor, die een deel van het teken-gedrag uitbreidt. |
+| [ExtendedApsImage](../com.aspose.note/extendedapsimage) | Stelt een wrapper voor de standaard ApsImage voor, die een deel van het teken-gedrag uitbreidt. |
+| [ExtendedApsNode](../com.aspose.note/extendedapsnode) | Stelt een wrapper voor een standaard ApsNode voor, die een deel van het teken-gedrag uitbreidt. |
+| [ExtendedApsPage](../com.aspose.note/extendedapspage) | Stelt een wrapper voor de standaard ApsGlyphs voor, die een deel van het teken-gedrag uitbreidt. |
+| [ExtendedApsPath](../com.aspose.note/extendedapspath) | Stelt een wrapper voor het standaard ApsPath voor, die een deel van het teken-gedrag uitbreidt. |
+| [ExtendedCompositeNode](../com.aspose.note/extendedcompositenode) | Combineert verschillende `IExtendedApsNode`-instanties. |
+| [FileFormat](../com.aspose.note/fileformat) | Stelt het OneNote-bestandsformaat voor. |
+| [FontSavingArgs](../com.aspose.note/fontsavingargs) | Levert gegevens voor het FontSaving evenement. |
+| [HtmlSaveOptions](../com.aspose.note/htmlsaveoptions) | Staat toe extra opties op te geven bij het opslaan van een document naar HTML-formaat. |
+| [Image](../com.aspose.note/image) | Stelt een afbeelding voor. |
+| [ImageBinarizationOptions](../com.aspose.note/imagebinarizationoptions) | Opties voor de binarisatie van de afbeelding. |
+| [ImageSaveOptions](../com.aspose.note/imagesaveoptions) | Staat toe extra opties op te geven bij het renderen van documentpagina's naar afbeeldingen. |
+| [ImageSavingArgs](../com.aspose.note/imagesavingargs) | Levert gegevens voor het ImageSaving evenement. |
+| [IndentatedNode&lt;T,Self&gt;](../com.aspose.note/indentatednode) | De basis-klasse voor knooppunten met relatieve inspringing voor onderliggende knooppunten. |
+| [InkDrawing](../com.aspose.note/inkdrawing) | Stelt een inktknooppunt voor dat enige getekende inhoud bevat. |
+| [InkNode](../com.aspose.note/inknode) | Stelt een algemene interface voor alle inktknooppunten voor. |
+| [InkParagraph](../com.aspose.note/inkparagraph) | Stelt een inktknooppunt voor dat handgeschreven tekst bevat met extra eigenschappen zoals scheef geschreven tekst. |
+| [InkWord](../com.aspose.note/inkword) | Stelt een inktknooppunt voor dat handgeschreven tekst bevat. |
+| [KeepPartAndCloneSolidObjectToNextPageAlgorithm](../com.aspose.note/keeppartandclonesolidobjecttonextpagealgorithm) | Voegt het bovenste deel van het object toe aan de onderkant van de pagina en kloont het volledige object naar de volgende pagina als het niet op de oorspronkelijke pagina past. |
+| [KeepSolidObjectsAlgorithm](../com.aspose.note/keepsolidobjectsalgorithm) | Verplaatst het volledige object naar de volgende pagina als het niet op de oorspronkelijke pagina past. |
+| [License](../com.aspose.note/license) | Biedt methoden om de component te licentiëren. |
+| [LicenseExceptions](../com.aspose.note/licenseexceptions) |  |
+| [LoadOptions](../com.aspose.note/loadoptions) | Opties die worden gebruikt om een document te laden. |
+| [LocaleOptions](../com.aspose.note/localeoptions) | Het type LocaleOptions specificeert de locale-configuratie voor Aspose.Note. |
+| [Loop](../com.aspose.note/loop) | Stelt een lus voor. |
+| [Margins](../com.aspose.note/margins) | Specificeert de afmetingen van de marges van een knooppunt. |
+| [Metered](../com.aspose.note/metered) | Biedt methoden om een gemeten sleutel in te stellen. |
+| [Node](../com.aspose.note/node) | De basisklasse voor alle knooppunten van een Aspose.Note-document. |
+| [NodeType](../com.aspose.note/nodetype) | Specificeert het type van het knooppunt. |
+| [NoteCheckBox](../com.aspose.note/notecheckbox) | Stelt een notitag voor die hun status kan schakelen tussen voltooid en onvoltooid. |
+| [NoteTag](../com.aspose.note/notetag) | Stelt een notitag voor. |
+| [NoteTask](../com.aspose.note/notetask) | Stelt een notitaak voor. |
+| [Notebook](../com.aspose.note/notebook) | Stelt een Aspose.Note-notitieblok voor. |
+| [NotebookImageSaveOptions](../com.aspose.note/notebookimagesaveoptions) | Staat toe extra opties op te geven bij het renderen van notitieblokpagina's naar afbeeldingen. |
+| [NotebookLoadOptions](../com.aspose.note/notebookloadoptions) | Opties die worden gebruikt om een notitieblok te laden. |
+| [NotebookOneSaveOptions](../com.aspose.note/notebookonesaveoptions) | Staat toe extra opties op te geven bij het opslaan van een notitieblok in OneNote-indeling. |
+| [NotebookPdfSaveOptions](../com.aspose.note/notebookpdfsaveoptions) | Staat toe extra opties op te geven bij het renderen van notitieblokpagina's naar PDF. |
+| [NotebookSaveOptions](../com.aspose.note/notebooksaveoptions) | Een abstracte basisklasse die notitieblok-opslagopties voor een specifiek formaat voorstelt. |
+| [NotebookSaveOptionsGeneric&lt;TDocumentSaveOptions&gt;](../com.aspose.note/notebooksaveoptionsgeneric) | Een abstracte basisklasse die notitieblok-opslagopties voor een specifiek formaat voorstelt en gemeenschappelijke opslagopties biedt voor alle onderliggende knooppunten van het document. |
+| [NumberFormat](../com.aspose.note/numberformat) | Specificeert het nummeringsformaat dat kan worden gebruikt voor een groep automatisch genummerde objecten. |
+| [NumberList](../com.aspose.note/numberlist) | Stelt de genummerde of opsomminglijst voor. |
+| [OneSaveOptions](../com.aspose.note/onesaveoptions) | Staat toe extra opties op te geven bij het opslaan van een document in OneNote-indeling. |
+| [Outline](../com.aspose.note/outline) | Stelt een overzicht voor. |
+| [OutlineElement](../com.aspose.note/outlineelement) | Stelt een OutlineElement voor. |
+| [OutlineGroup](../com.aspose.note/outlinegroup) | Stelt een OutlineGroup voor. |
+| [Page](../com.aspose.note/page) | Stelt een pagina voor. |
+| [PageHistory](../com.aspose.note/pagehistory) | Stelt de paginageschiedenis voor. |
+| [PageSavingArgs](../com.aspose.note/pagesavingargs) | Levert gegevens voor het PageSaving event. |
+| [PageSettings](../com.aspose.note/pagesettings) | Stelt de lay-outinstellingen voor een pagina voor. |
+| [PageSizeType](../com.aspose.note/pagesizetype) | Specificeert de grootte van het paginaknooppunttype. |
+| [PageSplittingAlgorithm](../com.aspose.note/pagesplittingalgorithm) | Basisklasse voor het splitsen van een object als het niet in de oorspronkelijke pagina past. |
+| [ParagraphStyle](../com.aspose.note/paragraphstyle) | Tekstopmaakinstellingen die gebruikt worden als er geen overeenkomend TextStyle-object in de [RichText.\#getStyles](../com.aspose.note/richtext\#getStyles) collectie aanwezig is, of dit object geen benodigde instelling opgeeft. |
+| [PdfImageCompression](../com.aspose.note/pdfimagecompression) | Specificeert het type compressie dat op afbeeldingen in het PDF‑bestand wordt toegepast. |
+| [PdfSaveOptions](../com.aspose.note/pdfsaveoptions) | Staat toe extra opties op te geven bij het renderen van documentpagina's naar PDF. |
+| [PrintOptions](../com.aspose.note/printoptions) | Opties die worden gebruikt om een document af te drukken. |
+| [ResourceExportType](../com.aspose.note/resourceexporttype) |  |
+| [ResourceSavingArgs](../com.aspose.note/resourcesavingargs) | Levert gegevens voor het ResourceSaving event. |
+| [RevisionSummary](../com.aspose.note/revisionsummary) | Stelt een samenvatting voor van de revisie van een knoop. |
+| [RichText](../com.aspose.note/richtext) | Stelt een rich text voor. |
+| [SaveFormat](../com.aspose.note/saveformat) | Geeft het formaat aan waarin het document wordt opgeslagen. |
+| [SaveFormatConverter](../com.aspose.note/saveformatconverter) | De converter voor het opslagformaat. |
+| [SaveOptions](../com.aspose.note/saveoptions) | Een abstracte basisklasse die documentopslagopties voor een bepaald formaat voorstelt. |
+| [Style&lt;T&gt;](../com.aspose.note/style) | Deze klasse bevat gemeenschappelijke eigenschappen van de klassen [ParagraphStyle](../com.aspose.note/paragraphstyle) en [TextStyle](../com.aspose.note/textstyle). |
+| [Table](../com.aspose.note/table) | Stelt een tabel voor. |
+| [TableCell](../com.aspose.note/tablecell) | Stelt een tabelcel voor. |
+| [TableColumn](../com.aspose.note/tablecolumn) | Stelt een tabelkolom voor. |
+| [TableRow](../com.aspose.note/tablerow) | Stelt een tabelrij voor. |
+| [TagStatus](../com.aspose.note/tagstatus) | Specificeert de status van de notitie‑tagknoop. |
+| [TextRun](../com.aspose.note/textrun) | De klasse die een stuk tekst met bijbehorende opmaak voorstelt. |
+| [TextStyle](../com.aspose.note/textstyle) | Specificeert de tekststijl. |
+| [TiffCompression](../com.aspose.note/tiffcompression) | Specificeert welk type compressie te gebruiken bij het opslaan van een document in het TIFF-formaat. |
+| [Title](../com.aspose.note/title) | Stelt een titel voor. |
+
+## Interfaces
+
+| Interface | Beschrijving |
+| --- | --- |
+| [ICompositeNode](../com.aspose.note/icompositenode) | De interface voor knooppunten die andere knooppunten kunnen bevatten. |
+| [ICompositeNodeT&lt;T&gt;](../com.aspose.note/icompositenodet) | De interface voor knooppunten die andere knooppunten kunnen bevatten. |
+| [ICssSavingCallback](../com.aspose.note/icsssavingcallback) | Implementeer deze interface als u wilt bepalen hoe Aspose.Note CSS (Cascading Style Sheet) opslaat bij het opslaan van een document naar HTML. |
+| [IFontSavingCallback](../com.aspose.note/ifontsavingcallback) | Implementeer deze interface als u wilt bepalen hoe Aspose.Note lettertypen opslaat bij het opslaan van een document naar HTML. |
+| [IImageSavingCallback](../com.aspose.note/iimagesavingcallback) | Implementeer deze interface als u wilt bepalen hoe Aspose.Note afbeeldingen opslaat bij het opslaan van een document naar HTML. |
+| [IIndentatedNode](../com.aspose.note/iindentatednode) | De interface voor knooppunten met relatieve inspringing voor onderliggende knooppunten. |
+| [INode](../com.aspose.note/inode) | De interface voor alle knooppunten van een Aspose.Note-document. |
+| [INoteTag](../com.aspose.note/inotetag) | De interface voor notitie‑tags(i.e. |
+| [INotebookChildNode](../com.aspose.note/inotebookchildnode) | Stelt een kind van een Aspose.Note-notitieboek voor. |
+| [IOutlineChildNode](../com.aspose.note/ioutlinechildnode) | De interface voor alle onderliggende knooppunten van een outline‑knooppunt. |
+| [IOutlineElementChildNode](../com.aspose.note/ioutlineelementchildnode) | De interface voor alle onderliggende knooppunten van een outline‑elementknooppunt. |
+| [IPageChildNode](../com.aspose.note/ipagechildnode) | De interface voor alle onderliggende knooppunten van een paginaknooppunt. |
+| [IPageSavingCallback](../com.aspose.note/ipagesavingcallback) | Implementeer deze interface als u wilt bepalen hoe Aspose.Note afzonderlijke pagina's opslaat. |
+| [ITag](../com.aspose.note/itag) | De interface voor tags van alle soorten. |
+| [ITaggable](../com.aspose.note/itaggable) | De interface voor knooppunten die door tags gemarkeerd kunnen worden. |

--- a/netherlands/java/com.aspose.note/alwayssplitobjectsalgorithm/_index.md
+++ b/netherlands/java/com.aspose.note/alwayssplitobjectsalgorithm/_index.md
@@ -1,0 +1,27 @@
+---
+title: "AlwaysSplitObjectsAlgorithm"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Splitst een object in meerdere delen als het niet op de oorspronkelijke pagina past."
+type: docs
+weight: 10
+url: /nl/java/com.aspose.note/alwayssplitobjectsalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm)
+```
+public class AlwaysSplitObjectsAlgorithm extends PageSplittingAlgorithm
+```
+
+Split een object in meerdere delen als het niet op de oorspronkelijke pagina past.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [AlwaysSplitObjectsAlgorithm()](#AlwaysSplitObjectsAlgorithm--) |  |
+### AlwaysSplitObjectsAlgorithm() {#AlwaysSplitObjectsAlgorithm--}
+```
+public AlwaysSplitObjectsAlgorithm()
+```
+
+

--- a/netherlands/java/com.aspose.note/attachedfile/_index.md
+++ b/netherlands/java/com.aspose.note/attachedfile/_index.md
@@ -1,0 +1,497 @@
+---
+title: "AttachedFile"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een bijgevoegd bestand voor."
+type: docs
+weight: 11
+url: /nl/java/com.aspose.note/attachedfile/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node)
+
+**All Implemented Interfaces:**
+[com.aspose.note.IPageChildNode](../../com.aspose.note/ipagechildnode), [com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode), [com.aspose.note.ITaggable](../../com.aspose.note/itaggable)
+```
+public class AttachedFile extends Node implements IPageChildNode, IOutlineElementChildNode, ITaggable
+```
+
+Stelt een bijgevoegd bestand voor.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [AttachedFile(String path)](#AttachedFile-java.lang.String-) | Initialiseert een nieuw exemplaar van de `AttachedFile`-klasse. |
+| [AttachedFile(String path, InputStream icon, System.Drawing.Imaging.ImageFormat iconFormat)](#AttachedFile-java.lang.String-java.io.InputStream-com.aspose.ms.System.Drawing.Imaging.ImageFormat-) | Initialiseert een nieuw exemplaar van de `AttachedFile`-klasse. |
+| [AttachedFile(String fileName, InputStream attachedFileStream)](#AttachedFile-java.lang.String-java.io.InputStream-) | Initialiseert een nieuw exemplaar van de `AttachedFile`-klasse. |
+| [AttachedFile(String fileName, InputStream attachedFileStream, InputStream icon, System.Drawing.Imaging.ImageFormat iconFormat)](#AttachedFile-java.lang.String-java.io.InputStream-java.io.InputStream-com.aspose.ms.System.Drawing.Imaging.ImageFormat-) | Initialiseert een nieuw exemplaar van de `AttachedFile`-klasse. |
+| [AttachedFile()](#AttachedFile--) | Initialiseert een nieuw exemplaar van de `AttachedFile`-klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | Accepteert de bezoeker van de node. |
+| [getAlignment()](#getAlignment--) | Haalt de uitlijning op. |
+| [getAlternativeTextDescription()](#getAlternativeTextDescription--) | Haalt op of stelt een alternatieve tekst voor het pictogram van het bijgevoegde bestand in. |
+| [getAlternativeTextTitle()](#getAlternativeTextTitle--) | Haalt op of stelt een titel van alternatieve tekst voor het pictogram van het bijgevoegde bestand in. |
+| [getBytes()](#getBytes--) | Haalt de binaire gegevens op voor een ingebed bestand. |
+| [getExtension()](#getExtension--) | Haalt de extensie op van een ingebed bestand. |
+| [getFileName()](#getFileName--) | Haalt de naam op van een ingebed bestand. |
+| [getFilePath()](#getFilePath--) | Haalt het pad op naar het originele bestand. |
+| [getHeight()](#getHeight--) | Haalt de oorspronkelijke hoogte op van het pictogram van het ingebedde bestand. |
+| [getHorizontalOffset()](#getHorizontalOffset--) | Haalt de horizontale offset op. |
+| [getIcon()](#getIcon--) | Haalt de binaire gegevens op voor het pictogram dat is gekoppeld aan het ingebedde bestand. |
+| [getIconExtension()](#getIconExtension--) | Haalt de extensie op van het pictogram. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | Haalt de laatst gewijzigde tijd op. |
+| [getMaxHeight()](#getMaxHeight--) | Haalt de maximale hoogte op om het ingesloten bestandspictogram weer te geven. |
+| [getMaxWidth()](#getMaxWidth--) | Haalt de maximale breedte op om het ingesloten bestandspictogram weer te geven. |
+| [getParsingErrorInfo()](#getParsingErrorInfo--) | Haalt de gegevens over de fout op die optrad tijdens het openen van het bestand. |
+| [getTags()](#getTags--) | Haalt de lijst met tags van een bijgevoegd bestand op. |
+| [getText()](#getText--) | Haalt de tekstrepresentatie van het ingesloten bestand op. |
+| [getVerticalOffset()](#getVerticalOffset--) | Haalt de verticale offset op. |
+| [getWidth()](#getWidth--) | Haalt de oorspronkelijke breedte van het ingesloten bestandspictogram op. |
+| [isPrintout()](#isPrintout--) | Haalt een waarde op die aangeeft of de weergave van het bestand een afdruk is. |
+| [isSizeSetByUser()](#isSizeSetByUser--) | Haalt een waarde op die aangeeft of de grootte van het pictogram expliciet door de gebruiker is bijgewerkt. |
+| [setAlignment(int value)](#setAlignment-int-) | Stelt de uitlijning in. |
+| [setAlternativeTextDescription(String value)](#setAlternativeTextDescription-java.lang.String-) | Haalt op of stelt een alternatieve tekst voor het pictogram van het bijgevoegde bestand in. |
+| [setAlternativeTextTitle(String value)](#setAlternativeTextTitle-java.lang.String-) | Haalt op of stelt een titel van alternatieve tekst voor het pictogram van het bijgevoegde bestand in. |
+| [setHorizontalOffset(float value)](#setHorizontalOffset-float-) | Stelt de horizontale offset in. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | Stelt de laatst gewijzigde tijd in. |
+| [setMaxHeight(float value)](#setMaxHeight-float-) | Stelt de maximale hoogte in om het ingesloten bestandspictogram weer te geven. |
+| [setMaxWidth(float value)](#setMaxWidth-float-) | Stelt de maximale breedte in om het ingesloten bestandspictogram weer te geven. |
+| [setPrintout(boolean value)](#setPrintout-boolean-) | Stelt een waarde in die aangeeft of de weergave van het bestand een afdruk is. |
+| [setSizeSetByUser(boolean value)](#setSizeSetByUser-boolean-) | Stelt een waarde in die aangeeft of de grootte van het pictogram expliciet door de gebruiker is bijgewerkt. |
+| [setText(String value)](#setText-java.lang.String-) | Stelt de tekstrepresentatie van het ingesloten bestand in. |
+| [setVerticalOffset(float value)](#setVerticalOffset-float-) | Stelt de verticale offset in. |
+### AttachedFile(String path) {#AttachedFile-java.lang.String-}
+```
+public AttachedFile(String path)
+```
+
+
+Initialiseert een nieuw exemplaar van de `AttachedFile`-klasse.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| path | java.lang.String | Een tekenreeks die het pad bevat naar het bestand waaruit de `AttachedFile` moet worden gemaakt. |
+
+### AttachedFile(String path, InputStream icon, System.Drawing.Imaging.ImageFormat iconFormat) {#AttachedFile-java.lang.String-java.io.InputStream-com.aspose.ms.System.Drawing.Imaging.ImageFormat-}
+```
+public AttachedFile(String path, InputStream icon, System.Drawing.Imaging.ImageFormat iconFormat)
+```
+
+
+Initialiseert een nieuw exemplaar van de `AttachedFile`-klasse.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| path | java.lang.String | Een tekenreeks die het pad bevat naar het bestand waaruit de `AttachedFile` moet worden gemaakt. |
+| icon | java.io.InputStream | Een pictogram voor het bijgevoegde bestand. |
+| iconFormat | com.aspose.ms.System.Drawing.Imaging.ImageFormat |  |
+
+### AttachedFile(String fileName, InputStream attachedFileStream) {#AttachedFile-java.lang.String-java.io.InputStream-}
+```
+public AttachedFile(String fileName, InputStream attachedFileStream)
+```
+
+
+Initialiseert een nieuw exemplaar van de `AttachedFile`-klasse.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| fileName | java.lang.String | Een naam van het bijgevoegde bestand. |
+| attachedFileStream | java.io.InputStream | Een stream die de bytes van het bijgevoegde bestand bevat. |
+
+### AttachedFile(String fileName, InputStream attachedFileStream, InputStream icon, System.Drawing.Imaging.ImageFormat iconFormat) {#AttachedFile-java.lang.String-java.io.InputStream-java.io.InputStream-com.aspose.ms.System.Drawing.Imaging.ImageFormat-}
+```
+public AttachedFile(String fileName, InputStream attachedFileStream, InputStream icon, System.Drawing.Imaging.ImageFormat iconFormat)
+```
+
+
+Initialiseert een nieuw exemplaar van de `AttachedFile`-klasse.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| fileName | java.lang.String | Een naam van het bijgevoegde bestand. |
+| attachedFileStream | java.io.InputStream | Een stream die de bytes van het bijgevoegde bestand bevat. |
+| icon | java.io.InputStream | Een pictogram voor het bijgevoegde bestand. |
+| iconFormat | com.aspose.ms.System.Drawing.Imaging.ImageFormat | Een formaat van het pictogram van het bijgevoegde bestand. |
+
+### AttachedFile() {#AttachedFile--}
+```
+public AttachedFile()
+```
+
+
+Initialiseert een nieuw exemplaar van de `AttachedFile`-klasse.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+Accepteert de bezoeker van de node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | Het object van een klasse die afgeleid is van de `DocumentVisitor`. |
+
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+Haalt de uitlijning op.
+
+**Returns:**
+int
+### getAlternativeTextDescription() {#getAlternativeTextDescription--}
+```
+public final String getAlternativeTextDescription()
+```
+
+
+Haalt op of stelt een alternatieve tekst voor het pictogram van het bijgevoegde bestand in.
+
+**Returns:**
+java.lang.String
+### getAlternativeTextTitle() {#getAlternativeTextTitle--}
+```
+public final String getAlternativeTextTitle()
+```
+
+
+Haalt op of stelt een titel van alternatieve tekst voor het pictogram van het bijgevoegde bestand in.
+
+**Returns:**
+java.lang.String
+### getBytes() {#getBytes--}
+```
+public byte[] getBytes()
+```
+
+
+Haalt de binaire gegevens op voor een ingebed bestand.
+
+**Returns:**
+byte[]
+### getExtension() {#getExtension--}
+```
+public String getExtension()
+```
+
+
+Haalt de extensie op van een ingebed bestand.
+
+**Returns:**
+java.lang.String
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+Haalt de naam op van een ingebed bestand.
+
+**Returns:**
+java.lang.String
+### getFilePath() {#getFilePath--}
+```
+public String getFilePath()
+```
+
+
+Haalt het pad op naar het originele bestand.
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public float getHeight()
+```
+
+
+Haalt de oorspronkelijke hoogte op van het pictogram van het ingebedde bestand.
+
+**Returns:**
+float
+### getHorizontalOffset() {#getHorizontalOffset--}
+```
+public float getHorizontalOffset()
+```
+
+
+Haalt de horizontale offset op.
+
+**Returns:**
+float
+### getIcon() {#getIcon--}
+```
+public byte[] getIcon()
+```
+
+
+Haalt de binaire gegevens op voor het pictogram dat is gekoppeld aan het ingebedde bestand.
+
+**Returns:**
+byte[]
+### getIconExtension() {#getIconExtension--}
+```
+public String getIconExtension()
+```
+
+
+Haalt de extensie op van het pictogram.
+
+**Returns:**
+java.lang.String
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+Haalt de laatst gewijzigde tijd op.
+
+**Returns:**
+java.util.Date
+### getMaxHeight() {#getMaxHeight--}
+```
+public float getMaxHeight()
+```
+
+
+Haalt de maximale hoogte op om het ingesloten bestandspictogram weer te geven.
+
+**Returns:**
+float
+### getMaxWidth() {#getMaxWidth--}
+```
+public float getMaxWidth()
+```
+
+
+Haalt de maximale breedte op om het ingesloten bestandspictogram weer te geven.
+
+**Returns:**
+float
+### getParsingErrorInfo() {#getParsingErrorInfo--}
+```
+public final ParsingErrorInfo getParsingErrorInfo()
+```
+
+
+Haalt de gegevens over de fout op die optrad tijdens het openen van het bestand.
+
+**Returns:**
+[ParsingErrorInfo](../../com.aspose.note.infrastructure/parsingerrorinfo)
+### getTags() {#getTags--}
+```
+public final System.Collections.Generic.List<ITag> getTags()
+```
+
+
+Haalt de lijst met tags van een bijgevoegd bestand op.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List&lt;com.aspose.note.ITag&gt;
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+Haalt de tekstrepresentatie van het ingebedde bestand op. De string MAG GEEN tekens bevatten met de waarde 10 (regelvoeding) of 13 (carriage return).
+
+**Returns:**
+java.lang.String
+### getVerticalOffset() {#getVerticalOffset--}
+```
+public float getVerticalOffset()
+```
+
+
+Haalt de verticale offset op.
+
+**Returns:**
+float
+### getWidth() {#getWidth--}
+```
+public float getWidth()
+```
+
+
+Haalt de oorspronkelijke breedte van het ingesloten bestandspictogram op.
+
+**Returns:**
+float
+### isPrintout() {#isPrintout--}
+```
+public boolean isPrintout()
+```
+
+
+Haalt een waarde op die aangeeft of de weergave van het bestand een afdruk is.
+
+**Returns:**
+boolean
+### isSizeSetByUser() {#isSizeSetByUser--}
+```
+public boolean isSizeSetByUser()
+```
+
+
+Haalt een waarde op die aangeeft of de grootte van het pictogram expliciet door de gebruiker is bijgewerkt.
+
+**Returns:**
+boolean
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+Stelt de uitlijning in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int | Waarde van Alignment. |
+
+### setAlternativeTextDescription(String value) {#setAlternativeTextDescription-java.lang.String-}
+```
+public final void setAlternativeTextDescription(String value)
+```
+
+
+Haalt op of stelt een alternatieve tekst voor het pictogram van het bijgevoegde bestand in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+
+### setAlternativeTextTitle(String value) {#setAlternativeTextTitle-java.lang.String-}
+```
+public final void setAlternativeTextTitle(String value)
+```
+
+
+Haalt op of stelt een titel van alternatieve tekst voor het pictogram van het bijgevoegde bestand in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+
+### setHorizontalOffset(float value) {#setHorizontalOffset-float-}
+```
+public void setHorizontalOffset(float value)
+```
+
+
+Stelt de horizontale offset in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float | Waarde van Offsets. |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+Stelt de laatst gewijzigde tijd in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Date | Waarde van Date. |
+
+### setMaxHeight(float value) {#setMaxHeight-float-}
+```
+public void setMaxHeight(float value)
+```
+
+
+Stelt de maximale hoogte in om het ingesloten bestandspictogram weer te geven.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float | Waarde van Maximum height. |
+
+### setMaxWidth(float value) {#setMaxWidth-float-}
+```
+public void setMaxWidth(float value)
+```
+
+
+Stelt de maximale breedte in om het ingesloten bestandspictogram weer te geven.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float | Waarde van Maximum width. |
+
+### setPrintout(boolean value) {#setPrintout-boolean-}
+```
+public void setPrintout(boolean value)
+```
+
+
+Stelt een waarde in die aangeeft of de weergave van het bestand een afdruk is.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean | Nieuwe waarde. |
+
+### setSizeSetByUser(boolean value) {#setSizeSetByUser-boolean-}
+```
+public void setSizeSetByUser(boolean value)
+```
+
+
+Stelt een waarde in die aangeeft of de grootte van het pictogram expliciet door de gebruiker is bijgewerkt.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean | Nieuwe waarde. |
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public void setText(String value)
+```
+
+
+Stelt de tekstrepresentatie van het ingebedde bestand in. De string MAG GEEN tekens bevatten met de waarde 10 (regelvoeding) of 13 (carriage return).
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String | Waarde van Text. |
+
+### setVerticalOffset(float value) {#setVerticalOffset-float-}
+```
+public void setVerticalOffset(float value)
+```
+
+
+Stelt de verticale offset in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float | Waarde van Offset. |
+

--- a/netherlands/java/com.aspose.note/binarizationmethod/_index.md
+++ b/netherlands/java/com.aspose.note/binarizationmethod/_index.md
@@ -1,0 +1,38 @@
+---
+title: "BinarizationMethod"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Specificeert de binarisatiemethode voor een afbeelding."
+type: docs
+weight: 12
+url: /nl/java/com.aspose.note/binarizationmethod/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class BinarizationMethod extends System.Enum
+```
+
+Specificeert de binarisatiemethode voor een afbeelding.
+## Velden
+
+| Veld | Beschrijving |
+| --- | --- |
+| [FixedThreshold](#FixedThreshold) | De binarisatie van de afbeelding wordt uitgevoerd met een opgegeven vaste drempel. |
+| [Otsu](#Otsu) | De binarisatie van de afbeelding wordt adaptief uitgevoerd met behulp van de Otsu-methode om de drempel te evalueren. |
+### FixedThreshold {#FixedThreshold}
+```
+public static final int FixedThreshold
+```
+
+
+De binarisatie van de afbeelding wordt uitgevoerd met een opgegeven vaste drempel.
+
+### Otsu {#Otsu}
+```
+public static final int Otsu
+```
+
+
+De binarisatie van de afbeelding wordt adaptief uitgevoerd met behulp van de Otsu-methode om de drempel te evalueren.
+

--- a/netherlands/java/com.aspose.note/checkbox/_index.md
+++ b/netherlands/java/com.aspose.note/checkbox/_index.md
@@ -1,0 +1,131 @@
+---
+title: "CheckBox"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De basisklasse voor tags die hun status kunnen schakelen tussen voltooid en onvoltooid."
+type: docs
+weight: 13
+url: /nl/java/com.aspose.note/checkbox/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.note.TagExtended
+```
+public abstract class CheckBox extends TagExtended
+```
+
+De basisklasse voor tags die hun status kunnen schakelen tussen voltooid en onvoltooid.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getChecked()](#getChecked--) | Haalt een waarde op die aangeeft of de CheckBox zich in de aangevinkte toestand bevindt. |
+| [getCompletedTime()](#getCompletedTime--) | Haalt het voltooid tijdstip op of stelt het in. |
+| [getCreationTime()](#getCreationTime--) | Haalt het aanmaaktijdstip op of stelt het in. |
+| [getIcon()](#getIcon--) | Haalt het pictogram op of stelt dit in. |
+| [getStatus()](#getStatus--) | Haalt de status op of stelt deze in. |
+| [setCompleted()](#setCompleted--) | Stelt de tag in op de voltooide status met gebruik van de huidige tijd als voltooid tijdstip. |
+| [setCompleted(Date completedTime)](#setCompleted-java.util.Date-) | Stelt de tag in op de voltooide status. |
+| [setCreationTime(Date value)](#setCreationTime-java.util.Date-) | Haalt het aanmaaktijdstip op of stelt het in. |
+| [setOpen()](#setOpen--) | Stelt de tag in op open status. |
+### getChecked() {#getChecked--}
+```
+public final boolean getChecked()
+```
+
+
+Haalt een waarde op die aangeeft of de CheckBox zich in de aangevinkte toestand bevindt.
+
+**Returns:**
+boolean
+### getCompletedTime() {#getCompletedTime--}
+```
+public final Date getCompletedTime()
+```
+
+
+Haalt het voltooid tijdstip op of stelt het in.
+
+Waarde: De `Nullable{DateTime}`.
+
+**Returns:**
+java.util.Date
+### getCreationTime() {#getCreationTime--}
+```
+public final Date getCreationTime()
+```
+
+
+Haalt het aanmaaktijdstip op of stelt het in.
+
+Waarde: De java.util.Date.
+
+**Returns:**
+java.util.Date
+### getIcon() {#getIcon--}
+```
+public abstract int getIcon()
+```
+
+
+Haalt het pictogram op of stelt dit in.
+
+Waarde: De [TagIcon](../../com.aspose.note.infrastructure/tagicon).
+
+**Returns:**
+int
+### getStatus() {#getStatus--}
+```
+public final int getStatus()
+```
+
+
+Haalt de status op of stelt deze in.
+
+Waarde: De [TagStatus](../../com.aspose.note/tagstatus).
+
+**Returns:**
+int
+### setCompleted() {#setCompleted--}
+```
+public final void setCompleted()
+```
+
+
+Stelt de tag in op de voltooide status met gebruik van de huidige tijd als voltooid tijdstip.
+
+### setCompleted(Date completedTime) {#setCompleted-java.util.Date-}
+```
+public final void setCompleted(Date completedTime)
+```
+
+
+Stelt de tag in op de voltooide status.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| completedTime | java.util.Date | De voltooide tijd. |
+
+### setCreationTime(Date value) {#setCreationTime-java.util.Date-}
+```
+public final void setCreationTime(Date value)
+```
+
+
+Haalt het aanmaaktijdstip op of stelt het in.
+
+Waarde: De java.util.Date.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Date |  |
+
+### setOpen() {#setOpen--}
+```
+public void setOpen()
+```
+
+
+Stelt de tag in op open status.
+

--- a/netherlands/java/com.aspose.note/colormode/_index.md
+++ b/netherlands/java/com.aspose.note/colormode/_index.md
@@ -1,0 +1,47 @@
+---
+title: "ColorMode"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De kleermodus van de afbeelding."
+type: docs
+weight: 14
+url: /nl/java/com.aspose.note/colormode/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class ColorMode extends System.Enum
+```
+
+De kleermodus van de afbeelding.
+## Velden
+
+| Veld | Beschrijving |
+| --- | --- |
+| [BlackAndWhite](#BlackAndWhite) | Binaire afbeelding: alleen zwart-witte kleuren worden gebruikt |
+| [GrayScale](#GrayScale) | Grijswaardenafbeelding |
+| [Normal](#Normal) | Volle kleurafbeelding |
+### BlackAndWhite {#BlackAndWhite}
+```
+public static final int BlackAndWhite
+```
+
+
+Binaire afbeelding: alleen zwart-witte kleuren worden gebruikt
+
+### GrayScale {#GrayScale}
+```
+public static final int GrayScale
+```
+
+
+Grijswaardenafbeelding
+
+### Normal {#Normal}
+```
+public static final int Normal
+```
+
+
+Volle kleurafbeelding
+

--- a/netherlands/java/com.aspose.note/compositenode/_index.md
+++ b/netherlands/java/com.aspose.note/compositenode/_index.md
@@ -1,0 +1,198 @@
+---
+title: "CompositeNode"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De basisgenerieke klasse voor knooppunten die andere knooppunten kunnen bevatten."
+type: docs
+weight: 15
+url: /nl/java/com.aspose.note/compositenode/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase)
+
+**All Implemented Interfaces:**
+com.aspose.note.ICompositeNodeT
+```
+public abstract class CompositeNode<T> extends CompositeNodeBase implements ICompositeNodeT<T>
+```
+
+De basisgenerieke klasse voor knooppunten die andere knooppunten kunnen bevatten.
+
+`T`: Het type elementen in het samengestelde knooppunt.
+
+T :
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [&lt;T1&gt;appendChildFirst(T1 newChild)](#-T1-appendChildFirst-T1-) | Voegt het knooppunt toe aan het begin van de lijst met onderliggende knooppunten voor dit knooppunt. |
+| [&lt;T1&gt;appendChildLast(T1 newChild)](#-T1-appendChildLast-T1-) | Voegt het knooppunt toe aan het einde van de lijst met onderliggende knooppunten voor dit knooppunt. |
+| [&lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass)](#-T1-getChildNodes-java.lang.Class-T1--) | Haalt alle kindknopen op op basis van het knooptype. |
+| [&lt;T1&gt;insertChild(int i, T1 newChild)](#-T1-insertChild-int-T1-) | Voegt het knooppunt in op de opgegeven positie in de lijst met onderliggende knooppunten voor dit knooppunt. |
+| [&lt;T1&gt;removeChild(T1 oldChild)](#-T1-removeChild-T1-) | Verwijdert de kindknoop. |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | Accepteert de bezoeker van de node. |
+| [getFirstChild()](#getFirstChild--) | Haalt het eerste onderliggende knooppunt van dit knooppunt op. |
+| [getLastChild()](#getLastChild--) | Haalt het laatste onderliggende knooppunt van dit knooppunt op. |
+| [insertChildrenRange(int i, T[] newChildren)](#insertChildrenRange-int-T...-) | Voegt de reeks knooppunten in, beginnend vanaf de opgegeven positie in de lijst met onderliggende knooppunten voor dit knooppunt. |
+| [insertChildrenRange(int i, Iterable&lt;T&gt; newChildren)](#insertChildrenRange-int-java.lang.Iterable-T--) | Voegt de reeks knooppunten in, beginnend vanaf de opgegeven positie in de lijst met onderliggende knooppunten voor dit knooppunt. |
+| [isComposite()](#isComposite--) | Controleert of het knooppunt samengesteld is. |
+| [iterator()](#iterator--) | Retourneert een enumerator die door de onderliggende knooppunten van de `CompositeNode\{T\}` itereren. |
+### &lt;T1&gt;appendChildFirst(T1 newChild) {#-T1-appendChildFirst-T1-}
+```
+public T1 <T1>appendChildFirst(T1 newChild)
+```
+
+
+Voegt het knooppunt toe aan het begin van de lijst met onderliggende knooppunten voor dit knooppunt.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| newChild | T1 | Het toe te voegen knooppunt. |
+
+**Returns:**
+T1 - Het toegevoegde knooppunt.
+### &lt;T1&gt;appendChildLast(T1 newChild) {#-T1-appendChildLast-T1-}
+```
+public T1 <T1>appendChildLast(T1 newChild)
+```
+
+
+Voegt het knooppunt toe aan het einde van de lijst met onderliggende knooppunten voor dit knooppunt.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| newChild | T1 | Het toe te voegen knooppunt. |
+
+**Returns:**
+T1 - Het toegevoegde knooppunt.
+### &lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass) {#-T1-getChildNodes-java.lang.Class-T1--}
+```
+public List<T1> <T1>getChildNodes(Class<T1> typeParameterClass)
+```
+
+
+Haalt alle kindknopen op op basis van het knooptype.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| typeParameterClass | java.lang.Class&lt;T1&gt; |  |
+
+**Returns:**
+java.util.List&lt;T1&gt; - Een lijst van kindknooppunten.
+
+`T1`: Het type van elementen in de geretourneerde lijst.
+### &lt;T1&gt;insertChild(int i, T1 newChild) {#-T1-insertChild-int-T1-}
+```
+public T1 <T1>insertChild(int i, T1 newChild)
+```
+
+
+Voegt het knooppunt in op de opgegeven positie in de lijst met onderliggende knooppunten voor dit knooppunt.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| i | int | Positie om in te voegen |
+| newChild | T1 | Het knooppunt om in te voegen. |
+
+**Returns:**
+T1 - Het toegevoegde knooppunt.
+### &lt;T1&gt;removeChild(T1 oldChild) {#-T1-removeChild-T1-}
+```
+public T1 <T1>removeChild(T1 oldChild)
+```
+
+
+Verwijdert de kindknoop.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| oldChild | T1 | Het te verwijderen knooppunt. |
+
+**Returns:**
+T1 - Het verwijderde knooppunt.
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+Accepteert de bezoeker van de node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | Het object van een klasse die afgeleid is van de `DocumentVisitor`. |
+
+### getFirstChild() {#getFirstChild--}
+```
+public T getFirstChild()
+```
+
+
+Haalt het eerste onderliggende knooppunt van dit knooppunt op.
+
+**Returns:**
+T
+### getLastChild() {#getLastChild--}
+```
+public T getLastChild()
+```
+
+
+Haalt het laatste onderliggende knooppunt van dit knooppunt op.
+
+**Returns:**
+T
+### insertChildrenRange(int i, T[] newChildren) {#insertChildrenRange-int-T...-}
+```
+public final void insertChildrenRange(int i, T[] newChildren)
+```
+
+
+Voegt de reeks knooppunten in, beginnend vanaf de opgegeven positie in de lijst met onderliggende knooppunten voor dit knooppunt.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| i | int | Positie om in te voegen |
+| newChildren | T[] | De reeks knooppunten die ingevoegd moet worden. |
+
+### insertChildrenRange(int i, Iterable&lt;T&gt; newChildren) {#insertChildrenRange-int-java.lang.Iterable-T--}
+```
+public final void insertChildrenRange(int i, Iterable<T> newChildren)
+```
+
+
+Voegt de reeks knooppunten in, beginnend vanaf de opgegeven positie in de lijst met onderliggende knooppunten voor dit knooppunt.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| i | int | Positie om in te voegen |
+| newChildren | java.lang.Iterable&lt;T&gt; | De reeks knooppunten die ingevoegd moet worden. |
+
+### isComposite() {#isComposite--}
+```
+public final boolean isComposite()
+```
+
+
+Controleert of het knooppunt samengesteld is. Indien waar kan het knooppunt onderliggende knooppunten hebben.
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public System.Collections.Generic.IGenericEnumerator<T> iterator()
+```
+
+
+Retourneert een enumerator die door de onderliggende knooppunten van de `CompositeNode\{T\}` itereren.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;T&gt; - Een `T:IEnumerator`1` voor de `CompositeNode\{T\}`.

--- a/netherlands/java/com.aspose.note/compositenodebase/_index.md
+++ b/netherlands/java/com.aspose.note/compositenodebase/_index.md
@@ -1,0 +1,19 @@
+---
+title: "CompositeNodeBase"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De niet-generieke klasse voor knooppunten die andere knooppunten kunnen bevatten."
+type: docs
+weight: 16
+url: /nl/java/com.aspose.note/compositenodebase/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node)
+
+**All Implemented Interfaces:**
+[com.aspose.note.ICompositeNode](../../com.aspose.note/icompositenode)
+```
+public abstract class CompositeNodeBase extends Node implements ICompositeNode
+```
+
+De niet-generieke klasse voor knooppunten die andere knooppunten kunnen bevatten.

--- a/netherlands/java/com.aspose.note/csssavingargs/_index.md
+++ b/netherlands/java/com.aspose.note/csssavingargs/_index.md
@@ -1,0 +1,16 @@
+---
+title: "CssSavingArgs"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Levert gegevens voor het CssSaving evenement."
+type: docs
+weight: 17
+url: /nl/java/com.aspose.note/csssavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ResourceSavingArgs](../../com.aspose.note/resourcesavingargs)
+```
+public class CssSavingArgs extends ResourceSavingArgs
+```
+
+Levert gegevens voor het CssSaving evenement.

--- a/netherlands/java/com.aspose.note/defaultmsonenotevaluesaccessor/_index.md
+++ b/netherlands/java/com.aspose.note/defaultmsonenotevaluesaccessor/_index.md
@@ -1,0 +1,62 @@
+---
+title: "DefaultMsOneNoteValuesAccessor"
+second_title: "Aspose.Note for Java API-referentie"
+description: 
+type: docs
+weight: 18
+url: /nl/java/com.aspose.note/defaultmsonenotevaluesaccessor/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.internals.Accessor](../../com.aspose.note.internals/accessor)
+```
+public class DefaultMsOneNoteValuesAccessor extends Accessor
+```
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [DefaultMsOneNoteValuesAccessor()](#DefaultMsOneNoteValuesAccessor--) |  |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getDefaultFontColor()](#getDefaultFontColor--) |  |
+| [getDefaultFontFamily()](#getDefaultFontFamily--) |  |
+| [getDefaultFontSizeInPoints()](#getDefaultFontSizeInPoints--) |  |
+### DefaultMsOneNoteValuesAccessor() {#DefaultMsOneNoteValuesAccessor--}
+```
+public DefaultMsOneNoteValuesAccessor()
+```
+
+
+### getDefaultFontColor() {#getDefaultFontColor--}
+```
+public static System.Drawing.Color getDefaultFontColor()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Drawing.Color
+### getDefaultFontFamily() {#getDefaultFontFamily--}
+```
+public static String getDefaultFontFamily()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getDefaultFontSizeInPoints() {#getDefaultFontSizeInPoints--}
+```
+public static int getDefaultFontSizeInPoints()
+```
+
+
+
+
+**Returns:**
+int

--- a/netherlands/java/com.aspose.note/displayunitsconverter/_index.md
+++ b/netherlands/java/com.aspose.note/displayunitsconverter/_index.md
@@ -1,0 +1,118 @@
+---
+title: "DisplayUnitsConverter"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De klasse bevat de methoden voor het converteren van waarden."
+type: docs
+weight: 19
+url: /nl/java/com.aspose.note/displayunitsconverter/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DisplayUnitsConverter
+```
+
+De klasse bevat de methoden voor het converteren van waarden.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [inchToPoint(float inches)](#inchToPoint-float-) | Converteert inches naar punten. |
+| [millimeterToInch(float mm)](#millimeterToInch-float-) | Converteert millimeters naar inches. |
+| [millimeterToPoint(float mm)](#millimeterToPoint-float-) | Converteert millimeters naar punten. |
+| [pixelToPoint(int pixels, float dpi)](#pixelToPoint-int-float-) | Converteert pixels naar punten met de opgegeven pixelresolutie. |
+| [pointToInch(float points)](#pointToInch-float-) | Converteert punten naar inches. |
+| [pointToPixel(float points, float dpi)](#pointToPixel-float-float-) | Converteert punten naar pixels met de opgegeven pixelresolutie. |
+### inchToPoint(float inches) {#inchToPoint-float-}
+```
+public static float inchToPoint(float inches)
+```
+
+
+Converteert inches naar punten.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| inches | float | De waarde om te converteren in inches. |
+
+**Returns:**
+float - De `float`.
+### millimeterToInch(float mm) {#millimeterToInch-float-}
+```
+public static float millimeterToInch(float mm)
+```
+
+
+Converteert millimeters naar inches.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| mm | float | De waarde om te converteren in millimeters. |
+
+**Returns:**
+float - De `float`.
+### millimeterToPoint(float mm) {#millimeterToPoint-float-}
+```
+public static float millimeterToPoint(float mm)
+```
+
+
+Converteert millimeters naar punten.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| mm | float | De waarde om te converteren in millimeters. |
+
+**Returns:**
+float - De `float`.
+### pixelToPoint(int pixels, float dpi) {#pixelToPoint-int-float-}
+```
+public static float pixelToPoint(int pixels, float dpi)
+```
+
+
+Converteert pixels naar punten met de opgegeven pixelresolutie.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| pixels | int | De waarde om te converteren in pixels. |
+| dpi | float | Schermresolutie. |
+
+**Returns:**
+float - De `int`.
+### pointToInch(float points) {#pointToInch-float-}
+```
+public static float pointToInch(float points)
+```
+
+
+Converteert punten naar inches.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| punten | float | De waarde om te converteren in punten. |
+
+**Returns:**
+float - De `float`.
+### pointToPixel(float points, float dpi) {#pointToPixel-float-float-}
+```
+public static int pointToPixel(float points, float dpi)
+```
+
+
+Converteert punten naar pixels met de opgegeven pixelresolutie.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| punten | float | De waarde om te converteren in punten. |
+| dpi | float | Schermresolutie. |
+
+**Returns:**
+int - De `int`.

--- a/netherlands/java/com.aspose.note/document/_index.md
+++ b/netherlands/java/com.aspose.note/document/_index.md
@@ -1,0 +1,511 @@
+---
+title: "Document"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een Aspose.Note-document voor."
+type: docs
+weight: 20
+url: /nl/java/com.aspose.note/document/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode
+
+**All Implemented Interfaces:**
+[com.aspose.note.INotebookChildNode](../../com.aspose.note/inotebookchildnode)
+```
+public class Document extends CompositeNode<Page> implements INotebookChildNode
+```
+
+Stelt een Aspose.Note-document voor.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [Document()](#Document--) | Initialiseert een nieuw exemplaar van de `Document` klasse. |
+| [Document(String filePath)](#Document-java.lang.String-) | Initialiseert een nieuw exemplaar van de `Document` klasse. |
+| [Document(String filePath, LoadOptions loadOptions)](#Document-java.lang.String-com.aspose.note.LoadOptions-) | Initialiseert een nieuw exemplaar van de `Document` klasse. |
+| [Document(InputStream inStream)](#Document-java.io.InputStream-) | Initialiseert een nieuw exemplaar van de `Document` klasse. |
+| [Document(InputStream inStream, LoadOptions loadOptions)](#Document-java.io.InputStream-com.aspose.note.LoadOptions-) | Initialiseert een nieuw exemplaar van de `Document` klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | Accepteert de bezoeker van de node. |
+| [detectLayoutChanges()](#detectLayoutChanges--) | Detecteert alle wijzigingen die zijn aangebracht in de documentindeling sinds de vorige `DetectLayoutChanges` oproep. |
+| [getAutomaticLayoutChangesDetectionEnabled()](#getAutomaticLayoutChangesDetectionEnabled--) | Haalt een waarde op die aangeeft of Aspose.Note automatisch detectie van indelingswijzigingen uitvoert. |
+| [getColor()](#getColor--) | Haalt de kleur op. |
+| [getCreationTime()](#getCreationTime--) | Haalt de creatietijd op. |
+| [getDisplayName()](#getDisplayName--) | Haalt de weergavenaam op. |
+| [getFileFormat()](#getFileFormat--) | Haalt het bestandsformaat op (OneNote 2010, OneNote Online). |
+| [getGuid()](#getGuid--) | Haalt de wereldwijd unieke id van het object op. |
+| [getGuidInternal()](#getGuidInternal--) |  |
+| [getPageHistory(Page page)](#getPageHistory-com.aspose.note.Page-) | Haalt de `PageHistory` op die de volledige geschiedenis bevat voor elke pagina die in een document wordt gepresenteerd (de vroegste op index 0). |
+| [isEncrypted(InputStream stream, Document[] document)](#isEncrypted-java.io.InputStream-com.aspose.note.Document---) | Controleert of een document uit een stream versleuteld is. |
+| [isEncrypted(InputStream stream, LoadOptions options, Document[] document)](#isEncrypted-java.io.InputStream-com.aspose.note.LoadOptions-com.aspose.note.Document---) | Controleert of een document uit een stream versleuteld is. |
+| [isEncrypted(InputStream stream, String password, Document[] document)](#isEncrypted-java.io.InputStream-java.lang.String-com.aspose.note.Document---) | Controleert of een document uit een stream versleuteld is. |
+| [isEncrypted(String filePath, Document[] document)](#isEncrypted-java.lang.String-com.aspose.note.Document---) | Controleert of een document uit een bestand versleuteld is. |
+| [isEncrypted(String filePath, LoadOptions options, Document[] document)](#isEncrypted-java.lang.String-com.aspose.note.LoadOptions-com.aspose.note.Document---) | Controleert of een document uit een bestand versleuteld is. |
+| [isEncrypted(String filePath, String password, Document[] document)](#isEncrypted-java.lang.String-java.lang.String-com.aspose.note.Document---) | Controleert of een document uit een bestand versleuteld is. |
+| [print()](#print--) | Print het document met de standaardprinter. |
+| [print(PrintOptions options)](#print-com.aspose.note.PrintOptions-) | Print het document met de standaardprinter. |
+| [print(String printerName)](#print-java.lang.String-) | Print het document met de standaardprinter. |
+| [print(AttributeSet printSettings)](#print-javax.print.attribute.AttributeSet-) | Print het document met de standaardprinter. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Slaat het OneNote-document op naar een stream. |
+| [save(OutputStream stream, SaveOptions options)](#save-java.io.OutputStream-com.aspose.note.SaveOptions-) | Slaat het OneNote-document op naar een stream met de opgegeven opslagopties. |
+| [save(OutputStream stream, int format)](#save-java.io.OutputStream-int-) | Slaat het OneNote-document op naar een stream in het opgegeven formaat. |
+| [save(String fileName)](#save-java.lang.String-) | Slaat het OneNote-document op naar een bestand. |
+| [save(String fileName, SaveOptions options)](#save-java.lang.String-com.aspose.note.SaveOptions-) | Slaat het OneNote-document op naar een bestand met de opgegeven opslagopties. |
+| [save(String fileName, int format)](#save-java.lang.String-int-) | Slaat het OneNote-document op naar een bestand in het opgegeven formaat. |
+| [setAutomaticLayoutChangesDetectionEnabled(boolean value)](#setAutomaticLayoutChangesDetectionEnabled-boolean-) | Stelt een waarde in die aangeeft of Aspose.Note automatisch detectie van lay-outwijzigingen uitvoert. |
+| [setColor(Color value)](#setColor-java.awt.Color-) | Stelt de kleur in. |
+| [setCreationTime(Date value)](#setCreationTime-java.util.Date-) | Stelt de creatietijd in. |
+| [setDisplayName(String value)](#setDisplayName-java.lang.String-) | Stelt de weergavenaam in. |
+### Document() {#Document--}
+```
+public Document()
+```
+
+
+Initialiseert een nieuw exemplaar van de `Document` klasse. Maakt een leeg OneNote-document aan.
+
+### Document(String filePath) {#Document-java.lang.String-}
+```
+public Document(String filePath)
+```
+
+
+Initialiseert een nieuw exemplaar van de `Document` klasse. Opent een bestaand OneNote-document uit een bestand.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| filePath | java.lang.String | Het bestandspad. |
+
+### Document(String filePath, LoadOptions loadOptions) {#Document-java.lang.String-com.aspose.note.LoadOptions-}
+```
+public Document(String filePath, LoadOptions loadOptions)
+```
+
+
+Initialiseert een nieuw exemplaar van de `Document` klasse. Opent een bestaand OneNote-document uit een bestand. Stelt toe om extra opties op te geven, zoals een encryptiewachtwoord.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| filePath | java.lang.String | Het bestandspad. |
+| loadOptions | [LoadOptions](../../com.aspose.note/loadoptions) | Opties die worden gebruikt om een document te laden. Kan null zijn. |
+
+### Document(InputStream inStream) {#Document-java.io.InputStream-}
+```
+public Document(InputStream inStream)
+```
+
+
+Initialiseert een nieuw exemplaar van de `Document` klasse. Opent een bestaand OneNote-document uit een stream.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| inStream | java.io.InputStream | De stream. |
+
+### Document(InputStream inStream, LoadOptions loadOptions) {#Document-java.io.InputStream-com.aspose.note.LoadOptions-}
+```
+public Document(InputStream inStream, LoadOptions loadOptions)
+```
+
+
+Initialiseert een nieuw exemplaar van de `Document` klasse. Opent een bestaand OneNote-document uit een stream. Stelt toe om extra opties op te geven, zoals een encryptiewachtwoord.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| inStream | java.io.InputStream | De stream. |
+| loadOptions | [LoadOptions](../../com.aspose.note/loadoptions) | Opties die worden gebruikt om een document te laden. Kan null zijn. |
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+Accepteert de bezoeker van de node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | Het object van een klasse die afgeleid is van de `DocumentVisitor`. |
+
+### detectLayoutChanges() {#detectLayoutChanges--}
+```
+public void detectLayoutChanges()
+```
+
+
+Detecteert alle wijzigingen die zijn aangebracht in de documentlay-out sinds de vorige `DetectLayoutChanges`-aanroep. In het geval dat `AutomaticLayoutChangesDetectionEnabled` op true is ingesteld, wordt dit automatisch gebruikt aan het begin van de documentexport.
+
+### getAutomaticLayoutChangesDetectionEnabled() {#getAutomaticLayoutChangesDetectionEnabled--}
+```
+public boolean getAutomaticLayoutChangesDetectionEnabled()
+```
+
+
+Haalt een waarde op die aangeeft of Aspose.Note automatisch detectie van lay-outwijzigingen uitvoert. Standaardwaarde is `true`.
+
+**Returns:**
+boolean
+### getColor() {#getColor--}
+```
+public Color getColor()
+```
+
+
+Haalt de kleur op.
+
+**Returns:**
+java.awt.Color
+### getCreationTime() {#getCreationTime--}
+```
+public Date getCreationTime()
+```
+
+
+Haalt de creatietijd op.
+
+**Returns:**
+java.util.Date
+### getDisplayName() {#getDisplayName--}
+```
+public String getDisplayName()
+```
+
+
+Haalt de weergavenaam op.
+
+**Returns:**
+java.lang.String
+### getFileFormat() {#getFileFormat--}
+```
+public int getFileFormat()
+```
+
+
+Haalt het bestandsformaat op (OneNote 2010, OneNote Online).
+
+**Returns:**
+int
+### getGuid() {#getGuid--}
+```
+public UUID getGuid()
+```
+
+
+Haalt de wereldwijd unieke id van het object op.
+
+**Returns:**
+java.util.UUID
+### getGuidInternal() {#getGuidInternal--}
+```
+public System.Guid getGuidInternal()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Guid
+### getPageHistory(Page page) {#getPageHistory-com.aspose.note.Page-}
+```
+public PageHistory getPageHistory(Page page)
+```
+
+
+Haalt de `PageHistory` op die de volledige geschiedenis bevat voor elke pagina die in een document wordt gepresenteerd (de vroegste op index 0). De huidige paginarevisie kan worden benaderd als `PageHistory.current` en staat apart van de verzameling historische versies.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.note/page) | De huidige revisie van een pagina. |
+
+**Returns:**
+[PageHistory](../../com.aspose.note/pagehistory) - The `PageHistory`.
+### isEncrypted(InputStream stream, Document[] document) {#isEncrypted-java.io.InputStream-com.aspose.note.Document---}
+```
+public static boolean isEncrypted(InputStream stream, Document[] document)
+```
+
+
+Controleert of een document uit een stream versleuteld is. Om dit te controleren moeten we dit document volledig laden. Daarom kan deze methode leiden tot een prestatieverlies.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| stroom | java.io.InputStream | De stream. |
+| document | [Document\[\]](../../com.aspose.note/document) | Het geladen document. |
+
+**Returns:**
+boolean - Retourneert true als het document versleuteld is, anders false.
+### isEncrypted(InputStream stream, LoadOptions options, Document[] document) {#isEncrypted-java.io.InputStream-com.aspose.note.LoadOptions-com.aspose.note.Document---}
+```
+public static boolean isEncrypted(InputStream stream, LoadOptions options, Document[] document)
+```
+
+
+Controleert of een document uit een stream versleuteld is. Om dit te controleren moeten we dit document volledig laden. Daarom kan deze methode leiden tot een prestatieverlies.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| stroom | java.io.InputStream | De stream. |
+| options | [LoadOptions](../../com.aspose.note/loadoptions) | De laadopties. |
+| document | [Document\[\]](../../com.aspose.note/document) | Het geladen document. |
+
+**Returns:**
+boolean - Retourneert true als het document versleuteld is, anders false.
+### isEncrypted(InputStream stream, String password, Document[] document) {#isEncrypted-java.io.InputStream-java.lang.String-com.aspose.note.Document---}
+```
+public static boolean isEncrypted(InputStream stream, String password, Document[] document)
+```
+
+
+Controleert of een document uit een stream versleuteld is. Om dit te controleren moeten we dit document volledig laden. Daarom kan deze methode leiden tot een prestatieverlies.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| stroom | java.io.InputStream | De stream. |
+| password | java.lang.String | Het wachtwoord om een document te ontsleutelen. |
+| document | [Document\[\]](../../com.aspose.note/document) | Het geladen document. |
+
+**Returns:**
+boolean - Retourneert true als het document versleuteld is, anders false.
+### isEncrypted(String filePath, Document[] document) {#isEncrypted-java.lang.String-com.aspose.note.Document---}
+```
+public static boolean isEncrypted(String filePath, Document[] document)
+```
+
+
+Controleert of een document uit een bestand versleuteld is. Om dit te controleren moeten we dit document volledig laden. Daarom kan deze methode leiden tot een prestatieverlies.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| filePath | java.lang.String | Het bestandspad. |
+| document | [Document\[\]](../../com.aspose.note/document) | Het geladen document. |
+
+**Returns:**
+boolean - Retourneert true als het document versleuteld is, anders false.
+### isEncrypted(String filePath, LoadOptions options, Document[] document) {#isEncrypted-java.lang.String-com.aspose.note.LoadOptions-com.aspose.note.Document---}
+```
+public static boolean isEncrypted(String filePath, LoadOptions options, Document[] document)
+```
+
+
+Controleert of een document uit een bestand versleuteld is. Om dit te controleren moeten we dit document volledig laden. Daarom kan deze methode leiden tot een prestatieverlies.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| filePath | java.lang.String | Het bestandspad. |
+| options | [LoadOptions](../../com.aspose.note/loadoptions) | De laadopties. |
+| document | [Document\[\]](../../com.aspose.note/document) | Het geladen document. |
+
+**Returns:**
+boolean - Retourneert true als het document versleuteld is, anders false.
+### isEncrypted(String filePath, String password, Document[] document) {#isEncrypted-java.lang.String-java.lang.String-com.aspose.note.Document---}
+```
+public static boolean isEncrypted(String filePath, String password, Document[] document)
+```
+
+
+Controleert of een document uit een bestand versleuteld is. Om dit te controleren moeten we dit document volledig laden. Daarom kan deze methode leiden tot een prestatieverlies.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| filePath | java.lang.String | Het bestandspad. |
+| password | java.lang.String | Het wachtwoord om een document te ontsleutelen. |
+| document | [Document\[\]](../../com.aspose.note/document) | Het geladen document. |
+
+**Returns:**
+boolean - Retourneert true als het document versleuteld is, anders false.
+### print() {#print--}
+```
+public void print()
+```
+
+
+Print het document met de standaardprinter.
+
+### print(PrintOptions options) {#print-com.aspose.note.PrintOptions-}
+```
+public void print(PrintOptions options)
+```
+
+
+Print het document met de standaardprinter.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| options | [PrintOptions](../../com.aspose.note/printoptions) | Opties die worden gebruikt om een document af te drukken. Kan null zijn. |
+
+### print(String printerName) {#print-java.lang.String-}
+```
+public void print(String printerName)
+```
+
+
+Print het document met de standaardprinter.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| printerName | java.lang.String |  |
+
+### print(AttributeSet printSettings) {#print-javax.print.attribute.AttributeSet-}
+```
+public void print(AttributeSet printSettings)
+```
+
+
+Print het document met de standaardprinter.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| printSettings | javax.print.attribute.AttributeSet |  |
+
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Slaat het OneNote-document op naar een stream.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| stroom | java.io.OutputStream | De System.iO.stream waar het document wordt opgeslagen. |
+
+### save(OutputStream stream, SaveOptions options) {#save-java.io.OutputStream-com.aspose.note.SaveOptions-}
+```
+public void save(OutputStream stream, SaveOptions options)
+```
+
+
+Slaat het OneNote-document op naar een stream met de opgegeven opslagopties.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| stroom | java.io.OutputStream | De System.iO.stream waar het document wordt opgeslagen. |
+| options | [SaveOptions](../../com.aspose.note/saveoptions) | Specificeert de opties hoe het document wordt opgeslagen in de stream. |
+
+### save(OutputStream stream, int format) {#save-java.io.OutputStream-int-}
+```
+public void save(OutputStream stream, int format)
+```
+
+
+Slaat het OneNote-document op naar een stream in het opgegeven formaat.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| stroom | java.io.OutputStream | De System.iO.stream waar het document wordt opgeslagen. |
+| format | int | Het formaat waarin het document moet worden opgeslagen. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Slaat het OneNote-document op naar een bestand.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| fileName | java.lang.String | De volledige naam voor het bestand. Als er al een bestand met de opgegeven volledige naam bestaat, wordt het bestaande bestand overschreven. |
+
+### save(String fileName, SaveOptions options) {#save-java.lang.String-com.aspose.note.SaveOptions-}
+```
+public void save(String fileName, SaveOptions options)
+```
+
+
+Slaat het OneNote-document op naar een bestand met de opgegeven opslagopties.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| fileName | java.lang.String | De volledige naam voor het bestand. Als er al een bestand met de opgegeven volledige naam bestaat, wordt het bestaande bestand overschreven. |
+| options | [SaveOptions](../../com.aspose.note/saveoptions) | Specificeert de opties hoe het document in een bestand wordt opgeslagen. |
+
+### save(String fileName, int format) {#save-java.lang.String-int-}
+```
+public void save(String fileName, int format)
+```
+
+
+Slaat het OneNote-document op naar een bestand in het opgegeven formaat.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| fileName | java.lang.String | De volledige naam voor het bestand. Als er al een bestand met de opgegeven volledige naam bestaat, wordt het bestaande bestand overschreven. |
+| format | int | Het formaat waarin het document moet worden opgeslagen. |
+
+### setAutomaticLayoutChangesDetectionEnabled(boolean value) {#setAutomaticLayoutChangesDetectionEnabled-boolean-}
+```
+public void setAutomaticLayoutChangesDetectionEnabled(boolean value)
+```
+
+
+Stelt een waarde in die aangeeft of Aspose.Note automatisch detectie van lay-outwijzigingen uitvoert.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean | Nieuwe waarde. Kan null zijn. |
+
+### setColor(Color value) {#setColor-java.awt.Color-}
+```
+public void setColor(Color value)
+```
+
+
+Stelt de kleur in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.awt.Color | Waarde van Color. |
+
+### setCreationTime(Date value) {#setCreationTime-java.util.Date-}
+```
+public void setCreationTime(Date value)
+```
+
+
+Stelt de creatietijd in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Date | Waarde van DateTime. |
+
+### setDisplayName(String value) {#setDisplayName-java.lang.String-}
+```
+public void setDisplayName(String value)
+```
+
+
+Stelt de weergavenaam in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String | Waarde van DateTime. |
+

--- a/netherlands/java/com.aspose.note/documentprintattributeset/_index.md
+++ b/netherlands/java/com.aspose.note/documentprintattributeset/_index.md
@@ -1,0 +1,223 @@
+---
+title: "DocumentPrintAttributeSet"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een hulpprogrammaklasse met een gebruiksvriendelijke interface naar AttributeSet voor."
+type: docs
+weight: 21
+url: /nl/java/com.aspose.note/documentprintattributeset/
+---
+
+**Inheritance:**
+java.lang.Object, javax.print.attribute.HashAttributeSet
+```
+public final class DocumentPrintAttributeSet extends HashAttributeSet
+```
+
+Stelt een hulpprogrammaklasse met een gebruiksvriendelijke interface naar AttributeSet voor.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [DocumentPrintAttributeSet(int copies)](#DocumentPrintAttributeSet-int-) | Initialiseert een nieuw exemplaar van `DocumentPrintAttributeSet`. |
+| [DocumentPrintAttributeSet(String printerName, int copies)](#DocumentPrintAttributeSet-java.lang.String-int-) | Initialiseert een nieuw exemplaar van `DocumentPrintAttributeSet`. |
+| [DocumentPrintAttributeSet(String printerName)](#DocumentPrintAttributeSet-java.lang.String-) | Initialiseert een nieuw exemplaar van `DocumentPrintAttributeSet`. |
+| [DocumentPrintAttributeSet()](#DocumentPrintAttributeSet--) | Initialiseert een nieuw exemplaar van `DocumentPrintAttributeSet`. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getCopies()](#getCopies--) |  |
+| [getLandscape()](#getLandscape--) |  |
+| [getPrinterName()](#getPrinterName--) |  |
+| [setCollate(boolean value)](#setCollate-boolean-) | Stelt een waarde in die aangeeft of het document is gecollateerd. |
+| [setCopies(int value)](#setCopies-int-) | Stelt het aantal exemplaren in dat moet worden afgedrukt. |
+| [setDuplex(boolean value)](#setDuplex-boolean-) | Stelt de printerinstelling in voor dubbelzijdig afdrukken. |
+| [setLandscape(boolean value)](#setLandscape-boolean-) | Stelt de oriëntatie van de pagina in. |
+| [setPrintRange(int page)](#setPrintRange-int-) | Stelt de enkele pagina in die moet worden afgedrukt. |
+| [setPrintRange(int from, int to)](#setPrintRange-int-int-) | Stelt het paginabereik in dat moet worden afgedrukt. |
+| [setPrinterName(String printerName)](#setPrinterName-java.lang.String-) | De naam van de te gebruiken printer. |
+| [setPrinterName(String printerName, Locale locale)](#setPrinterName-java.lang.String-java.util.Locale-) | De naam van de te gebruiken printer. |
+### DocumentPrintAttributeSet(int copies) {#DocumentPrintAttributeSet-int-}
+```
+public DocumentPrintAttributeSet(int copies)
+```
+
+
+Initialiseert een nieuw exemplaar van `DocumentPrintAttributeSet`. Standaard worden alle pagina's van het document afgedrukt.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| copies | int | Het aantal exemplaren van het document dat moet worden afgedrukt. |
+
+### DocumentPrintAttributeSet(String printerName, int copies) {#DocumentPrintAttributeSet-java.lang.String-int-}
+```
+public DocumentPrintAttributeSet(String printerName, int copies)
+```
+
+
+Initialiseert een nieuw exemplaar van `DocumentPrintAttributeSet`. Standaard worden alle pagina's van het document afgedrukt.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| printerName | java.lang.String | De naam van de printer. |
+| copies | int | Het aantal exemplaren van het document dat moet worden afgedrukt. |
+
+### DocumentPrintAttributeSet(String printerName) {#DocumentPrintAttributeSet-java.lang.String-}
+```
+public DocumentPrintAttributeSet(String printerName)
+```
+
+
+Initialiseert een nieuw exemplaar van `DocumentPrintAttributeSet`. Standaard is er slechts één exemplaar van elke pagina.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| printerName | java.lang.String | De naam van de printer. |
+
+### DocumentPrintAttributeSet() {#DocumentPrintAttributeSet--}
+```
+public DocumentPrintAttributeSet()
+```
+
+
+Initialiseert een nieuw exemplaar van `DocumentPrintAttributeSet`. Standaard is er slechts één exemplaar van elke pagina.
+
+### getCopies() {#getCopies--}
+```
+public int getCopies()
+```
+
+
+
+
+**Returns:**
+int
+### getLandscape() {#getLandscape--}
+```
+public boolean getLandscape()
+```
+
+
+
+
+**Returns:**
+boolean
+### getPrinterName() {#getPrinterName--}
+```
+public String getPrinterName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### setCollate(boolean value) {#setCollate-boolean-}
+```
+public void setCollate(boolean value)
+```
+
+
+Stelt een waarde in die aangeeft of het document is gecollateerd.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean | true is equivalent aan de instelling van SheetCollate.COLLATED false is equivalent aan de instelling van SheetCollate.UNCOLLATED |
+
+### setCopies(int value) {#setCopies-int-}
+```
+public void setCopies(int value)
+```
+
+
+Stelt het aantal exemplaren in dat moet worden afgedrukt.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int | Het aantal exemplaren dat moet worden afgedrukt. |
+
+### setDuplex(boolean value) {#setDuplex-boolean-}
+```
+public void setDuplex(boolean value)
+```
+
+
+Stelt de printerinstelling in voor dubbelzijdig afdrukken.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean | true is equivalent aan de instelling van Sides.DUPLEX false is equivalent aan de instelling van Sides.ONE\_SIDED |
+
+### setLandscape(boolean value) {#setLandscape-boolean-}
+```
+public void setLandscape(boolean value)
+```
+
+
+Stelt de oriëntatie van de pagina in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean | true is equivalent aan de instelling van OrientationRequested.LANDSCAPE false is equivalent aan de instelling van OrientationRequested.PORTRAIT |
+
+### setPrintRange(int page) {#setPrintRange-int-}
+```
+public void setPrintRange(int page)
+```
+
+
+Stelt de enkele pagina in die moet worden afgedrukt.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| pagina | int | De pagina die moet worden afgedrukt. |
+
+### setPrintRange(int from, int to) {#setPrintRange-int-int-}
+```
+public void setPrintRange(int from, int to)
+```
+
+
+Stelt het paginabereik in dat moet worden afgedrukt.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| van | int | De eerste pagina. |
+| tot | int | De laatste pagina. |
+
+### setPrinterName(String printerName) {#setPrinterName-java.lang.String-}
+```
+public void setPrinterName(String printerName)
+```
+
+
+De naam van de te gebruiken printer.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| printerName | java.lang.String | De naam van de printer. |
+
+### setPrinterName(String printerName, Locale locale) {#setPrinterName-java.lang.String-java.util.Locale-}
+```
+public void setPrinterName(String printerName, Locale locale)
+```
+
+
+De naam van de te gebruiken printer.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| printerName | java.lang.String | De naam van de printer. |
+| locale | java.util.Locale | locale van printerName. |
+

--- a/netherlands/java/com.aspose.note/documentvisitor/_index.md
+++ b/netherlands/java/com.aspose.note/documentvisitor/_index.md
@@ -1,0 +1,479 @@
+---
+title: "DocumentVisitor"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De abstracte klasse voor het itereren door een subboom met wortel op het opgegeven knooppunt."
+type: docs
+weight: 22
+url: /nl/java/com.aspose.note/documentvisitor/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class DocumentVisitor
+```
+
+De abstracte klasse voor het itereren door een subboom met wortel op het opgegeven knooppunt.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [DocumentVisitor()](#DocumentVisitor--) |  |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [visitAttachedFileEnd(AttachedFile attachedFile)](#visitAttachedFileEnd-com.aspose.note.AttachedFile-) | Einde om het `AttachedFile`-knooppunt te bezoeken. |
+| [visitAttachedFileStart(AttachedFile attachedFile)](#visitAttachedFileStart-com.aspose.note.AttachedFile-) | Start met het bezoeken van de `AttachedFile` node. |
+| [visitDocumentEnd(Document document)](#visitDocumentEnd-com.aspose.note.Document-) | Einde van het bezoeken van de `Document` node. |
+| [visitDocumentStart(Document document)](#visitDocumentStart-com.aspose.note.Document-) | Start met het bezoeken van de `Document` node. |
+| [visitImageEnd(Image image)](#visitImageEnd-com.aspose.note.Image-) | Einde van het bezoeken van de `Image` node. |
+| [visitImageStart(Image image)](#visitImageStart-com.aspose.note.Image-) | Start met het bezoeken van de `Image` node. |
+| [visitInkDrawingEnd(InkDrawing inkDrawing)](#visitInkDrawingEnd-com.aspose.note.InkDrawing-) | Einde van het bezoeken van de [InkDrawing](../../com.aspose.note/inkdrawing) node. |
+| [visitInkDrawingStart(InkDrawing inkDrawing)](#visitInkDrawingStart-com.aspose.note.InkDrawing-) | Start met het bezoeken van de [InkDrawing](../../com.aspose.note/inkdrawing) node. |
+| [visitInkParagraphEnd(InkParagraph inkParagraph)](#visitInkParagraphEnd-com.aspose.note.InkParagraph-) | Einde van het bezoeken van de [InkParagraph](../../com.aspose.note/inkparagraph) node. |
+| [visitInkParagraphStart(InkParagraph inkParagraph)](#visitInkParagraphStart-com.aspose.note.InkParagraph-) | Start met het bezoeken van de [InkParagraph](../../com.aspose.note/inkparagraph) node. |
+| [visitInkWordEnd(InkWord inkWord)](#visitInkWordEnd-com.aspose.note.InkWord-) | Einde van het bezoeken van de [InkWord](../../com.aspose.note/inkword) node. |
+| [visitInkWordStart(InkWord inkWord)](#visitInkWordStart-com.aspose.note.InkWord-) | Start met het bezoeken van de [InkWord](../../com.aspose.note/inkword) node. |
+| [visitLoopEnd(Loop loop)](#visitLoopEnd-com.aspose.note.Loop-) | Einde van het bezoeken van de [Loop](../../com.aspose.note/loop) node. |
+| [visitLoopStart(Loop loop)](#visitLoopStart-com.aspose.note.Loop-) | Start met het bezoeken van de [Loop](../../com.aspose.note/loop) node. |
+| [visitOutlineElementEnd(OutlineElement outlineElement)](#visitOutlineElementEnd-com.aspose.note.OutlineElement-) | Einde van het bezoeken van de `OutlineElement` node. |
+| [visitOutlineElementStart(OutlineElement outlineElement)](#visitOutlineElementStart-com.aspose.note.OutlineElement-) | Start met het bezoeken van de `OutlineElement` node. |
+| [visitOutlineEnd(Outline outline)](#visitOutlineEnd-com.aspose.note.Outline-) | Einde van het bezoeken van de `Outline` node. |
+| [visitOutlineGroupEnd(OutlineGroup outlineGroup)](#visitOutlineGroupEnd-com.aspose.note.OutlineGroup-) | Einde van het bezoeken van de `OutlineGroup` node. |
+| [visitOutlineGroupStart(OutlineGroup outlineGroup)](#visitOutlineGroupStart-com.aspose.note.OutlineGroup-) | Start met het bezoeken van de `OutlineGroup` node. |
+| [visitOutlineStart(Outline outline)](#visitOutlineStart-com.aspose.note.Outline-) | Start met het bezoeken van de `Outline` node. |
+| [visitPageEnd(Page page)](#visitPageEnd-com.aspose.note.Page-) | Einde van het bezoeken van de `Page` node. |
+| [visitPageStart(Page page)](#visitPageStart-com.aspose.note.Page-) | Start met het bezoeken van de `Page` node. |
+| [visitRichTextEnd(RichText richText)](#visitRichTextEnd-com.aspose.note.RichText-) | Einde van het bezoeken van de `RichText` node. |
+| [visitRichTextStart(RichText richText)](#visitRichTextStart-com.aspose.note.RichText-) | Start met het bezoeken van de `RichText` node. |
+| [visitTableCellEnd(TableCell tableCell)](#visitTableCellEnd-com.aspose.note.TableCell-) | Einde van het bezoeken van de `TableCell` node. |
+| [visitTableCellStart(TableCell tableCell)](#visitTableCellStart-com.aspose.note.TableCell-) | Start met het bezoeken van de `TableCell` node. |
+| [visitTableEnd(Table table)](#visitTableEnd-com.aspose.note.Table-) | Einde om de `Table` node te bezoeken. |
+| [visitTableRowEnd(TableRow tableRow)](#visitTableRowEnd-com.aspose.note.TableRow-) | Einde om de `TableRow` node te bezoeken. |
+| [visitTableRowStart(TableRow tableRow)](#visitTableRowStart-com.aspose.note.TableRow-) | Begin om de `TableRow` node te bezoeken. |
+| [visitTableStart(Table table)](#visitTableStart-com.aspose.note.Table-) | Begin om de `Table` node te bezoeken. |
+| [visitTitleEnd(Title title)](#visitTitleEnd-com.aspose.note.Title-) | Einde om de `Title` node te bezoeken. |
+| [visitTitleStart(Title title)](#visitTitleStart-com.aspose.note.Title-) | Begin om de `Title` node te bezoeken. |
+### DocumentVisitor() {#DocumentVisitor--}
+```
+public DocumentVisitor()
+```
+
+
+### visitAttachedFileEnd(AttachedFile attachedFile) {#visitAttachedFileEnd-com.aspose.note.AttachedFile-}
+```
+public void visitAttachedFileEnd(AttachedFile attachedFile)
+```
+
+
+Einde om het `AttachedFile`-knooppunt te bezoeken.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| attachedFile | [AttachedFile](../../com.aspose.note/attachedfile) | De `AttachedFile` node. |
+
+### visitAttachedFileStart(AttachedFile attachedFile) {#visitAttachedFileStart-com.aspose.note.AttachedFile-}
+```
+public void visitAttachedFileStart(AttachedFile attachedFile)
+```
+
+
+Start met het bezoeken van de `AttachedFile` node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| attachedFile | [AttachedFile](../../com.aspose.note/attachedfile) | De `AttachedFile` node. |
+
+### visitDocumentEnd(Document document) {#visitDocumentEnd-com.aspose.note.Document-}
+```
+public void visitDocumentEnd(Document document)
+```
+
+
+Einde van het bezoeken van de `Document` node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| document | [Document](../../com.aspose.note/document) | De `Document` node. |
+
+### visitDocumentStart(Document document) {#visitDocumentStart-com.aspose.note.Document-}
+```
+public void visitDocumentStart(Document document)
+```
+
+
+Start met het bezoeken van de `Document` node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| document | [Document](../../com.aspose.note/document) | De `Document` node. |
+
+### visitImageEnd(Image image) {#visitImageEnd-com.aspose.note.Image-}
+```
+public void visitImageEnd(Image image)
+```
+
+
+Einde van het bezoeken van de `Image` node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| image | [Image](../../com.aspose.note/image) | De `Image` node. |
+
+### visitImageStart(Image image) {#visitImageStart-com.aspose.note.Image-}
+```
+public void visitImageStart(Image image)
+```
+
+
+Start met het bezoeken van de `Image` node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| image | [Image](../../com.aspose.note/image) | De `Image` node. |
+
+### visitInkDrawingEnd(InkDrawing inkDrawing) {#visitInkDrawingEnd-com.aspose.note.InkDrawing-}
+```
+public void visitInkDrawingEnd(InkDrawing inkDrawing)
+```
+
+
+Einde van het bezoeken van de [InkDrawing](../../com.aspose.note/inkdrawing) node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| inkDrawing | [InkDrawing](../../com.aspose.note/inkdrawing) | De [InkDrawing](../../com.aspose.note/inkdrawing) node. |
+
+### visitInkDrawingStart(InkDrawing inkDrawing) {#visitInkDrawingStart-com.aspose.note.InkDrawing-}
+```
+public void visitInkDrawingStart(InkDrawing inkDrawing)
+```
+
+
+Start met het bezoeken van de [InkDrawing](../../com.aspose.note/inkdrawing) node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| inkDrawing | [InkDrawing](../../com.aspose.note/inkdrawing) | De [InkDrawing](../../com.aspose.note/inkdrawing) node. |
+
+### visitInkParagraphEnd(InkParagraph inkParagraph) {#visitInkParagraphEnd-com.aspose.note.InkParagraph-}
+```
+public void visitInkParagraphEnd(InkParagraph inkParagraph)
+```
+
+
+Einde van het bezoeken van de [InkParagraph](../../com.aspose.note/inkparagraph) node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| inkParagraph | [InkParagraph](../../com.aspose.note/inkparagraph) | De [InkParagraph](../../com.aspose.note/inkparagraph) node. |
+
+### visitInkParagraphStart(InkParagraph inkParagraph) {#visitInkParagraphStart-com.aspose.note.InkParagraph-}
+```
+public void visitInkParagraphStart(InkParagraph inkParagraph)
+```
+
+
+Start met het bezoeken van de [InkParagraph](../../com.aspose.note/inkparagraph) node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| inkParagraph | [InkParagraph](../../com.aspose.note/inkparagraph) | De [InkParagraph](../../com.aspose.note/inkparagraph) node. |
+
+### visitInkWordEnd(InkWord inkWord) {#visitInkWordEnd-com.aspose.note.InkWord-}
+```
+public void visitInkWordEnd(InkWord inkWord)
+```
+
+
+Einde van het bezoeken van de [InkWord](../../com.aspose.note/inkword) node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| inkWord | [InkWord](../../com.aspose.note/inkword) | De [InkWord](../../com.aspose.note/inkword) node. |
+
+### visitInkWordStart(InkWord inkWord) {#visitInkWordStart-com.aspose.note.InkWord-}
+```
+public void visitInkWordStart(InkWord inkWord)
+```
+
+
+Start met het bezoeken van de [InkWord](../../com.aspose.note/inkword) node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| inkWord | [InkWord](../../com.aspose.note/inkword) | De [InkWord](../../com.aspose.note/inkword) node. |
+
+### visitLoopEnd(Loop loop) {#visitLoopEnd-com.aspose.note.Loop-}
+```
+public void visitLoopEnd(Loop loop)
+```
+
+
+Einde van het bezoeken van de [Loop](../../com.aspose.note/loop) node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| loop | [Loop](../../com.aspose.note/loop) | De [Loop](../../com.aspose.note/loop) node. |
+
+### visitLoopStart(Loop loop) {#visitLoopStart-com.aspose.note.Loop-}
+```
+public void visitLoopStart(Loop loop)
+```
+
+
+Start met het bezoeken van de [Loop](../../com.aspose.note/loop) node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| loop | [Loop](../../com.aspose.note/loop) | De [Loop](../../com.aspose.note/loop) node. |
+
+### visitOutlineElementEnd(OutlineElement outlineElement) {#visitOutlineElementEnd-com.aspose.note.OutlineElement-}
+```
+public void visitOutlineElementEnd(OutlineElement outlineElement)
+```
+
+
+Einde van het bezoeken van de `OutlineElement` node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| outlineElement | [OutlineElement](../../com.aspose.note/outlineelement) | De `OutlineElement` node. |
+
+### visitOutlineElementStart(OutlineElement outlineElement) {#visitOutlineElementStart-com.aspose.note.OutlineElement-}
+```
+public void visitOutlineElementStart(OutlineElement outlineElement)
+```
+
+
+Start met het bezoeken van de `OutlineElement` node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| outlineElement | [OutlineElement](../../com.aspose.note/outlineelement) | De `OutlineElement` node. |
+
+### visitOutlineEnd(Outline outline) {#visitOutlineEnd-com.aspose.note.Outline-}
+```
+public void visitOutlineEnd(Outline outline)
+```
+
+
+Einde van het bezoeken van de `Outline` node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| outline | [Outline](../../com.aspose.note/outline) | De `Outline` node. |
+
+### visitOutlineGroupEnd(OutlineGroup outlineGroup) {#visitOutlineGroupEnd-com.aspose.note.OutlineGroup-}
+```
+public void visitOutlineGroupEnd(OutlineGroup outlineGroup)
+```
+
+
+Einde van het bezoeken van de `OutlineGroup` node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| outlineGroup | [OutlineGroup](../../com.aspose.note/outlinegroup) | De `OutlineGroup` node. |
+
+### visitOutlineGroupStart(OutlineGroup outlineGroup) {#visitOutlineGroupStart-com.aspose.note.OutlineGroup-}
+```
+public void visitOutlineGroupStart(OutlineGroup outlineGroup)
+```
+
+
+Start met het bezoeken van de `OutlineGroup` node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| outlineGroup | [OutlineGroup](../../com.aspose.note/outlinegroup) | De `OutlineGroup` node. |
+
+### visitOutlineStart(Outline outline) {#visitOutlineStart-com.aspose.note.Outline-}
+```
+public void visitOutlineStart(Outline outline)
+```
+
+
+Start met het bezoeken van de `Outline` node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| outline | [Outline](../../com.aspose.note/outline) | De `Outline` node. |
+
+### visitPageEnd(Page page) {#visitPageEnd-com.aspose.note.Page-}
+```
+public void visitPageEnd(Page page)
+```
+
+
+Einde van het bezoeken van de `Page` node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.note/page) | De `Page` node. |
+
+### visitPageStart(Page page) {#visitPageStart-com.aspose.note.Page-}
+```
+public void visitPageStart(Page page)
+```
+
+
+Start met het bezoeken van de `Page` node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.note/page) | De `Page` node. |
+
+### visitRichTextEnd(RichText richText) {#visitRichTextEnd-com.aspose.note.RichText-}
+```
+public void visitRichTextEnd(RichText richText)
+```
+
+
+Einde van het bezoeken van de `RichText` node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| richText | [RichText](../../com.aspose.note/richtext) | De `RichText` node. |
+
+### visitRichTextStart(RichText richText) {#visitRichTextStart-com.aspose.note.RichText-}
+```
+public void visitRichTextStart(RichText richText)
+```
+
+
+Start met het bezoeken van de `RichText` node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| richText | [RichText](../../com.aspose.note/richtext) | De `RichText` node. |
+
+### visitTableCellEnd(TableCell tableCell) {#visitTableCellEnd-com.aspose.note.TableCell-}
+```
+public void visitTableCellEnd(TableCell tableCell)
+```
+
+
+Einde van het bezoeken van de `TableCell` node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| tableCell | [TableCell](../../com.aspose.note/tablecell) | De `TableCell` node. |
+
+### visitTableCellStart(TableCell tableCell) {#visitTableCellStart-com.aspose.note.TableCell-}
+```
+public void visitTableCellStart(TableCell tableCell)
+```
+
+
+Start met het bezoeken van de `TableCell` node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| tableCell | [TableCell](../../com.aspose.note/tablecell) | De `TableCell` node. |
+
+### visitTableEnd(Table table) {#visitTableEnd-com.aspose.note.Table-}
+```
+public void visitTableEnd(Table table)
+```
+
+
+Einde om de `Table` node te bezoeken.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| table | [Table](../../com.aspose.note/table) | De `Table` node. |
+
+### visitTableRowEnd(TableRow tableRow) {#visitTableRowEnd-com.aspose.note.TableRow-}
+```
+public void visitTableRowEnd(TableRow tableRow)
+```
+
+
+Einde om de `TableRow` node te bezoeken.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| tableRow | [TableRow](../../com.aspose.note/tablerow) | De `TableRow` node. |
+
+### visitTableRowStart(TableRow tableRow) {#visitTableRowStart-com.aspose.note.TableRow-}
+```
+public void visitTableRowStart(TableRow tableRow)
+```
+
+
+Begin om de `TableRow` node te bezoeken.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| tableRow | [TableRow](../../com.aspose.note/tablerow) | De `TableRow` node. |
+
+### visitTableStart(Table table) {#visitTableStart-com.aspose.note.Table-}
+```
+public void visitTableStart(Table table)
+```
+
+
+Begin om de `Table` node te bezoeken.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| table | [Table](../../com.aspose.note/table) | De `Table` node. |
+
+### visitTitleEnd(Title title) {#visitTitleEnd-com.aspose.note.Title-}
+```
+public void visitTitleEnd(Title title)
+```
+
+
+Einde om de `Title` node te bezoeken.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| title | [Title](../../com.aspose.note/title) | De `Title` node. |
+
+### visitTitleStart(Title title) {#visitTitleStart-com.aspose.note.Title-}
+```
+public void visitTitleStart(Title title)
+```
+
+
+Begin om de `Title` node te bezoeken.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| title | [Title](../../com.aspose.note/title) | De `Title` node. |
+

--- a/netherlands/java/com.aspose.note/extendedapsdocument/_index.md
+++ b/netherlands/java/com.aspose.note/extendedapsdocument/_index.md
@@ -1,0 +1,97 @@
+---
+title: "ExtendedApsDocument"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een volledig one-note document voor dat bestaat uit pagina's vertaald naar paginagroepen."
+type: docs
+weight: 23
+url: /nl/java/com.aspose.note/extendedapsdocument/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.foundation.rendering.ApsNode
+
+**All Implemented Interfaces:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerable
+```
+public class ExtendedApsDocument extends ApsNode implements System.Collections.Generic.IGenericEnumerable<ApsPage>
+```
+
+Stelt een volledig OneNote-document voor, bestaande uit Pagina's die zijn vertaald naar pagina-sets.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [ExtendedApsDocument()](#ExtendedApsDocument--) | Initialiseert een nieuw exemplaar van de `ExtendedApsDocument` klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [accept(ApsDocumentVisitor visitor)](#accept-com.aspose.foundation.rendering.ApsDocumentVisitor-) | Accepteert ApsDocumentVisitor voor dit element. |
+| [addPage(ApsPage page)](#addPage-com.aspose.foundation.rendering.ApsPage-) | Voegt een paginagroep toe aan het document. |
+| [getPageList()](#getPageList--) | Haalt de lijst met paginagroepen op. |
+| [iterator()](#iterator--) | Retourneert een enumerator. |
+| [iterator_Rename_Namesake()](#iterator-Rename-Namesake--) |  |
+### ExtendedApsDocument() {#ExtendedApsDocument--}
+```
+public ExtendedApsDocument()
+```
+
+
+Initialiseert een nieuw exemplaar van de `ExtendedApsDocument` klasse.
+
+### accept(ApsDocumentVisitor visitor) {#accept-com.aspose.foundation.rendering.ApsDocumentVisitor-}
+```
+public void accept(ApsDocumentVisitor visitor)
+```
+
+
+Accepteert ApsDocumentVisitor voor dit element.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| bezoeker | com.aspose.foundation.rendering.ApsDocumentVisitor | Een bezoeker. |
+
+### addPage(ApsPage page) {#addPage-com.aspose.foundation.rendering.ApsPage-}
+```
+public void addPage(ApsPage page)
+```
+
+
+Voegt een paginagroep toe aan het document.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| pagina | com.aspose.foundation.rendering.ApsPage | Een paginagroep. |
+
+### getPageList() {#getPageList--}
+```
+public System.Collections.Generic.List<ApsPage> getPageList()
+```
+
+
+Haalt de lijst met paginagroepen op.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List&lt;com.aspose.foundation.rendering.ApsPage&gt;
+### iterator() {#iterator--}
+```
+public System.Collections.Generic.IGenericEnumerator<ApsPage> iterator()
+```
+
+
+Retourneert een enumerator.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;com.aspose.foundation.rendering.ApsPage&gt;
+### iterator_Rename_Namesake() {#iterator-Rename-Namesake--}
+```
+public System.Collections.IEnumerator iterator_Rename_Namesake()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Collections.IEnumerator

--- a/netherlands/java/com.aspose.note/extendedapsglyphs/_index.md
+++ b/netherlands/java/com.aspose.note/extendedapsglyphs/_index.md
@@ -1,0 +1,135 @@
+---
+title: "ExtendedApsGlyphs"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een wrapper voor standaard ApsGlyphs voor die een deel van het teken‑gedrag uitbreidt."
+type: docs
+weight: 24
+url: /nl/java/com.aspose.note/extendedapsglyphs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ExtendedApsNode](../../com.aspose.note/extendedapsnode)
+```
+public class ExtendedApsGlyphs extends ExtendedApsNode
+```
+
+Stelt een wrapper voor standaard ApsGlyphs voor, die een deel van het teken-gedrag uitbreidt.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [ExtendedApsGlyphs(ApsGlyphs internalGlyphs)](#ExtendedApsGlyphs-com.aspose.foundation.rendering.ApsGlyphs-) | Initialiseert een nieuw exemplaar van de `ExtendedApsGlyphs` klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [addToCompositeNode(ApsCompositeNode compositeNode)](#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-) | Voegt dit knooppunt toe aan de gegeven `compositeNode`. |
+| [applyPlaneTransform(System.Drawing.PointF transformVector)](#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-) | Past een vlaktransformatie toe, waarbij het knooppunt in de x- en y-vlakken wordt verplaatst. |
+| [applyScaleTransform(float scaleTransform)](#applyScaleTransform-float-) | Past schaal toe op de glyphs. |
+| [getBottom()](#getBottom--) | Haalt de onderkant van de glyphs op. |
+| [getCopy()](#getCopy--) | Haalt een kopie van de glyphs op. |
+| [getOrigin()](#getOrigin--) | Haalt de oorsprong op. |
+| [getSize()](#getSize--) | Haalt de grootte op. |
+| [getTop()](#getTop--) | Haalt de bovenkant op. |
+### ExtendedApsGlyphs(ApsGlyphs internalGlyphs) {#ExtendedApsGlyphs-com.aspose.foundation.rendering.ApsGlyphs-}
+```
+public ExtendedApsGlyphs(ApsGlyphs internalGlyphs)
+```
+
+
+Initialiseert een nieuw exemplaar van de `ExtendedApsGlyphs` klasse.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| internalGlyphs | com.aspose.foundation.rendering.ApsGlyphs | Een originele aps-glyfen. |
+
+### addToCompositeNode(ApsCompositeNode compositeNode) {#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-}
+```
+public void addToCompositeNode(ApsCompositeNode compositeNode)
+```
+
+
+Voegt dit knooppunt toe aan de gegeven `compositeNode`.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| compositeNode | com.aspose.foundation.rendering.ApsCompositeNode |  |
+
+### applyPlaneTransform(System.Drawing.PointF transformVector) {#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-}
+```
+public void applyPlaneTransform(System.Drawing.PointF transformVector)
+```
+
+
+Past een vlaktransformatie toe, waarbij het knooppunt in de x- en y-vlakken wordt verplaatst.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| transformVector | com.aspose.ms.System.Drawing.PointF |  |
+
+### applyScaleTransform(float scaleTransform) {#applyScaleTransform-float-}
+```
+public void applyScaleTransform(float scaleTransform)
+```
+
+
+Past schaal toe op de glyphs.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| scaleTransform | float | De schaalfactor voor de transformatie. |
+
+### getBottom() {#getBottom--}
+```
+public float getBottom()
+```
+
+
+Haalt de onderkant van de glyphs op.
+
+**Returns:**
+float
+### getCopy() {#getCopy--}
+```
+public ExtendedApsNode getCopy()
+```
+
+
+Haalt een kopie van de glyphs op.
+
+**Returns:**
+[ExtendedApsNode](../../com.aspose.note/extendedapsnode) - The `IExtendedApsNode`.
+### getOrigin() {#getOrigin--}
+```
+public System.Drawing.PointF getOrigin()
+```
+
+
+Haalt de oorsprong op.
+
+**Returns:**
+com.aspose.ms.System.Drawing.PointF
+### getSize() {#getSize--}
+```
+public System.Drawing.SizeF getSize()
+```
+
+
+Haalt de grootte op.
+
+**Returns:**
+com.aspose.ms.System.Drawing.SizeF
+### getTop() {#getTop--}
+```
+public float getTop()
+```
+
+
+Haalt de bovenkant op.
+
+**Returns:**
+float

--- a/netherlands/java/com.aspose.note/extendedapsimage/_index.md
+++ b/netherlands/java/com.aspose.note/extendedapsimage/_index.md
@@ -1,0 +1,146 @@
+---
+title: "ExtendedApsImage"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een wrapper voor de standaard ApsImage voor die een deel van het teken‑gedrag uitbreidt."
+type: docs
+weight: 25
+url: /nl/java/com.aspose.note/extendedapsimage/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ExtendedApsNode](../../com.aspose.note/extendedapsnode)
+```
+public class ExtendedApsImage extends ExtendedApsNode
+```
+
+Stelt een wrapper voor de standaard ApsImage voor, die een deel van het teken-gedrag uitbreidt.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [ExtendedApsImage(ApsImage internalImage)](#ExtendedApsImage-com.aspose.foundation.rendering.ApsImage-) | Initialiseert een nieuw exemplaar van de `ExtendedApsImage`-klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [addToCompositeNode(ApsCompositeNode compositeNode)](#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-) | Voegt dit knooppunt toe aan de gegeven `compositeNode`. |
+| [applyPlaneTransform(System.Drawing.PointF transformVector)](#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-) | Past een vlaktransformatie toe, waarbij het knooppunt in de x- en y-vlakken wordt verplaatst. |
+| [applyScaleTransform(float scaleTransform)](#applyScaleTransform-float-) | Past schaling toe op de afbeelding. |
+| [getBottom()](#getBottom--) | Haalt de onderkant op. |
+| [getCopy()](#getCopy--) | Maakt een volledige kopie van dit knooppunt. |
+| [getOrigin()](#getOrigin--) | Haalt de oorsprong op. |
+| [getSize()](#getSize--) | Haalt de grootte op. |
+| [getTop()](#getTop--) | Haalt de bovenkant op. |
+| [isBackground()](#isBackground--) | Haalt op of de afbeelding een achtergrondafbeelding is. |
+### ExtendedApsImage(ApsImage internalImage) {#ExtendedApsImage-com.aspose.foundation.rendering.ApsImage-}
+```
+public ExtendedApsImage(ApsImage internalImage)
+```
+
+
+Initialiseert een nieuw exemplaar van de `ExtendedApsImage`-klasse.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| internalImage | com.aspose.foundation.rendering.ApsImage | De afbeelding. |
+
+### addToCompositeNode(ApsCompositeNode compositeNode) {#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-}
+```
+public void addToCompositeNode(ApsCompositeNode compositeNode)
+```
+
+
+Voegt dit knooppunt toe aan de gegeven `compositeNode`.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| compositeNode | com.aspose.foundation.rendering.ApsCompositeNode |  |
+
+### applyPlaneTransform(System.Drawing.PointF transformVector) {#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-}
+```
+public void applyPlaneTransform(System.Drawing.PointF transformVector)
+```
+
+
+Past een vlaktransformatie toe, waarbij het knooppunt in de x- en y-vlakken wordt verplaatst.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| transformVector | com.aspose.ms.System.Drawing.PointF |  |
+
+### applyScaleTransform(float scaleTransform) {#applyScaleTransform-float-}
+```
+public void applyScaleTransform(float scaleTransform)
+```
+
+
+Past schaling toe op de afbeelding.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| scaleTransform | float | De schaalfactor voor de transformatie. |
+
+### getBottom() {#getBottom--}
+```
+public float getBottom()
+```
+
+
+Haalt de onderkant op.
+
+**Returns:**
+float
+### getCopy() {#getCopy--}
+```
+public ExtendedApsNode getCopy()
+```
+
+
+Maakt een volledige kopie van dit knooppunt.
+
+**Returns:**
+[ExtendedApsNode](../../com.aspose.note/extendedapsnode) - The `IExtendedApsNode`.
+### getOrigin() {#getOrigin--}
+```
+public System.Drawing.PointF getOrigin()
+```
+
+
+Haalt de oorsprong op.
+
+**Returns:**
+com.aspose.ms.System.Drawing.PointF
+### getSize() {#getSize--}
+```
+public System.Drawing.SizeF getSize()
+```
+
+
+Haalt de grootte op.
+
+**Returns:**
+com.aspose.ms.System.Drawing.SizeF
+### getTop() {#getTop--}
+```
+public float getTop()
+```
+
+
+Haalt de bovenkant op.
+
+**Returns:**
+float
+### isBackground() {#isBackground--}
+```
+public final boolean isBackground()
+```
+
+
+Haalt op of de afbeelding een achtergrondafbeelding is.
+
+**Returns:**
+boolean

--- a/netherlands/java/com.aspose.note/extendedapsnode/_index.md
+++ b/netherlands/java/com.aspose.note/extendedapsnode/_index.md
@@ -1,0 +1,158 @@
+---
+title: "ExtendedApsNode"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een wrapper voor een standaard ApsNode voor die een deel van het teken gedrag uitbreidt."
+type: docs
+weight: 26
+url: /nl/java/com.aspose.note/extendedapsnode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class ExtendedApsNode
+```
+
+Stelt een wrapper voor een standaard ApsNode voor, die een deel van het teken-gedrag uitbreidt.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [ExtendedApsNode()](#ExtendedApsNode--) |  |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [addToCompositeNode(ApsCompositeNode compositeNode)](#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-) | Voegt dit knooppunt toe aan de gegeven `compositeNode`. |
+| [applyPlaneTransform(System.Drawing.PointF transformVector)](#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-) | Past een vlaktransformatie toe, waarbij het knooppunt in de x- en y-vlakken wordt verplaatst. |
+| [applyScaleTransform(float scaleTransform)](#applyScaleTransform-float-) | Past schaalvergroting toe op het knooppunt. |
+| [copyAttributes(ApsNode src, ApsNode dst)](#copyAttributes-com.aspose.foundation.rendering.ApsNode-com.aspose.foundation.rendering.ApsNode-) |  |
+| [copyAttributes(ApsNodeAttributes src, ApsNodeAttributes dst)](#copyAttributes-com.aspose.foundation.rendering.ApsNodeAttributes-com.aspose.foundation.rendering.ApsNodeAttributes-) |  |
+| [getBottom()](#getBottom--) | Haalt op of stelt de y-coördinaat van de onderkant van het knooppunt in. |
+| [getCopy()](#getCopy--) | Maakt een volledige kopie van dit knooppunt. |
+| [getOrigin()](#getOrigin--) | Haalt de oorsprong van het knooppunt op of stelt deze in. |
+| [getSize()](#getSize--) | Haalt de grootte van het knooppunt op of stelt deze in. |
+| [getTop()](#getTop--) | Haalt de y-coördinaat van de bovenkant van het knooppunt op of stelt deze in. |
+### ExtendedApsNode() {#ExtendedApsNode--}
+```
+public ExtendedApsNode()
+```
+
+
+### addToCompositeNode(ApsCompositeNode compositeNode) {#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-}
+```
+public abstract void addToCompositeNode(ApsCompositeNode compositeNode)
+```
+
+
+Voegt dit knooppunt toe aan de gegeven `compositeNode`.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| compositeNode | com.aspose.foundation.rendering.ApsCompositeNode |  |
+
+### applyPlaneTransform(System.Drawing.PointF transformVector) {#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-}
+```
+public abstract void applyPlaneTransform(System.Drawing.PointF transformVector)
+```
+
+
+Past een vlaktransformatie toe, waarbij het knooppunt in de x- en y-vlakken wordt verplaatst.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| transformVector | com.aspose.ms.System.Drawing.PointF |  |
+
+### applyScaleTransform(float scaleTransform) {#applyScaleTransform-float-}
+```
+public abstract void applyScaleTransform(float scaleTransform)
+```
+
+
+Past schaalvergroting toe op het knooppunt.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| scaleTransform | float | De schaalfactor voor de transformatie. |
+
+### copyAttributes(ApsNode src, ApsNode dst) {#copyAttributes-com.aspose.foundation.rendering.ApsNode-com.aspose.foundation.rendering.ApsNode-}
+```
+public static void copyAttributes(ApsNode src, ApsNode dst)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| src | com.aspose.foundation.rendering.ApsNode |  |
+| dst | com.aspose.foundation.rendering.ApsNode |  |
+
+### copyAttributes(ApsNodeAttributes src, ApsNodeAttributes dst) {#copyAttributes-com.aspose.foundation.rendering.ApsNodeAttributes-com.aspose.foundation.rendering.ApsNodeAttributes-}
+```
+public static void copyAttributes(ApsNodeAttributes src, ApsNodeAttributes dst)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| src | com.aspose.foundation.rendering.ApsNodeAttributes |  |
+| dst | com.aspose.foundation.rendering.ApsNodeAttributes |  |
+
+### getBottom() {#getBottom--}
+```
+public float getBottom()
+```
+
+
+Haalt op of stelt de y-coördinaat van de onderkant van het knooppunt in.
+
+**Returns:**
+float
+### getCopy() {#getCopy--}
+```
+public abstract ExtendedApsNode getCopy()
+```
+
+
+Maakt een volledige kopie van dit knooppunt.
+
+**Returns:**
+[ExtendedApsNode](../../com.aspose.note/extendedapsnode) - The `!:ExtendedApsNode`.
+### getOrigin() {#getOrigin--}
+```
+public System.Drawing.PointF getOrigin()
+```
+
+
+Haalt de oorsprong van het knooppunt op of stelt deze in.
+
+**Returns:**
+com.aspose.ms.System.Drawing.PointF
+### getSize() {#getSize--}
+```
+public System.Drawing.SizeF getSize()
+```
+
+
+Haalt de grootte van het knooppunt op of stelt deze in.
+
+**Returns:**
+com.aspose.ms.System.Drawing.SizeF
+### getTop() {#getTop--}
+```
+public float getTop()
+```
+
+
+Haalt de y-coördinaat van de bovenkant van het knooppunt op of stelt deze in.
+
+**Returns:**
+float

--- a/netherlands/java/com.aspose.note/extendedapspage/_index.md
+++ b/netherlands/java/com.aspose.note/extendedapspage/_index.md
@@ -1,0 +1,120 @@
+---
+title: "ExtendedApsPage"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een wrapper voor de standaard ApsGlyphs voor die een deel van het teken‑gedrag uitbreidt."
+type: docs
+weight: 27
+url: /nl/java/com.aspose.note/extendedapspage/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.foundation.rendering.ApsNode, com.aspose.foundation.rendering.ApsCompositeNode, com.aspose.foundation.rendering.ApsPage
+
+**All Implemented Interfaces:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerable
+```
+public class ExtendedApsPage extends ApsPage implements System.Collections.Generic.IGenericEnumerable<ApsNode>
+```
+
+Stelt een wrapper voor de standaard ApsGlyphs voor, die een deel van het teken-gedrag uitbreidt.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [ExtendedApsPage(System.Drawing.SizeF pageSize, float pageStartInNotePage, Margin margin)](#ExtendedApsPage-com.aspose.ms.System.Drawing.SizeF-float-com.aspose.foundation.layout.Margin-) | Initialiseert een nieuw exemplaar van de `ExtendedApsPage`‑klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getContentSize()](#getContentSize--) | Haalt de paginagrootte op exclusief marges. |
+| [getMargin()](#getMargin--) | Haalt de marge van deze pagina op. |
+| [getPageEndInNotePage()](#getPageEndInNotePage--) | Haalt de positie van het paginavoor einde op, in de MS OneNote‑pagina, wanneer één MS OneNote‑pagina wordt verdeeld over meerdere aps‑pagina's. |
+| [getPageSize()](#getPageSize--) | Haalt de uiteindelijke paginagrootte op. |
+| [getPageStartInNotePage()](#getPageStartInNotePage--) | Haalt de positie van het paginavoor begin op in de MS OneNote‑pagina, wanneer één MS OneNote‑pagina wordt verdeeld over meerdere aps‑pagina's. |
+| [iterator()](#iterator--) | Retourneert de enumerator die door alle knooppunten van deze pagina iterereert. |
+| [iterator_Rename_Namesake()](#iterator-Rename-Namesake--) | De get‑enumerator. |
+### ExtendedApsPage(System.Drawing.SizeF pageSize, float pageStartInNotePage, Margin margin) {#ExtendedApsPage-com.aspose.ms.System.Drawing.SizeF-float-com.aspose.foundation.layout.Margin-}
+```
+public ExtendedApsPage(System.Drawing.SizeF pageSize, float pageStartInNotePage, Margin margin)
+```
+
+
+Initialiseert een nieuw exemplaar van de `ExtendedApsPage`‑klasse.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| pageSize | com.aspose.ms.System.Drawing.SizeF | De paginagrootte. |
+| pageStartInNotePage | float | Het begin van de pagina in de originele MS OneNote‑pagina. |
+| margin | com.aspose.foundation.layout.Margin | The extended page margin. |
+
+### getContentSize() {#getContentSize--}
+```
+public System.Drawing.SizeF getContentSize()
+```
+
+
+Haalt de paginagrootte op exclusief marges.
+
+**Returns:**
+com.aspose.ms.System.Drawing.SizeF
+### getMargin() {#getMargin--}
+```
+public Margin getMargin()
+```
+
+
+Haalt de marge van deze pagina op.
+
+**Returns:**
+com.aspose.foundation.layout.Margin
+### getPageEndInNotePage() {#getPageEndInNotePage--}
+```
+public float getPageEndInNotePage()
+```
+
+
+Haalt de positie van het paginavoor einde op, in de MS OneNote‑pagina, wanneer één MS OneNote‑pagina wordt verdeeld over meerdere aps‑pagina's.
+
+**Returns:**
+float
+### getPageSize() {#getPageSize--}
+```
+public System.Drawing.SizeF getPageSize()
+```
+
+
+Haalt de uiteindelijke paginagrootte op.
+
+**Returns:**
+com.aspose.ms.System.Drawing.SizeF
+### getPageStartInNotePage() {#getPageStartInNotePage--}
+```
+public float getPageStartInNotePage()
+```
+
+
+Haalt de positie van het paginavoor begin op in de MS OneNote‑pagina, wanneer één MS OneNote‑pagina wordt verdeeld over meerdere aps‑pagina's.
+
+**Returns:**
+float
+### iterator() {#iterator--}
+```
+public System.Collections.Generic.IGenericEnumerator<ApsNode> iterator()
+```
+
+
+Retourneert de enumerator die door alle knooppunten van deze pagina iterereert.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;com.aspose.foundation.rendering.ApsNode&gt; - De `IEnumerator`.
+### iterator_Rename_Namesake() {#iterator-Rename-Namesake--}
+```
+public System.Collections.IEnumerator iterator_Rename_Namesake()
+```
+
+
+De get‑enumerator.
+
+**Returns:**
+com.aspose.ms.System.Collections.IEnumerator - De `IEnumerator`.

--- a/netherlands/java/com.aspose.note/extendedapspath/_index.md
+++ b/netherlands/java/com.aspose.note/extendedapspath/_index.md
@@ -1,0 +1,113 @@
+---
+title: "ExtendedApsPath"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een wrapper voor de standaard ApsPath voor die een deel van het teken‑gedrag uitbreidt."
+type: docs
+weight: 28
+url: /nl/java/com.aspose.note/extendedapspath/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ExtendedApsNode](../../com.aspose.note/extendedapsnode)
+```
+public class ExtendedApsPath extends ExtendedApsNode
+```
+
+Stelt een wrapper voor het standaard ApsPath voor, die een deel van het teken-gedrag uitbreidt.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [ExtendedApsPath(ApsPath internalApsPath)](#ExtendedApsPath-com.aspose.foundation.rendering.ApsPath-) | Initialiseert een nieuw exemplaar van de `ExtendedApsPath`-klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [addToCompositeNode(ApsCompositeNode compositeNode)](#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-) | Voegt dit knooppunt toe aan de gegeven `compositeNode`. |
+| [applyPlaneTransform(System.Drawing.PointF transformVector)](#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-) | Past een vlaktransformatie toe, waarbij het knooppunt in de x- en y-vlakken wordt verplaatst. |
+| [applyScaleTransform(float scaleTransform)](#applyScaleTransform-float-) | Past schaalvergroting toe op het knooppunt. |
+| [getBottom()](#getBottom--) | Haalt de onderkant op. |
+| [getCopy()](#getCopy--) | Maakt een volledige kopie van dit knooppunt. |
+| [getTop()](#getTop--) | Haalt de bovenkant op. |
+### ExtendedApsPath(ApsPath internalApsPath) {#ExtendedApsPath-com.aspose.foundation.rendering.ApsPath-}
+```
+public ExtendedApsPath(ApsPath internalApsPath)
+```
+
+
+Initialiseert een nieuw exemplaar van de `ExtendedApsPath`-klasse.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| internalApsPath | com.aspose.foundation.rendering.ApsPath | Het aps-pad. |
+
+### addToCompositeNode(ApsCompositeNode compositeNode) {#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-}
+```
+public void addToCompositeNode(ApsCompositeNode compositeNode)
+```
+
+
+Voegt dit knooppunt toe aan de gegeven `compositeNode`.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| compositeNode | com.aspose.foundation.rendering.ApsCompositeNode |  |
+
+### applyPlaneTransform(System.Drawing.PointF transformVector) {#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-}
+```
+public void applyPlaneTransform(System.Drawing.PointF transformVector)
+```
+
+
+Past een vlaktransformatie toe, waarbij het knooppunt in de x- en y-vlakken wordt verplaatst.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| transformVector | com.aspose.ms.System.Drawing.PointF |  |
+
+### applyScaleTransform(float scaleTransform) {#applyScaleTransform-float-}
+```
+public void applyScaleTransform(float scaleTransform)
+```
+
+
+Past schaalvergroting toe op het knooppunt.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| scaleTransform | float | De schaalfactor voor de transformatie. |
+
+### getBottom() {#getBottom--}
+```
+public float getBottom()
+```
+
+
+Haalt de onderkant op.
+
+**Returns:**
+float
+### getCopy() {#getCopy--}
+```
+public ExtendedApsNode getCopy()
+```
+
+
+Maakt een volledige kopie van dit knooppunt.
+
+**Returns:**
+[ExtendedApsNode](../../com.aspose.note/extendedapsnode) - The `IExtendedApsNode`.
+### getTop() {#getTop--}
+```
+public float getTop()
+```
+
+
+Haalt de bovenkant op.
+
+**Returns:**
+float

--- a/netherlands/java/com.aspose.note/extendedcompositenode/_index.md
+++ b/netherlands/java/com.aspose.note/extendedcompositenode/_index.md
@@ -1,0 +1,111 @@
+---
+title: "ExtendedCompositeNode"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Combineert meerdere IExtendedApsNode-instanties."
+type: docs
+weight: 29
+url: /nl/java/com.aspose.note/extendedcompositenode/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ExtendedApsNode](../../com.aspose.note/extendedapsnode)
+```
+public class ExtendedCompositeNode extends ExtendedApsNode
+```
+
+Combineert verschillende `IExtendedApsNode`-instanties.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [ExtendedCompositeNode()](#ExtendedCompositeNode--) | Initialiseert een nieuw exemplaar van de `ExtendedCompositeNode`-klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [add(ExtendedApsNode extendedApsNode)](#add-com.aspose.note.ExtendedApsNode-) | Voegt `extendedApsNode` toe aan de interne lijst met knooppunten. |
+| [addToCompositeNode(ApsCompositeNode compositeNode)](#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-) | Voegt dit knooppunt toe aan de gegeven `compositeNode`. |
+| [applyPlaneTransform(System.Drawing.PointF transformVector)](#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-) | Past een vlaktransformatie toe, waarbij het knooppunt in de x- en y-vlakken wordt verplaatst. |
+| [applyScaleTransform(float scaleTransform)](#applyScaleTransform-float-) | Past schaalvergroting toe op het knooppunt. |
+| [getApsNodes()](#getApsNodes--) | Haalt alle `IExtendedApsNode`-instanties op die zijn gecombineerd in deze `ExtendedCompositeNode`. |
+| [getCopy()](#getCopy--) | Maakt een volledige kopie van dit knooppunt. |
+### ExtendedCompositeNode() {#ExtendedCompositeNode--}
+```
+public ExtendedCompositeNode()
+```
+
+
+Initialiseert een nieuw exemplaar van de `ExtendedCompositeNode`-klasse.
+
+### add(ExtendedApsNode extendedApsNode) {#add-com.aspose.note.ExtendedApsNode-}
+```
+public final void add(ExtendedApsNode extendedApsNode)
+```
+
+
+Voegt `extendedApsNode` toe aan de interne lijst met knooppunten.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| extendedApsNode | [ExtendedApsNode](../../com.aspose.note/extendedapsnode) |  |
+
+### addToCompositeNode(ApsCompositeNode compositeNode) {#addToCompositeNode-com.aspose.foundation.rendering.ApsCompositeNode-}
+```
+public void addToCompositeNode(ApsCompositeNode compositeNode)
+```
+
+
+Voegt dit knooppunt toe aan de gegeven `compositeNode`.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| compositeNode | com.aspose.foundation.rendering.ApsCompositeNode |  |
+
+### applyPlaneTransform(System.Drawing.PointF transformVector) {#applyPlaneTransform-com.aspose.ms.System.Drawing.PointF-}
+```
+public void applyPlaneTransform(System.Drawing.PointF transformVector)
+```
+
+
+Past een vlaktransformatie toe, waarbij het knooppunt in de x- en y-vlakken wordt verplaatst.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| transformVector | com.aspose.ms.System.Drawing.PointF |  |
+
+### applyScaleTransform(float scaleTransform) {#applyScaleTransform-float-}
+```
+public void applyScaleTransform(float scaleTransform)
+```
+
+
+Past schaalvergroting toe op het knooppunt.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| scaleTransform | float | De schaalfactor voor de transformatie. |
+
+### getApsNodes() {#getApsNodes--}
+```
+public final System.Collections.Generic.IGenericCollection<ExtendedApsNode> getApsNodes()
+```
+
+
+Haalt alle `IExtendedApsNode`-instanties op die zijn gecombineerd in deze `ExtendedCompositeNode`.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericCollection&lt;com.aspose.note.ExtendedApsNode&gt;
+### getCopy() {#getCopy--}
+```
+public ExtendedApsNode getCopy()
+```
+
+
+Maakt een volledige kopie van dit knooppunt.
+
+**Returns:**
+[ExtendedApsNode](../../com.aspose.note/extendedapsnode) - The `IExtendedApsNode`.

--- a/netherlands/java/com.aspose.note/fileformat/_index.md
+++ b/netherlands/java/com.aspose.note/fileformat/_index.md
@@ -1,0 +1,56 @@
+---
+title: "FileFormat"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt het OneNote-bestandsformaat voor."
+type: docs
+weight: 30
+url: /nl/java/com.aspose.note/fileformat/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class FileFormat extends System.Enum
+```
+
+Stelt het OneNote-bestandsformaat voor.
+## Velden
+
+| Veld | Beschrijving |
+| --- | --- |
+| [OneNote2007](#OneNote2007) | OneNote 2010. |
+| [OneNote2010](#OneNote2010) | OneNote 2010. |
+| [OneNoteOnline](#OneNoteOnline) | OneNote Online. |
+| [Unknown](#Unknown) | Onbekend bestandsformaat. |
+### OneNote2007 {#OneNote2007}
+```
+public static final int OneNote2007
+```
+
+
+OneNote 2010.
+
+### OneNote2010 {#OneNote2010}
+```
+public static final int OneNote2010
+```
+
+
+OneNote 2010.
+
+### OneNoteOnline {#OneNoteOnline}
+```
+public static final int OneNoteOnline
+```
+
+
+OneNote Online.
+
+### Unknown {#Unknown}
+```
+public static final int Unknown
+```
+
+
+Onbekend bestandsformaat.
+

--- a/netherlands/java/com.aspose.note/fontsavingargs/_index.md
+++ b/netherlands/java/com.aspose.note/fontsavingargs/_index.md
@@ -1,0 +1,53 @@
+---
+title: "FontSavingArgs"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Levert gegevens voor het FontSaving evenement."
+type: docs
+weight: 31
+url: /nl/java/com.aspose.note/fontsavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ResourceSavingArgs](../../com.aspose.note/resourcesavingargs)
+```
+public class FontSavingArgs extends ResourceSavingArgs
+```
+
+Levert gegevens voor het FontSaving evenement.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getFontFamilyName()](#getFontFamilyName--) | Haalt de familienaam van het op te slaan lettertype op. |
+| [isBold()](#isBold--) | Haalt een waarde op die aangeeft of het op te slaan lettertype vetgedrukt is. |
+| [isItalic()](#isItalic--) | Haalt een waarde op die aangeeft of het op te slaan lettertype cursief is. |
+### getFontFamilyName() {#getFontFamilyName--}
+```
+public final String getFontFamilyName()
+```
+
+
+Haalt de familienaam van het op te slaan lettertype op.
+
+**Returns:**
+java.lang.String
+### isBold() {#isBold--}
+```
+public final boolean isBold()
+```
+
+
+Haalt een waarde op die aangeeft of het op te slaan lettertype vetgedrukt is.
+
+**Returns:**
+boolean
+### isItalic() {#isItalic--}
+```
+public final boolean isItalic()
+```
+
+
+Haalt een waarde op die aangeeft of het op te slaan lettertype cursief is.
+
+**Returns:**
+boolean

--- a/netherlands/java/com.aspose.note/htmlsaveoptions/_index.md
+++ b/netherlands/java/com.aspose.note/htmlsaveoptions/_index.md
@@ -1,0 +1,287 @@
+---
+title: "HtmlSaveOptions"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Staat toe extra opties op te geven bij het opslaan van een document naar HTML-formaat."
+type: docs
+weight: 32
+url: /nl/java/com.aspose.note/htmlsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.SaveOptions](../../com.aspose.note/saveoptions)
+```
+public class HtmlSaveOptions extends SaveOptions
+```
+
+Staat toe extra opties op te geven bij het opslaan van een document naar HTML-formaat.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [HtmlSaveOptions()](#HtmlSaveOptions--) | Initialiseert een nieuw exemplaar van de [HtmlSaveOptions](../../com.aspose.note/htmlsaveoptions) klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getCssPerPageGeneration()](#getCssPerPageGeneration--) | Haalt op of stelt in of het StyleSheet-bestand afzonderlijk voor elke nieuwe pagina wordt gegenereerd. |
+| [getCssSavingCallback()](#getCssSavingCallback--) | Haalt op of stelt de callback in die wordt aangeroepen om een bron te maken om CSS op te slaan. |
+| [getDocumentPerPageGeneration()](#getDocumentPerPageGeneration--) | Haalt op of stelt een waarde in die aangeeft of document-per-pagina generatie is ingeschakeld. |
+| [getExportCss()](#getExportCss--) | Haalt op of stelt de manier in waarop css wordt geëxporteerd. |
+| [getExportFonts()](#getExportFonts--) | Haalt op of stelt de manier in waarop lettertypen worden geëxporteerd. |
+| [getExportImages()](#getExportImages--) | Haalt op of stelt de manier in waarop afbeeldingen worden geëxporteerd. |
+| [getFontFaceTypes()](#getFontFaceTypes--) | Haalt op of stelt de font face types in. |
+| [getFontSavingCallback()](#getFontSavingCallback--) | Haalt op of stelt de callback in die wordt aangeroepen om een bron te maken om lettertype op te slaan. |
+| [getImageSavingCallback()](#getImageSavingCallback--) | Haalt op of stelt de callback in die wordt aangeroepen om een bron te maken om afbeelding op te slaan. |
+| [getPageSavingCallback()](#getPageSavingCallback--) | Haalt op of stelt de callback in die wordt aangeroepen om een bron te maken om pagina op te slaan. |
+| [setCssPerPageGeneration(boolean value)](#setCssPerPageGeneration-boolean-) | Haalt op of stelt in of het StyleSheet-bestand afzonderlijk voor elke nieuwe pagina wordt gegenereerd. |
+| [setCssSavingCallback(ICssSavingCallback value)](#setCssSavingCallback-com.aspose.note.ICssSavingCallback-) | Haalt op of stelt de callback in die wordt aangeroepen om een bron te maken om CSS op te slaan. |
+| [setDocumentPerPageGeneration(boolean value)](#setDocumentPerPageGeneration-boolean-) | Haalt op of stelt een waarde in die aangeeft of document-per-pagina generatie is ingeschakeld. |
+| [setExportCss(int value)](#setExportCss-int-) | Haalt op of stelt de manier in waarop css wordt geëxporteerd. |
+| [setExportFonts(int value)](#setExportFonts-int-) | Haalt op of stelt de manier in waarop lettertypen worden geëxporteerd. |
+| [setExportImages(int value)](#setExportImages-int-) | Haalt op of stelt de manier in waarop afbeeldingen worden geëxporteerd. |
+| [setFontFaceTypes(int value)](#setFontFaceTypes-int-) | Haalt op of stelt de font face types in. |
+| [setFontSavingCallback(IFontSavingCallback value)](#setFontSavingCallback-com.aspose.note.IFontSavingCallback-) | Haalt op of stelt de callback in die wordt aangeroepen om een bron te maken om lettertype op te slaan. |
+| [setImageSavingCallback(IImageSavingCallback value)](#setImageSavingCallback-com.aspose.note.IImageSavingCallback-) | Haalt op of stelt de callback in die wordt aangeroepen om een bron te maken om afbeelding op te slaan. |
+| [setPageSavingCallback(IPageSavingCallback value)](#setPageSavingCallback-com.aspose.note.IPageSavingCallback-) | Haalt op of stelt de callback in die wordt aangeroepen om een bron te maken om pagina op te slaan. |
+### HtmlSaveOptions() {#HtmlSaveOptions--}
+```
+public HtmlSaveOptions()
+```
+
+
+Initialiseert een nieuw exemplaar van de [HtmlSaveOptions](../../com.aspose.note/htmlsaveoptions) klasse.
+
+### getCssPerPageGeneration() {#getCssPerPageGeneration--}
+```
+public final boolean getCssPerPageGeneration()
+```
+
+
+Haalt op of stelt in of het StyleSheet-bestand afzonderlijk voor elke nieuwe pagina wordt gegenereerd.
+
+**Returns:**
+boolean
+### getCssSavingCallback() {#getCssSavingCallback--}
+```
+public final ICssSavingCallback getCssSavingCallback()
+```
+
+
+Haalt op of stelt de callback in die wordt aangeroepen om een bron te maken om CSS op te slaan.
+
+**Returns:**
+[ICssSavingCallback](../../com.aspose.note/icsssavingcallback)
+### getDocumentPerPageGeneration() {#getDocumentPerPageGeneration--}
+```
+public final boolean getDocumentPerPageGeneration()
+```
+
+
+Haalt op of stelt een waarde in die aangeeft of document-per-pagina generatie is ingeschakeld.
+
+**Returns:**
+boolean
+### getExportCss() {#getExportCss--}
+```
+public final int getExportCss()
+```
+
+
+Haalt op of stelt de manier in waarop css wordt geëxporteerd.
+
+**Returns:**
+int
+### getExportFonts() {#getExportFonts--}
+```
+public final int getExportFonts()
+```
+
+
+Haalt op of stelt de manier in waarop lettertypen worden geëxporteerd.
+
+**Returns:**
+int
+### getExportImages() {#getExportImages--}
+```
+public final int getExportImages()
+```
+
+
+Haalt op of stelt de manier in waarop afbeeldingen worden geëxporteerd.
+
+**Returns:**
+int
+### getFontFaceTypes() {#getFontFaceTypes--}
+```
+public final int getFontFaceTypes()
+```
+
+
+Haalt op of stelt de font face types in.
+
+Waarde: De font face types.
+
+**Returns:**
+int
+### getFontSavingCallback() {#getFontSavingCallback--}
+```
+public final IFontSavingCallback getFontSavingCallback()
+```
+
+
+Haalt op of stelt de callback in die wordt aangeroepen om een bron te maken om lettertype op te slaan.
+
+**Returns:**
+[IFontSavingCallback](../../com.aspose.note/ifontsavingcallback)
+### getImageSavingCallback() {#getImageSavingCallback--}
+```
+public final IImageSavingCallback getImageSavingCallback()
+```
+
+
+Haalt op of stelt de callback in die wordt aangeroepen om een bron te maken om afbeelding op te slaan.
+
+**Returns:**
+[IImageSavingCallback](../../com.aspose.note/iimagesavingcallback)
+### getPageSavingCallback() {#getPageSavingCallback--}
+```
+public final IPageSavingCallback getPageSavingCallback()
+```
+
+
+Haalt op of stelt de callback in die wordt aangeroepen om een bron te maken om pagina op te slaan.
+
+**Returns:**
+[IPageSavingCallback](../../com.aspose.note/ipagesavingcallback)
+### setCssPerPageGeneration(boolean value) {#setCssPerPageGeneration-boolean-}
+```
+public final void setCssPerPageGeneration(boolean value)
+```
+
+
+Haalt op of stelt in of het StyleSheet-bestand afzonderlijk voor elke nieuwe pagina wordt gegenereerd.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+### setCssSavingCallback(ICssSavingCallback value) {#setCssSavingCallback-com.aspose.note.ICssSavingCallback-}
+```
+public final void setCssSavingCallback(ICssSavingCallback value)
+```
+
+
+Haalt op of stelt de callback in die wordt aangeroepen om een bron te maken om CSS op te slaan.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| value | [ICssSavingCallback](../../com.aspose.note/icsssavingcallback) |  |
+
+### setDocumentPerPageGeneration(boolean value) {#setDocumentPerPageGeneration-boolean-}
+```
+public final void setDocumentPerPageGeneration(boolean value)
+```
+
+
+Haalt op of stelt een waarde in die aangeeft of document-per-pagina generatie is ingeschakeld.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+### setExportCss(int value) {#setExportCss-int-}
+```
+public final void setExportCss(int value)
+```
+
+
+Haalt op of stelt de manier in waarop css wordt geëxporteerd.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+
+### setExportFonts(int value) {#setExportFonts-int-}
+```
+public final void setExportFonts(int value)
+```
+
+
+Haalt op of stelt de manier in waarop lettertypen worden geëxporteerd.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+
+### setExportImages(int value) {#setExportImages-int-}
+```
+public final void setExportImages(int value)
+```
+
+
+Haalt op of stelt de manier in waarop afbeeldingen worden geëxporteerd.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+
+### setFontFaceTypes(int value) {#setFontFaceTypes-int-}
+```
+public final void setFontFaceTypes(int value)
+```
+
+
+Haalt op of stelt de font face types in.
+
+Waarde: De font face types.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+
+### setFontSavingCallback(IFontSavingCallback value) {#setFontSavingCallback-com.aspose.note.IFontSavingCallback-}
+```
+public final void setFontSavingCallback(IFontSavingCallback value)
+```
+
+
+Haalt op of stelt de callback in die wordt aangeroepen om een bron te maken om lettertype op te slaan.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| value | [IFontSavingCallback](../../com.aspose.note/ifontsavingcallback) |  |
+
+### setImageSavingCallback(IImageSavingCallback value) {#setImageSavingCallback-com.aspose.note.IImageSavingCallback-}
+```
+public final void setImageSavingCallback(IImageSavingCallback value)
+```
+
+
+Haalt op of stelt de callback in die wordt aangeroepen om een bron te maken om afbeelding op te slaan.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| value | [IImageSavingCallback](../../com.aspose.note/iimagesavingcallback) |  |
+
+### setPageSavingCallback(IPageSavingCallback value) {#setPageSavingCallback-com.aspose.note.IPageSavingCallback-}
+```
+public final void setPageSavingCallback(IPageSavingCallback value)
+```
+
+
+Haalt op of stelt de callback in die wordt aangeroepen om een bron te maken om pagina op te slaan.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| value | [IPageSavingCallback](../../com.aspose.note/ipagesavingcallback) |  |
+

--- a/netherlands/java/com.aspose.note/icompositenode/_index.md
+++ b/netherlands/java/com.aspose.note/icompositenode/_index.md
@@ -1,0 +1,33 @@
+---
+title: "ICompositeNode"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De interface voor knooppunten die andere knooppunten kunnen bevatten."
+type: docs
+weight: 96
+url: /nl/java/com.aspose.note/icompositenode/
+---
+```
+public interface ICompositeNode
+```
+
+De interface voor knooppunten die andere knooppunten kunnen bevatten.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [&lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass)](#-T1-getChildNodes-java.lang.Class-T1--) |  |
+### &lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass) {#-T1-getChildNodes-java.lang.Class-T1--}
+```
+public abstract List<T1> <T1>getChildNodes(Class<T1> typeParameterClass)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| typeParameterClass | java.lang.Class&lt;T1&gt; |  |
+
+**Returns:**
+java.util.List&lt;T1&gt;

--- a/netherlands/java/com.aspose.note/icompositenodet/_index.md
+++ b/netherlands/java/com.aspose.note/icompositenodet/_index.md
@@ -1,0 +1,20 @@
+---
+title: "ICompositeNodeT"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De interface voor knooppunten die andere knooppunten kunnen bevatten."
+type: docs
+weight: 97
+url: /nl/java/com.aspose.note/icompositenodet/
+---
+
+**All Implemented Interfaces:**
+[com.aspose.note.ICompositeNode](../../com.aspose.note/icompositenode), com.aspose.ms.System.Collections.Generic.IGenericEnumerable
+```
+public interface ICompositeNodeT<T> extends ICompositeNode, System.Collections.Generic.IGenericEnumerable<T>
+```
+
+De interface voor knooppunten die andere knooppunten kunnen bevatten.
+
+`T`: Type van kindknopen
+
+T :

--- a/netherlands/java/com.aspose.note/icsssavingcallback/_index.md
+++ b/netherlands/java/com.aspose.note/icsssavingcallback/_index.md
@@ -1,0 +1,31 @@
+---
+title: "ICssSavingCallback"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Implementeer deze interface als je wilt bepalen hoe Aspose.Note CSS Cascading Style Sheet opslaat bij het opslaan van een document naar HTML."
+type: docs
+weight: 98
+url: /nl/java/com.aspose.note/icsssavingcallback/
+---
+```
+public interface ICssSavingCallback
+```
+
+Implementeer deze interface als u wilt bepalen hoe Aspose.Note CSS (Cascading Style Sheet) opslaat bij het opslaan van een document naar HTML.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [cssSaving(CssSavingArgs args)](#cssSaving-com.aspose.note.CssSavingArgs-) | Wordt aangeroepen wanneer Aspose.Note een CSS (Cascading Style Sheet) opslaat. |
+### cssSaving(CssSavingArgs args) {#cssSaving-com.aspose.note.CssSavingArgs-}
+```
+public abstract void cssSaving(CssSavingArgs args)
+```
+
+
+Wordt aangeroepen wanneer Aspose.Note een CSS (Cascading Style Sheet) opslaat.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| args | [CssSavingArgs](../../com.aspose.note/csssavingargs) | Opslagparameters. |
+

--- a/netherlands/java/com.aspose.note/ifontsavingcallback/_index.md
+++ b/netherlands/java/com.aspose.note/ifontsavingcallback/_index.md
@@ -1,0 +1,31 @@
+---
+title: "IFontSavingCallback"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Implementeer deze interface als u wilt bepalen hoe Aspose.Note lettertypen opslaat bij het opslaan van een document naar HTML."
+type: docs
+weight: 99
+url: /nl/java/com.aspose.note/ifontsavingcallback/
+---
+```
+public interface IFontSavingCallback
+```
+
+Implementeer deze interface als u wilt bepalen hoe Aspose.Note lettertypen opslaat bij het opslaan van een document naar HTML.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [fontSaving(FontSavingArgs args)](#fontSaving-com.aspose.note.FontSavingArgs-) | Wordt aangeroepen wanneer Aspose.Note een lettertype opslaat. |
+### fontSaving(FontSavingArgs args) {#fontSaving-com.aspose.note.FontSavingArgs-}
+```
+public abstract void fontSaving(FontSavingArgs args)
+```
+
+
+Wordt aangeroepen wanneer Aspose.Note een lettertype opslaat.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| args | [FontSavingArgs](../../com.aspose.note/fontsavingargs) | Opslagparameters. |
+

--- a/netherlands/java/com.aspose.note/iimagesavingcallback/_index.md
+++ b/netherlands/java/com.aspose.note/iimagesavingcallback/_index.md
@@ -1,0 +1,31 @@
+---
+title: "IImageSavingCallback"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Implementeer deze interface als u wilt bepalen hoe Aspose.Note afbeeldingen opslaat bij het opslaan van een document naar HTML."
+type: docs
+weight: 100
+url: /nl/java/com.aspose.note/iimagesavingcallback/
+---
+```
+public interface IImageSavingCallback
+```
+
+Implementeer deze interface als u wilt bepalen hoe Aspose.Note afbeeldingen opslaat bij het opslaan van een document naar HTML.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [imageSaving(ImageSavingArgs args)](#imageSaving-com.aspose.note.ImageSavingArgs-) | Wordt aangeroepen wanneer Aspose.Note een afbeelding opslaat. |
+### imageSaving(ImageSavingArgs args) {#imageSaving-com.aspose.note.ImageSavingArgs-}
+```
+public abstract void imageSaving(ImageSavingArgs args)
+```
+
+
+Wordt aangeroepen wanneer Aspose.Note een afbeelding opslaat.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| args | [ImageSavingArgs](../../com.aspose.note/imagesavingargs) | Opslagparameters. |
+

--- a/netherlands/java/com.aspose.note/iindentatednode/_index.md
+++ b/netherlands/java/com.aspose.note/iindentatednode/_index.md
@@ -1,0 +1,60 @@
+---
+title: "IIndentatedNode"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De interface voor knooppunten met relatieve inspringing voor onderliggende knooppunten."
+type: docs
+weight: 101
+url: /nl/java/com.aspose.note/iindentatednode/
+---
+```
+public interface IIndentatedNode
+```
+
+De interface voor knooppunten met relatieve inspringing voor onderliggende knooppunten.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [&lt;T&gt;setIndentPosition(byte value)](#-T-setIndentPosition-byte-) | Haalt op of stelt de insprongpositie in. |
+| [&lt;T&gt;setIndentPosition(int value)](#-T-setIndentPosition-int-) | Haalt op of stelt de insprongpositie in. |
+| [getIndentPosition()](#getIndentPosition--) | Haalt op of stelt de insprongpositie in. |
+### &lt;T&gt;setIndentPosition(byte value) {#-T-setIndentPosition-byte-}
+```
+public abstract T <T>setIndentPosition(byte value)
+```
+
+
+Haalt op of stelt de insprongpositie in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | byte |  |
+
+**Returns:**
+T
+### &lt;T&gt;setIndentPosition(int value) {#-T-setIndentPosition-int-}
+```
+public abstract T <T>setIndentPosition(int value)
+```
+
+
+Haalt op of stelt de insprongpositie in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+
+**Returns:**
+T
+### getIndentPosition() {#getIndentPosition--}
+```
+public abstract byte getIndentPosition()
+```
+
+
+Haalt op of stelt de insprongpositie in.
+
+**Returns:**
+byte

--- a/netherlands/java/com.aspose.note/image/_index.md
+++ b/netherlands/java/com.aspose.note/image/_index.md
@@ -1,0 +1,420 @@
+---
+title: "Afbeelding"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een afbeelding voor."
+type: docs
+weight: 33
+url: /nl/java/com.aspose.note/image/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode
+
+**All Implemented Interfaces:**
+[com.aspose.note.IPageChildNode](../../com.aspose.note/ipagechildnode), [com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode), [com.aspose.note.ITaggable](../../com.aspose.note/itaggable)
+```
+public final class Image extends CompositeNode<Loop> implements IPageChildNode, IOutlineElementChildNode, ITaggable
+```
+
+Stelt een afbeelding voor.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [Image(String path)](#Image-java.lang.String-) | Initialiseert een nieuw exemplaar van de `Image`-klasse. |
+| [Image(String fileName, InputStream imageStream)](#Image-java.lang.String-java.io.InputStream-) | Initialiseert een nieuw exemplaar van de `Image`-klasse. |
+| [Image()](#Image--) | Initialiseert een nieuw exemplaar van de `Image`-klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | Accepteert de bezoeker van de node. |
+| [getAlignment()](#getAlignment--) | Haalt de uitlijning op. |
+| [getAlternativeTextDescription()](#getAlternativeTextDescription--) | Haalt een body en alternatieve tekst voor de afbeelding op. |
+| [getAlternativeTextTitle()](#getAlternativeTextTitle--) | Haalt een titel van de alternatieve tekst voor de afbeelding op. |
+| [getBytes()](#getBytes--) | Haalt de afbeeldingsdatastore op. |
+| [getFileName()](#getFileName--) | Haalt de bestandsnaam op. |
+| [getFilePath()](#getFilePath--) | Haalt het pad naar het afbeeldingsbestand op. |
+| [getFormat()](#getFormat--) | Haalt het formaat van de afbeelding op. |
+| [getHeight()](#getHeight--) | Haalt de hoogte op. |
+| [getHorizontalOffset()](#getHorizontalOffset--) | Haalt de horizontale offset op. |
+| [getHyperlinkUrl()](#getHyperlinkUrl--) | Haalt de hyperlink op die aan de afbeelding is gekoppeld. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | Haalt de laatst gewijzigde tijd op. |
+| [getOriginalHeight()](#getOriginalHeight--) | Haalt de oorspronkelijke hoogte op. |
+| [getOriginalWidth()](#getOriginalWidth--) | Haalt de oorspronkelijke breedte op. |
+| [getTags()](#getTags--) | Haalt de lijst met alle tags van een afbeelding op. |
+| [getVerticalOffset()](#getVerticalOffset--) | Haalt de verticale offset op. |
+| [getWidth()](#getWidth--) | Haalt de breedte op. |
+| [isBackground()](#isBackground--) | Haalt op of de afbeelding een achtergrondafbeelding is. |
+| [replace(Image newImage)](#replace-com.aspose.note.Image-) | Vervangt de huidige afbeeldingsgegevens door de gegevens van het opgegeven Image-object. |
+| [setAlignment(int value)](#setAlignment-int-) | Stelt de uitlijning in. |
+| [setAlternativeTextDescription(String value)](#setAlternativeTextDescription-java.lang.String-) | Stelt een body en alternatieve tekst voor de afbeelding in. |
+| [setAlternativeTextTitle(String value)](#setAlternativeTextTitle-java.lang.String-) | Stelt een titel van de alternatieve tekst voor de afbeelding in. |
+| [setBackground(boolean value)](#setBackground-boolean-) | Haalt op of de afbeelding een achtergrondafbeelding is. |
+| [setHeight(float value)](#setHeight-float-) | Stelt de hoogte in. |
+| [setHorizontalOffset(float value)](#setHorizontalOffset-float-) | Stelt de horizontale offset in. |
+| [setHyperlinkUrl(String value)](#setHyperlinkUrl-java.lang.String-) | Stelt de hyperlink in die aan de afbeelding is gekoppeld. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | Stelt de laatste wijzigingstijd in. |
+| [setVerticalOffset(float value)](#setVerticalOffset-float-) | Stelt de verticale offset in. |
+| [setWidth(float value)](#setWidth-float-) | Stelt de breedte in. |
+### Image(String path) {#Image-java.lang.String-}
+```
+public Image(String path)
+```
+
+
+Initialiseert een nieuw exemplaar van de `Image`-klasse.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| path | java.lang.String | Een string die het pad naar het bestand bevat waaruit de `Image` wordt gemaakt. |
+
+### Image(String fileName, InputStream imageStream) {#Image-java.lang.String-java.io.InputStream-}
+```
+public Image(String fileName, InputStream imageStream)
+```
+
+
+Initialiseert een nieuw exemplaar van de `Image`-klasse.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| fileName | java.lang.String | Een naam van de afbeelding. |
+| imageStream | java.io.InputStream | Een stream die de afbeelding bevat. |
+
+### Image() {#Image--}
+```
+public Image()
+```
+
+
+Initialiseert een nieuw exemplaar van de `Image`-klasse.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+Accepteert de bezoeker van de node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | Het object van een klasse die afgeleid is van de `DocumentVisitor`. |
+
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+Haalt de uitlijning op.
+
+**Returns:**
+int
+### getAlternativeTextDescription() {#getAlternativeTextDescription--}
+```
+public final String getAlternativeTextDescription()
+```
+
+
+Haalt een body en alternatieve tekst voor de afbeelding op.
+
+**Returns:**
+java.lang.String
+### getAlternativeTextTitle() {#getAlternativeTextTitle--}
+```
+public final String getAlternativeTextTitle()
+```
+
+
+Haalt een titel van de alternatieve tekst voor de afbeelding op.
+
+**Returns:**
+java.lang.String
+### getBytes() {#getBytes--}
+```
+public byte[] getBytes()
+```
+
+
+Haalt de afbeeldingsdatastore op.
+
+**Returns:**
+byte[]
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+Haalt de bestandsnaam op.
+
+**Returns:**
+java.lang.String
+### getFilePath() {#getFilePath--}
+```
+public String getFilePath()
+```
+
+
+Haalt het pad naar het afbeeldingsbestand op.
+
+**Returns:**
+java.lang.String
+### getFormat() {#getFormat--}
+```
+public final System.Drawing.Imaging.ImageFormat getFormat()
+```
+
+
+Haalt het formaat van de afbeelding op.
+
+**Returns:**
+com.aspose.ms.System.Drawing.Imaging.ImageFormat
+### getHeight() {#getHeight--}
+```
+public final float getHeight()
+```
+
+
+Haalt de hoogte op. Dit is de werkelijke hoogte van de afbeelding in het MS OneNote-document.
+
+**Returns:**
+float
+### getHorizontalOffset() {#getHorizontalOffset--}
+```
+public float getHorizontalOffset()
+```
+
+
+Haalt de horizontale offset op.
+
+**Returns:**
+float
+### getHyperlinkUrl() {#getHyperlinkUrl--}
+```
+public String getHyperlinkUrl()
+```
+
+
+Haalt de hyperlink op die aan de afbeelding is gekoppeld.
+
+**Returns:**
+java.lang.String
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+Haalt de laatst gewijzigde tijd op.
+
+**Returns:**
+java.util.Date
+### getOriginalHeight() {#getOriginalHeight--}
+```
+public float getOriginalHeight()
+```
+
+
+Haalt de oorspronkelijke hoogte op. Dit is de oorspronkelijke breedte van de afbeelding, vóór het schalen.
+
+**Returns:**
+float
+### getOriginalWidth() {#getOriginalWidth--}
+```
+public float getOriginalWidth()
+```
+
+
+Haalt de oorspronkelijke breedte op. Dit is de oorspronkelijke breedte van de afbeelding, vóór het schalen.
+
+**Returns:**
+float
+### getTags() {#getTags--}
+```
+public final System.Collections.Generic.List<ITag> getTags()
+```
+
+
+Haalt de lijst met alle tags van een afbeelding op.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List&lt;com.aspose.note.ITag&gt;
+### getVerticalOffset() {#getVerticalOffset--}
+```
+public float getVerticalOffset()
+```
+
+
+Haalt de verticale offset op.
+
+**Returns:**
+float
+### getWidth() {#getWidth--}
+```
+public final float getWidth()
+```
+
+
+Haalt de breedte op. Dit is de werkelijke breedte van de afbeelding in het MS OneNote-document.
+
+**Returns:**
+float
+### isBackground() {#isBackground--}
+```
+public final boolean isBackground()
+```
+
+
+Haalt op of de afbeelding een achtergrondafbeelding is.
+
+**Returns:**
+boolean
+### replace(Image newImage) {#replace-com.aspose.note.Image-}
+```
+public void replace(Image newImage)
+```
+
+
+Vervangt de huidige afbeeldingsgegevens door de gegevens van het opgegeven Image-object.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| newImage | [Image](../../com.aspose.note/image) |  |
+
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+Stelt de uitlijning in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+
+### setAlternativeTextDescription(String value) {#setAlternativeTextDescription-java.lang.String-}
+```
+public final void setAlternativeTextDescription(String value)
+```
+
+
+Stelt een body en alternatieve tekst voor de afbeelding in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+
+### setAlternativeTextTitle(String value) {#setAlternativeTextTitle-java.lang.String-}
+```
+public final void setAlternativeTextTitle(String value)
+```
+
+
+Stelt een titel van de alternatieve tekst voor de afbeelding in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+
+### setBackground(boolean value) {#setBackground-boolean-}
+```
+public final void setBackground(boolean value)
+```
+
+
+Haalt op of de afbeelding een achtergrondafbeelding is.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+### setHeight(float value) {#setHeight-float-}
+```
+public final void setHeight(float value)
+```
+
+
+Stelt de hoogte in. Dit is de werkelijke hoogte van de afbeelding in het MS OneNote-document.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+
+### setHorizontalOffset(float value) {#setHorizontalOffset-float-}
+```
+public void setHorizontalOffset(float value)
+```
+
+
+Stelt de horizontale offset in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+
+### setHyperlinkUrl(String value) {#setHyperlinkUrl-java.lang.String-}
+```
+public void setHyperlinkUrl(String value)
+```
+
+
+Stelt de hyperlink in die aan de afbeelding is gekoppeld.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+Stelt de laatste wijzigingstijd in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Date |  |
+
+### setVerticalOffset(float value) {#setVerticalOffset-float-}
+```
+public void setVerticalOffset(float value)
+```
+
+
+Stelt de verticale offset in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+
+### setWidth(float value) {#setWidth-float-}
+```
+public final void setWidth(float value)
+```
+
+
+Stelt de breedte in. Dit is de werkelijke breedte van de afbeelding in het MS OneNote-document.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+

--- a/netherlands/java/com.aspose.note/imagebinarizationoptions/_index.md
+++ b/netherlands/java/com.aspose.note/imagebinarizationoptions/_index.md
@@ -1,0 +1,83 @@
+---
+title: "ImageBinarizationOptions"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Opties voor beeldbinarisatie."
+type: docs
+weight: 34
+url: /nl/java/com.aspose.note/imagebinarizationoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ImageBinarizationOptions
+```
+
+Opties voor de binarisatie van de afbeelding.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [ImageBinarizationOptions()](#ImageBinarizationOptions--) | Initialiseert een nieuw exemplaar van de [ImageBinarizationOptions](../../com.aspose.note/imagebinarizationoptions) klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getBinarizationMethod()](#getBinarizationMethod--) | Haalt de binarisatiemethode op of stelt deze in. |
+| [getBinarizationThreshold()](#getBinarizationThreshold--) | Haalt de drempelwaarde op of stelt deze in voor de vaste drempel binarisatiemethode. |
+| [setBinarizationMethod(int value)](#setBinarizationMethod-int-) | Haalt de binarisatiemethode op of stelt deze in. |
+| [setBinarizationThreshold(int value)](#setBinarizationThreshold-int-) | Haalt de drempelwaarde op of stelt deze in voor de vaste drempel binarisatiemethode. |
+### ImageBinarizationOptions() {#ImageBinarizationOptions--}
+```
+public ImageBinarizationOptions()
+```
+
+
+Initialiseert een nieuw exemplaar van de [ImageBinarizationOptions](../../com.aspose.note/imagebinarizationoptions) klasse.
+
+### getBinarizationMethod() {#getBinarizationMethod--}
+```
+public final int getBinarizationMethod()
+```
+
+
+Haalt de binarisatiemethode op of stelt deze in. De standaardwaarde is [BinarizationMethod.FixedThreshold](../../com.aspose.note/binarizationmethod\#FixedThreshold).
+
+**Returns:**
+int
+### getBinarizationThreshold() {#getBinarizationThreshold--}
+```
+public final int getBinarizationThreshold()
+```
+
+
+Haalt de drempelwaarde op of stelt deze in voor de vaste drempel binarisatiemethode. De standaardwaarde is 128.
+
+**Returns:**
+int
+### setBinarizationMethod(int value) {#setBinarizationMethod-int-}
+```
+public final void setBinarizationMethod(int value)
+```
+
+
+Haalt de binarisatiemethode op of stelt deze in. De standaardwaarde is [BinarizationMethod.FixedThreshold](../../com.aspose.note/binarizationmethod\#FixedThreshold).
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+
+### setBinarizationThreshold(int value) {#setBinarizationThreshold-int-}
+```
+public final void setBinarizationThreshold(int value)
+```
+
+
+Haalt de drempelwaarde op of stelt deze in voor de vaste drempel binarisatiemethode. De standaardwaarde is 128.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+

--- a/netherlands/java/com.aspose.note/imagesaveoptions/_index.md
+++ b/netherlands/java/com.aspose.note/imagesaveoptions/_index.md
@@ -1,0 +1,179 @@
+---
+title: "ImageSaveOptions"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Staat toe extra opties op te geven bij het renderen van documentpagina's naar afbeeldingen."
+type: docs
+weight: 35
+url: /nl/java/com.aspose.note/imagesaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.SaveOptions](../../com.aspose.note/saveoptions)
+```
+public class ImageSaveOptions extends SaveOptions
+```
+
+Staat toe extra opties op te geven bij het renderen van documentpagina's naar afbeeldingen.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [ImageSaveOptions(int format)](#ImageSaveOptions-int-) | Initialiseert een nieuw exemplaar van de `ImageSaveOptions`-klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getBinarizationOptions()](#getBinarizationOptions--) | Haalt of stelt opties in voor de binarisatie van de afbeelding. |
+| [getColorMode()](#getColorMode--) | Haalt of stelt `ColorMode`([getColorMode](../../com.aspose.note/imagesaveoptions\#getColorMode--)/[setColorMode(int)](../../com.aspose.note/imagesaveoptions\#setColorMode-int-)) in voor de uitvoerafbeelding. |
+| [getQuality()](#getQuality--) | Haalt een waarde op die de kwaliteit van de opgeslagen afbeelding bepaalt. |
+| [getResolution()](#getResolution--) | Haalt de resolutie op voor de gegenereerde afbeeldingen, in punten per inch. |
+| [getTiffCompression()](#getTiffCompression--) | Haalt op of stelt het type compressie in dat moet worden gebruikt bij het opslaan van gegenereerde afbeeldingen in het TIFF-formaat. |
+| [setBinarizationOptions(ImageBinarizationOptions value)](#setBinarizationOptions-com.aspose.note.ImageBinarizationOptions-) | Haalt of stelt opties in voor de binarisatie van de afbeelding. |
+| [setColorMode(int value)](#setColorMode-int-) | Haalt of stelt `ColorMode`([getColorMode](../../com.aspose.note/imagesaveoptions\#getColorMode--)/[setColorMode(int)](../../com.aspose.note/imagesaveoptions\#setColorMode-int-)) in voor de uitvoerafbeelding. |
+| [setQuality(int value)](#setQuality-int-) | Stelt een waarde in die de kwaliteit van de opgeslagen afbeelding bepaalt. |
+| [setResolution(float value)](#setResolution-float-) | Stelt de resolutie in voor de gegenereerde afbeeldingen, in dots per inch. |
+| [setTiffCompression(int value)](#setTiffCompression-int-) | Haalt op of stelt het type compressie in dat moet worden gebruikt bij het opslaan van gegenereerde afbeeldingen in het TIFF-formaat. |
+### ImageSaveOptions(int format) {#ImageSaveOptions-int-}
+```
+public ImageSaveOptions(int format)
+```
+
+
+Initialiseert een nieuw exemplaar van de `ImageSaveOptions`-klasse.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| format | int | Het formaat waarin het document wordt opgeslagen. |
+
+### getBinarizationOptions() {#getBinarizationOptions--}
+```
+public final ImageBinarizationOptions getBinarizationOptions()
+```
+
+
+Haalt of stelt opties in voor de binarisatie van de afbeelding.
+
+**Returns:**
+[ImageBinarizationOptions](../../com.aspose.note/imagebinarizationoptions)
+### getColorMode() {#getColorMode--}
+```
+public final int getColorMode()
+```
+
+
+Haalt of stelt `ColorMode`([getColorMode](../../com.aspose.note/imagesaveoptions\#getColorMode--)/[setColorMode(int)](../../com.aspose.note/imagesaveoptions\#setColorMode-int-)) in voor de uitvoerafbeelding.
+
+**Returns:**
+int
+### getQuality() {#getQuality--}
+```
+public final int getQuality()
+```
+
+
+Haalt een waarde op die de kwaliteit van de opgeslagen afbeelding bepaalt. Deze waarde wordt doorgegeven aan de codec als de System.Drawing.Imaging.Encoder.Quality‑parameter.
+
+--------------------
+
+Het bereik van bruikbare waarden voor de kwaliteitscategorie is van 0 tot 100. Hoe lager het opgegeven getal, hoe hoger de compressie en dus hoe lager de kwaliteit van de afbeelding. Nul geeft de laagste kwaliteit afbeelding en 100 de hoogste. De standaardwaarde is 90.
+
+**Returns:**
+int
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+Haalt de resolutie op voor de gegenereerde afbeeldingen, in punten per inch.
+
+--------------------
+
+De standaardwaarde is 96.
+
+**Returns:**
+float
+### getTiffCompression() {#getTiffCompression--}
+```
+public final int getTiffCompression()
+```
+
+
+Haalt op of stelt het type compressie in dat moet worden gebruikt bij het opslaan van gegenereerde afbeeldingen in het TIFF-formaat.
+
+**Returns:**
+int
+### setBinarizationOptions(ImageBinarizationOptions value) {#setBinarizationOptions-com.aspose.note.ImageBinarizationOptions-}
+```
+public final void setBinarizationOptions(ImageBinarizationOptions value)
+```
+
+
+Haalt of stelt opties in voor de binarisatie van de afbeelding.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| value | [ImageBinarizationOptions](../../com.aspose.note/imagebinarizationoptions) |  |
+
+### setColorMode(int value) {#setColorMode-int-}
+```
+public final void setColorMode(int value)
+```
+
+
+Haalt of stelt `ColorMode`([getColorMode](../../com.aspose.note/imagesaveoptions\#getColorMode--)/[setColorMode(int)](../../com.aspose.note/imagesaveoptions\#setColorMode-int-)) in voor de uitvoerafbeelding.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+
+### setQuality(int value) {#setQuality-int-}
+```
+public final void setQuality(int value)
+```
+
+
+Stelt een waarde in die de kwaliteit van de opgeslagen afbeelding bepaalt. Deze waarde wordt doorgegeven aan de codec als de System.Drawing.Imaging.Encoder.Quality‑parameter.
+
+--------------------
+
+Het bereik van bruikbare waarden voor de kwaliteitscategorie is van 0 tot 100. Hoe lager het opgegeven getal, hoe hoger de compressie en dus hoe lager de kwaliteit van de afbeelding. Nul geeft de laagste kwaliteit afbeelding en 100 de hoogste. De standaardwaarde is 90.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+Stelt de resolutie in voor de gegenereerde afbeeldingen, in dots per inch.
+
+--------------------
+
+De standaardwaarde is 90.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+
+### setTiffCompression(int value) {#setTiffCompression-int-}
+```
+public final void setTiffCompression(int value)
+```
+
+
+Haalt op of stelt het type compressie in dat moet worden gebruikt bij het opslaan van gegenereerde afbeeldingen in het TIFF-formaat.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+

--- a/netherlands/java/com.aspose.note/imagesavingargs/_index.md
+++ b/netherlands/java/com.aspose.note/imagesavingargs/_index.md
@@ -1,0 +1,31 @@
+---
+title: "ImageSavingArgs"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Levert gegevens voor het ImageSaving evenement."
+type: docs
+weight: 36
+url: /nl/java/com.aspose.note/imagesavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ResourceSavingArgs](../../com.aspose.note/resourcesavingargs)
+```
+public class ImageSavingArgs extends ResourceSavingArgs
+```
+
+Levert gegevens voor het ImageSaving evenement.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getImageType()](#getImageType--) | Haalt het type afbeelding op dat moet worden opgeslagen. |
+### getImageType() {#getImageType--}
+```
+public final int getImageType()
+```
+
+
+Haalt het type afbeelding op dat moet worden opgeslagen.
+
+**Returns:**
+int

--- a/netherlands/java/com.aspose.note/indentatednode/_index.md
+++ b/netherlands/java/com.aspose.note/indentatednode/_index.md
@@ -1,0 +1,82 @@
+---
+title: "IndentatedNode"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De basis-klasse voor knooppunten met relatieve inspringing voor onderliggende knooppunten."
+type: docs
+weight: 37
+url: /nl/java/com.aspose.note/indentatednode/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode
+
+**All Implemented Interfaces:**
+com.aspose.note.IIndentatedNodeExtended
+```
+public class IndentatedNode<T,Self> extends CompositeNode<T> implements IIndentatedNodeExtended
+```
+
+De basis-klasse voor knooppunten met relatieve inspringing voor onderliggende knooppunten.
+
+`T`: Het type elementen in het samengestelde knooppunt.
+
+T :
+Self :
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getIndentPosition()](#getIndentPosition--) | Haalt op of stelt de insprongpositie in. |
+| [getInternalIndentPosition()](#getInternalIndentPosition--) | Haalt de hoeveelheid items op die opgeteld moeten worden in de RgOutlineIndentDistance-array om de inspronggrootte te verkrijgen. |
+| [setIndentPosition(byte value)](#setIndentPosition-byte-) | Haalt op of stelt de insprongpositie in. |
+| [setIndentPosition(int value)](#setIndentPosition-int-) |  |
+### getIndentPosition() {#getIndentPosition--}
+```
+public final byte getIndentPosition()
+```
+
+
+Haalt op of stelt de insprongpositie in.
+
+**Returns:**
+byte
+### getInternalIndentPosition() {#getInternalIndentPosition--}
+```
+public int getInternalIndentPosition()
+```
+
+
+Haalt de hoeveelheid items op die opgeteld moeten worden in de RgOutlineIndentDistance-array om de inspronggrootte te verkrijgen.
+
+**Returns:**
+int
+### setIndentPosition(byte value) {#setIndentPosition-byte-}
+```
+public final Self setIndentPosition(byte value)
+```
+
+
+Haalt op of stelt de insprongpositie in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | byte |  |
+
+**Returns:**
+Self
+### setIndentPosition(int value) {#setIndentPosition-int-}
+```
+public final Self setIndentPosition(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+
+**Returns:**
+Self

--- a/netherlands/java/com.aspose.note/inkdrawing/_index.md
+++ b/netherlands/java/com.aspose.note/inkdrawing/_index.md
@@ -1,0 +1,87 @@
+---
+title: "InkDrawing"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een inktknooppunt voor dat enige getekende inhoud bevat."
+type: docs
+weight: 38
+url: /nl/java/com.aspose.note/inkdrawing/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.InkNode](../../com.aspose.note/inknode)
+
+**All Implemented Interfaces:**
+[com.aspose.note.IPageChildNode](../../com.aspose.note/ipagechildnode)
+```
+public final class InkDrawing extends InkNode implements IPageChildNode
+```
+
+Stelt een inktknooppunt voor dat enige getekende inhoud bevat.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | Accepteert de bezoeker van de node. |
+| [getHorizontalOffset()](#getHorizontalOffset--) | Haalt de horizontale offset op. |
+| [getVerticalOffset()](#getVerticalOffset--) | Haalt de verticale offset op. |
+| [setHorizontalOffset(float value)](#setHorizontalOffset-float-) | Stelt de horizontale offset in. |
+| [setVerticalOffset(float value)](#setVerticalOffset-float-) | Stelt de verticale offset in. |
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+Accepteert de bezoeker van de node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | Het object van een klasse afgeleid van de [DocumentVisitor](../../com.aspose.note/documentvisitor). |
+
+### getHorizontalOffset() {#getHorizontalOffset--}
+```
+public final float getHorizontalOffset()
+```
+
+
+Haalt de horizontale offset op.
+
+**Returns:**
+float
+### getVerticalOffset() {#getVerticalOffset--}
+```
+public final float getVerticalOffset()
+```
+
+
+Haalt de verticale offset op.
+
+**Returns:**
+float
+### setHorizontalOffset(float value) {#setHorizontalOffset-float-}
+```
+public final void setHorizontalOffset(float value)
+```
+
+
+Stelt de horizontale offset in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+
+### setVerticalOffset(float value) {#setVerticalOffset-float-}
+```
+public final void setVerticalOffset(float value)
+```
+
+
+Stelt de verticale offset in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+

--- a/netherlands/java/com.aspose.note/inknode/_index.md
+++ b/netherlands/java/com.aspose.note/inknode/_index.md
@@ -1,0 +1,16 @@
+---
+title: "InkNode"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een algemene interface voor alle inktknooppunten voor."
+type: docs
+weight: 39
+url: /nl/java/com.aspose.note/inknode/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node)
+```
+public abstract class InkNode extends Node
+```
+
+Stelt een algemene interface voor alle inktknooppunten voor.

--- a/netherlands/java/com.aspose.note/inkparagraph/_index.md
+++ b/netherlands/java/com.aspose.note/inkparagraph/_index.md
@@ -1,0 +1,37 @@
+---
+title: "InkParagraph"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een inktknooppunt voor dat handgeschreven tekst bevat met extra eigenschappen zoals scheef geschreven tekst."
+type: docs
+weight: 40
+url: /nl/java/com.aspose.note/inkparagraph/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.InkNode](../../com.aspose.note/inknode)
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode)
+```
+public final class InkParagraph extends InkNode implements IOutlineElementChildNode
+```
+
+Stelt een inktknooppunt voor dat handgeschreven tekst bevat met extra eigenschappen zoals scheef geschreven tekst.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | Accepteert de bezoeker van de node. |
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+Accepteert de bezoeker van de node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | Het object van een klasse afgeleid van de [DocumentVisitor](../../com.aspose.note/documentvisitor). |
+

--- a/netherlands/java/com.aspose.note/inkword/_index.md
+++ b/netherlands/java/com.aspose.note/inkword/_index.md
@@ -1,0 +1,37 @@
+---
+title: "InkWord"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een inktknooppunt voor dat handgeschreven tekst bevat."
+type: docs
+weight: 41
+url: /nl/java/com.aspose.note/inkword/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.InkNode](../../com.aspose.note/inknode)
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode)
+```
+public final class InkWord extends InkNode implements IOutlineElementChildNode
+```
+
+Stelt een inktknooppunt voor dat handgeschreven tekst bevat.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | Accepteert de bezoeker van de node. |
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+Accepteert de bezoeker van de node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | Het object van een klasse afgeleid van de [DocumentVisitor](../../com.aspose.note/documentvisitor). |
+

--- a/netherlands/java/com.aspose.note/inode/_index.md
+++ b/netherlands/java/com.aspose.note/inode/_index.md
@@ -1,0 +1,53 @@
+---
+title: "INode"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De interface voor alle knooppunten van een Aspose.Note-document."
+type: docs
+weight: 102
+url: /nl/java/com.aspose.note/inode/
+---
+```
+public interface INode
+```
+
+De interface voor alle knooppunten van een Aspose.Note-document.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) |  |
+| [getNextSibling()](#getNextSibling--) |  |
+| [getPreviousSibling()](#getPreviousSibling--) |  |
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public abstract void accept(DocumentVisitor visitor)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) |  |
+
+### getNextSibling() {#getNextSibling--}
+```
+public abstract INode getNextSibling()
+```
+
+
+
+
+**Returns:**
+[INode](../../com.aspose.note/inode)
+### getPreviousSibling() {#getPreviousSibling--}
+```
+public abstract INode getPreviousSibling()
+```
+
+
+
+
+**Returns:**
+[INode](../../com.aspose.note/inode)

--- a/netherlands/java/com.aspose.note/inotebookchildnode/_index.md
+++ b/netherlands/java/com.aspose.note/inotebookchildnode/_index.md
@@ -1,0 +1,61 @@
+---
+title: "INotebookChildNode"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een kind van een Aspose.Note-notitieboek voor."
+type: docs
+weight: 104
+url: /nl/java/com.aspose.note/inotebookchildnode/
+---
+```
+public interface INotebookChildNode
+```
+
+Stelt een kind van een Aspose.Note-notitieboek voor.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getColor()](#getColor--) |  |
+| [getDisplayName()](#getDisplayName--) |  |
+| [getGuid()](#getGuid--) |  |
+| [getGuidInternal()](#getGuidInternal--) |  |
+### getColor() {#getColor--}
+```
+public abstract Color getColor()
+```
+
+
+
+
+**Returns:**
+java.awt.Color
+### getDisplayName() {#getDisplayName--}
+```
+public abstract String getDisplayName()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getGuid() {#getGuid--}
+```
+public abstract UUID getGuid()
+```
+
+
+
+
+**Returns:**
+java.util.UUID
+### getGuidInternal() {#getGuidInternal--}
+```
+public abstract System.Guid getGuidInternal()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Guid

--- a/netherlands/java/com.aspose.note/inotetag/_index.md
+++ b/netherlands/java/com.aspose.note/inotetag/_index.md
@@ -1,0 +1,84 @@
+---
+title: "INoteTag"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De interface voor notitie-tags, d.w.z."
+type: docs
+weight: 103
+url: /nl/java/com.aspose.note/inotetag/
+---
+
+**All Implemented Interfaces:**
+[com.aspose.note.ITag](../../com.aspose.note/itag)
+```
+public interface INoteTag extends ITag
+```
+
+De interface voor notitie-tags (d.w.z. tags die niet geassocieerd zijn met Outlook-taken).
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getFontColor()](#getFontColor--) | Haalt de letterkleur op. |
+| [getHighlight()](#getHighlight--) | Haalt de markeerkleur op. |
+| [setFontColor(Color value)](#setFontColor-java.awt.Color-) | Stelt de letterkleur in. |
+| [setHighlight(Color value)](#setHighlight-java.awt.Color-) | Stelt de markeerkleur in. |
+| [setLabel(String value)](#setLabel-java.lang.String-) | Stelt de labeltekst in. |
+### getFontColor() {#getFontColor--}
+```
+public abstract Color getFontColor()
+```
+
+
+Haalt de letterkleur op.
+
+**Returns:**
+java.awt.Color
+### getHighlight() {#getHighlight--}
+```
+public abstract Color getHighlight()
+```
+
+
+Haalt de markeerkleur op.
+
+**Returns:**
+java.awt.Color
+### setFontColor(Color value) {#setFontColor-java.awt.Color-}
+```
+public abstract void setFontColor(Color value)
+```
+
+
+Stelt de letterkleur in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.awt.Color |  |
+
+### setHighlight(Color value) {#setHighlight-java.awt.Color-}
+```
+public abstract void setHighlight(Color value)
+```
+
+
+Stelt de markeerkleur in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.awt.Color |  |
+
+### setLabel(String value) {#setLabel-java.lang.String-}
+```
+public abstract void setLabel(String value)
+```
+
+
+Stelt de labeltekst in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+

--- a/netherlands/java/com.aspose.note/ioutlinechildnode/_index.md
+++ b/netherlands/java/com.aspose.note/ioutlinechildnode/_index.md
@@ -1,0 +1,16 @@
+---
+title: "IOutlineChildNode"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De interface voor alle onderliggende knooppunten van een outline‑knooppunt."
+type: docs
+weight: 105
+url: /nl/java/com.aspose.note/ioutlinechildnode/
+---
+
+**All Implemented Interfaces:**
+[com.aspose.note.INode](../../com.aspose.note/inode)
+```
+public interface IOutlineChildNode extends INode
+```
+
+De interface voor alle onderliggende knooppunten van een outline‑knooppunt.

--- a/netherlands/java/com.aspose.note/ioutlineelementchildnode/_index.md
+++ b/netherlands/java/com.aspose.note/ioutlineelementchildnode/_index.md
@@ -1,0 +1,16 @@
+---
+title: "IOutlineElementChildNode"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De interface voor alle onderliggende knooppunten van een outline‑elementknooppunt."
+type: docs
+weight: 106
+url: /nl/java/com.aspose.note/ioutlineelementchildnode/
+---
+
+**All Implemented Interfaces:**
+[com.aspose.note.INode](../../com.aspose.note/inode)
+```
+public interface IOutlineElementChildNode extends INode
+```
+
+De interface voor alle onderliggende knooppunten van een outline‑elementknooppunt.

--- a/netherlands/java/com.aspose.note/ipagechildnode/_index.md
+++ b/netherlands/java/com.aspose.note/ipagechildnode/_index.md
@@ -1,0 +1,70 @@
+---
+title: "IPageChildNode"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De interface voor alle onderliggende knooppunten van een paginaknooppunt."
+type: docs
+weight: 107
+url: /nl/java/com.aspose.note/ipagechildnode/
+---
+
+**All Implemented Interfaces:**
+[com.aspose.note.INode](../../com.aspose.note/inode)
+```
+public interface IPageChildNode extends INode
+```
+
+De interface voor alle onderliggende knooppunten van een paginaknooppunt.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getHorizontalOffset()](#getHorizontalOffset--) | Haalt op of stelt de horizontale offset in. |
+| [getVerticalOffset()](#getVerticalOffset--) | Haalt op of stelt de verticale offset in. |
+| [setHorizontalOffset(float value)](#setHorizontalOffset-float-) | Haalt op of stelt de horizontale offset in. |
+| [setVerticalOffset(float value)](#setVerticalOffset-float-) | Haalt op of stelt de verticale offset in. |
+### getHorizontalOffset() {#getHorizontalOffset--}
+```
+public abstract float getHorizontalOffset()
+```
+
+
+Haalt op of stelt de horizontale offset in.
+
+**Returns:**
+float
+### getVerticalOffset() {#getVerticalOffset--}
+```
+public abstract float getVerticalOffset()
+```
+
+
+Haalt op of stelt de verticale offset in.
+
+**Returns:**
+float
+### setHorizontalOffset(float value) {#setHorizontalOffset-float-}
+```
+public abstract void setHorizontalOffset(float value)
+```
+
+
+Haalt op of stelt de horizontale offset in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+
+### setVerticalOffset(float value) {#setVerticalOffset-float-}
+```
+public abstract void setVerticalOffset(float value)
+```
+
+
+Haalt op of stelt de verticale offset in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+

--- a/netherlands/java/com.aspose.note/ipagesavingcallback/_index.md
+++ b/netherlands/java/com.aspose.note/ipagesavingcallback/_index.md
@@ -1,0 +1,31 @@
+---
+title: "IPageSavingCallback"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Implementeer deze interface als u wilt bepalen hoe Aspose.Note afzonderlijke pagina's opslaat."
+type: docs
+weight: 108
+url: /nl/java/com.aspose.note/ipagesavingcallback/
+---
+```
+public interface IPageSavingCallback
+```
+
+Implementeer deze interface als u wilt bepalen hoe Aspose.Note afzonderlijke pagina's opslaat.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [pageSaving(PageSavingArgs args)](#pageSaving-com.aspose.note.PageSavingArgs-) | Wordt aangeroepen wanneer Aspose.Note een afzonderlijke pagina opslaat. |
+### pageSaving(PageSavingArgs args) {#pageSaving-com.aspose.note.PageSavingArgs-}
+```
+public abstract void pageSaving(PageSavingArgs args)
+```
+
+
+Wordt aangeroepen wanneer Aspose.Note een afzonderlijke pagina opslaat.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| args | [PageSavingArgs](../../com.aspose.note/pagesavingargs) | Opslagparameters. |
+

--- a/netherlands/java/com.aspose.note/itag/_index.md
+++ b/netherlands/java/com.aspose.note/itag/_index.md
@@ -1,0 +1,96 @@
+---
+title: "ITag"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De interface voor tags van alle soorten."
+type: docs
+weight: 109
+url: /nl/java/com.aspose.note/itag/
+---
+```
+public interface ITag
+```
+
+De interface voor tags van alle soorten.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getCompletedTime()](#getCompletedTime--) | Haalt de voltooidtijd op. |
+| [getCreationTime()](#getCreationTime--) | Haalt de creatietijd op. |
+| [getIcon()](#getIcon--) | Haalt het pictogram op. |
+| [getLabel()](#getLabel--) | Haalt de labeltekst op. |
+| [getStatus()](#getStatus--) | Haalt de status op. |
+| [setCreationTime(Date value)](#setCreationTime-java.util.Date-) | Stelt de creatietijd in. |
+### getCompletedTime() {#getCompletedTime--}
+```
+public abstract Date getCompletedTime()
+```
+
+
+Haalt de voltooidtijd op.
+
+Waarde: De `Nullable{DateTime}`.
+
+**Returns:**
+java.util.Date
+### getCreationTime() {#getCreationTime--}
+```
+public abstract Date getCreationTime()
+```
+
+
+Haalt de creatietijd op.
+
+Waarde: De java.util.Date.
+
+**Returns:**
+java.util.Date
+### getIcon() {#getIcon--}
+```
+public abstract int getIcon()
+```
+
+
+Haalt het pictogram op.
+
+Waarde: De [TagIcon](../../com.aspose.note.infrastructure/tagicon).
+
+**Returns:**
+int
+### getLabel() {#getLabel--}
+```
+public abstract String getLabel()
+```
+
+
+Haalt de labeltekst op.
+
+**Returns:**
+java.lang.String
+### getStatus() {#getStatus--}
+```
+public abstract int getStatus()
+```
+
+
+Haalt de status op.
+
+Waarde: De [TagStatus](../../com.aspose.note/tagstatus).
+
+**Returns:**
+int
+### setCreationTime(Date value) {#setCreationTime-java.util.Date-}
+```
+public abstract void setCreationTime(Date value)
+```
+
+
+Stelt de creatietijd in.
+
+Waarde: De java.util.Date.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Date |  |
+

--- a/netherlands/java/com.aspose.note/itaggable/_index.md
+++ b/netherlands/java/com.aspose.note/itaggable/_index.md
@@ -1,0 +1,31 @@
+---
+title: "ITaggable"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De interface voor knooppunten die door tags gemarkeerd kunnen worden."
+type: docs
+weight: 110
+url: /nl/java/com.aspose.note/itaggable/
+---
+
+**All Implemented Interfaces:**
+[com.aspose.note.INode](../../com.aspose.note/inode)
+```
+public interface ITaggable extends INode
+```
+
+De interface voor knooppunten die door tags gemarkeerd kunnen worden.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getTags()](#getTags--) | Haalt de lijst op van alle tags. |
+### getTags() {#getTags--}
+```
+public abstract System.Collections.Generic.List<ITag> getTags()
+```
+
+
+Haalt de lijst op van alle tags.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List&lt;com.aspose.note.ITag&gt;

--- a/netherlands/java/com.aspose.note/keeppartandclonesolidobjecttonextpagealgorithm/_index.md
+++ b/netherlands/java/com.aspose.note/keeppartandclonesolidobjecttonextpagealgorithm/_index.md
@@ -1,0 +1,71 @@
+---
+title: "KeepPartAndCloneSolidObjectToNextPageAlgorithm"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Voegt het bovenste deel van objecten toe aan de onderkant van de pagina en kloont het volledige object naar de volgende pagina als het niet in de oorspronkelijke pagina past."
+type: docs
+weight: 42
+url: /nl/java/com.aspose.note/keeppartandclonesolidobjecttonextpagealgorithm/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm)
+```
+public class KeepPartAndCloneSolidObjectToNextPageAlgorithm extends PageSplittingAlgorithm
+```
+
+Voegt het bovenste deel van het object toe aan de onderkant van de pagina en kloont het volledige object naar de volgende pagina als het niet op de oorspronkelijke pagina past.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [KeepPartAndCloneSolidObjectToNextPageAlgorithm()](#KeepPartAndCloneSolidObjectToNextPageAlgorithm--) | Initialiseert een nieuw exemplaar van de `KeepPartAndCloneSolidObjectToNextPageAlgorithm`-klasse, met de standaardhoogtelimiet van het gekloonde deel. |
+| [KeepPartAndCloneSolidObjectToNextPageAlgorithm(float heightLimitOfClonedPart)](#KeepPartAndCloneSolidObjectToNextPageAlgorithm-float-) | Initialiseert een nieuw exemplaar van de `KeepPartAndCloneSolidObjectToNextPageAlgorithm`-klasse, met een specifieke hoogtelimiet van het gekloonde deel. |
+## Velden
+
+| Veld | Beschrijving |
+| --- | --- |
+| [DEFAULT_HEIGHT_LIMIT_OF_CLONED_PART](#DEFAULT-HEIGHT-LIMIT-OF-CLONED-PART) | De standaard maximale grootte van het gekloonde deel. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getHeightLimitOfClonedPart()](#getHeightLimitOfClonedPart--) | Haalt de hoogtelimiet van het gekloonde deel op. |
+### KeepPartAndCloneSolidObjectToNextPageAlgorithm() {#KeepPartAndCloneSolidObjectToNextPageAlgorithm--}
+```
+public KeepPartAndCloneSolidObjectToNextPageAlgorithm()
+```
+
+
+Initialiseert een nieuw exemplaar van de `KeepPartAndCloneSolidObjectToNextPageAlgorithm`-klasse, met de standaardhoogtelimiet van het gekloonde deel.
+
+### KeepPartAndCloneSolidObjectToNextPageAlgorithm(float heightLimitOfClonedPart) {#KeepPartAndCloneSolidObjectToNextPageAlgorithm-float-}
+```
+public KeepPartAndCloneSolidObjectToNextPageAlgorithm(float heightLimitOfClonedPart)
+```
+
+
+Initialiseert een nieuw exemplaar van de `KeepPartAndCloneSolidObjectToNextPageAlgorithm`-klasse, met een specifieke hoogtelimiet van het gekloonde deel.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| heightLimitOfClonedPart | float | De maximale hoogte van het gekloonde onderdeel. |
+
+### DEFAULT_HEIGHT_LIMIT_OF_CLONED_PART {#DEFAULT-HEIGHT-LIMIT-OF-CLONED-PART}
+```
+public static final float DEFAULT_HEIGHT_LIMIT_OF_CLONED_PART
+```
+
+
+De standaard maximale grootte van het gekloonde deel.
+
+### getHeightLimitOfClonedPart() {#getHeightLimitOfClonedPart--}
+```
+public float getHeightLimitOfClonedPart()
+```
+
+
+Haalt de hoogtelimiet van het gekloonde deel op.
+
+**Returns:**
+float

--- a/netherlands/java/com.aspose.note/keepsolidobjectsalgorithm/_index.md
+++ b/netherlands/java/com.aspose.note/keepsolidobjectsalgorithm/_index.md
@@ -1,0 +1,71 @@
+---
+title: "KeepSolidObjectsAlgorithm"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Verplaatst het volledige object naar de volgende pagina als het niet op de oorspronkelijke pagina past."
+type: docs
+weight: 43
+url: /nl/java/com.aspose.note/keepsolidobjectsalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm)
+```
+public class KeepSolidObjectsAlgorithm extends PageSplittingAlgorithm
+```
+
+Verplaatst het volledige object naar de volgende pagina als het niet op de oorspronkelijke pagina past.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [KeepSolidObjectsAlgorithm()](#KeepSolidObjectsAlgorithm--) | Initialiseert een nieuw exemplaar van de `KeepSolidObjectsAlgorithm` class met de standaardhoogtelimiet van het gekloonde deel. |
+| [KeepSolidObjectsAlgorithm(float heightLimitOfClonedPart)](#KeepSolidObjectsAlgorithm-float-) | Initialiseert een nieuw exemplaar van de `KeepSolidObjectsAlgorithm` class met een specifieke hoogtelimiet van het gekloonde deel. |
+## Velden
+
+| Veld | Beschrijving |
+| --- | --- |
+| [DEFAULT_HEIGHT_LIMIT_OF_CLONED_PART](#DEFAULT-HEIGHT-LIMIT-OF-CLONED-PART) | De standaard maximale grootte van het gekloonde deel. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getHeightLimitOfClonedPart()](#getHeightLimitOfClonedPart--) | Haalt de hoogtelimiet van het gekloonde deel op. |
+### KeepSolidObjectsAlgorithm() {#KeepSolidObjectsAlgorithm--}
+```
+public KeepSolidObjectsAlgorithm()
+```
+
+
+Initialiseert een nieuw exemplaar van de `KeepSolidObjectsAlgorithm` class met de standaardhoogtelimiet van het gekloonde deel.
+
+### KeepSolidObjectsAlgorithm(float heightLimitOfClonedPart) {#KeepSolidObjectsAlgorithm-float-}
+```
+public KeepSolidObjectsAlgorithm(float heightLimitOfClonedPart)
+```
+
+
+Initialiseert een nieuw exemplaar van de `KeepSolidObjectsAlgorithm` class met een specifieke hoogtelimiet van het gekloonde deel.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| heightLimitOfClonedPart | float | De maximale hoogte van het gekloonde onderdeel. |
+
+### DEFAULT_HEIGHT_LIMIT_OF_CLONED_PART {#DEFAULT-HEIGHT-LIMIT-OF-CLONED-PART}
+```
+public static final float DEFAULT_HEIGHT_LIMIT_OF_CLONED_PART
+```
+
+
+De standaard maximale grootte van het gekloonde deel.
+
+### getHeightLimitOfClonedPart() {#getHeightLimitOfClonedPart--}
+```
+public float getHeightLimitOfClonedPart()
+```
+
+
+Haalt de hoogtelimiet van het gekloonde deel op.
+
+**Returns:**
+float

--- a/netherlands/java/com.aspose.note/license/_index.md
+++ b/netherlands/java/com.aspose.note/license/_index.md
@@ -1,0 +1,142 @@
+---
+title: "License"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Biedt methoden om de component te licentiëren."
+type: docs
+weight: 44
+url: /nl/java/com.aspose.note/license/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class License
+```
+
+Biedt methoden om de component te licentiëren.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [License()](#License--) | Initialiseert een nieuw exemplaar van deze klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [resetThreadContext()](#resetThreadContext--) | Reset een licentiecontext voor de huidige thread. |
+| [setLicense(File licenseFile)](#setLicense-java.io.File-) | Licentieert het component. |
+| [setLicense(InputStream stream)](#setLicense-java.io.InputStream-) | Licentieert het component. |
+| [setLicense(String licenseName)](#setLicense-java.lang.String-) | Licentieert het component. |
+| [setThreadContext(InputStream stream)](#setThreadContext-java.io.InputStream-) | Stelt een licentiecontext in voor de huidige thread. |
+### License() {#License--}
+```
+public License()
+```
+
+
+Initialiseert een nieuw exemplaar van deze klasse.
+
+### resetThreadContext() {#resetThreadContext--}
+```
+public static void resetThreadContext()
+```
+
+
+Reset een licentiecontext voor de huidige thread.
+
+### setLicense(File licenseFile) {#setLicense-java.io.File-}
+```
+public void setLicense(File licenseFile)
+```
+
+
+Licentieert het component.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| licenseFile | java.io.File | Bestand van licentie`System.IO.FileInfo`. |
+
+### setLicense(InputStream stream) {#setLicense-java.io.InputStream-}
+```
+public final void setLicense(InputStream stream)
+```
+
+
+Licentieert het component.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+|  | stroom | java.io.InputStream | Een stroom die de licentie bevat. |
+
+--------------------
+
+`
+
+Gebruik deze methode om een licentie te laden vanaf een stream.
+
+`
+
+`void setLicense(java.io.InputStream stream)` |
+
+### setLicense(String licenseName) {#setLicense-java.lang.String-}
+```
+public final void setLicense(String licenseName)
+```
+
+
+Licentieert het component.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+|  | licenseName | java.lang.String | Kan een volledige of korte bestandsnaam` of de naam van een ingebedde resource` zijn. Gebruik een lege tekenreeks om over te schakelen naar evaluatiemodus. |
+
+--------------------
+
+`
+
+Probeert de licentie te vinden op de volgende locaties:
+
+` `
+
+1. Expliciet pad.
+
+` `
+
+2. De map die de Aspose componentassembly bevat.
+
+3. De map die de aanroepende assembly van de client bevat.
+
+4. De map die de entry (startup) assembly bevat.
+
+5. Een ingebedde resource in de aanroepende assembly van de client.
+
+**Note:**On the .NET Compact Framework, tries to find the license only in these locations:
+
+1. Expliciet pad.
+
+2. Een ingebedde resource in de aanroepende assembly van de client.
+
+` `
+
+2. De map die het Aspose component JAR‑bestand bevat.
+
+3. De map die het JAR‑bestand van de client bevat.
+
+` |
+
+### setThreadContext(InputStream stream) {#setThreadContext-java.io.InputStream-}
+```
+public static void setThreadContext(InputStream stream)
+```
+
+
+Stelt een licentiecontext in voor de huidige thread.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| stroom | java.io.InputStream | Een stroom die de licentie bevat. |
+

--- a/netherlands/java/com.aspose.note/licenseexceptions/_index.md
+++ b/netherlands/java/com.aspose.note/licenseexceptions/_index.md
@@ -1,0 +1,145 @@
+---
+title: "LicenseExceptions"
+second_title: "Aspose.Note for Java API-referentie"
+description: 
+type: docs
+weight: 45
+url: /nl/java/com.aspose.note/licenseexceptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LicenseExceptions
+```
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [LicenseExceptions()](#LicenseExceptions--) |  |
+## Velden
+
+| Veld | Beschrijving |
+| --- | --- |
+| [BlackListedLicense_ExceptionMessage](#BlackListedLicense-ExceptionMessage) |  |
+| [ExpiredLicense_ExceptionMessage](#ExpiredLicense-ExceptionMessage) |  |
+| [InvalidBlackListResourceName_ExceptionMessage](#InvalidBlackListResourceName-ExceptionMessage) |  |
+| [InvalidEditionType_ExceptionMessage](#InvalidEditionType-ExceptionMessage) |  |
+| [InvalidLicenseSignature_ExceptionMessage](#InvalidLicenseSignature-ExceptionMessage) |  |
+| [InvalidProduct_ExceptionMessage](#InvalidProduct-ExceptionMessage) |  |
+| [InvalidSignatureBlackList_ExceptionMessage](#InvalidSignatureBlackList-ExceptionMessage) |  |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [throwBlackListedLicense()](#throwBlackListedLicense--) |  |
+| [throwExpiredLicense()](#throwExpiredLicense--) |  |
+| [throwInvalidBlackListResourceName()](#throwInvalidBlackListResourceName--) |  |
+| [throwInvalidEditionType()](#throwInvalidEditionType--) |  |
+| [throwInvalidLicense()](#throwInvalidLicense--) |  |
+| [throwInvalidProduct()](#throwInvalidProduct--) |  |
+| [throwInvalidSignatureBlackList()](#throwInvalidSignatureBlackList--) |  |
+### LicenseExceptions() {#LicenseExceptions--}
+```
+public LicenseExceptions()
+```
+
+
+### BlackListedLicense_ExceptionMessage {#BlackListedLicense-ExceptionMessage}
+```
+public static final String BlackListedLicense_ExceptionMessage
+```
+
+
+### ExpiredLicense_ExceptionMessage {#ExpiredLicense-ExceptionMessage}
+```
+public static final String ExpiredLicense_ExceptionMessage
+```
+
+
+### InvalidBlackListResourceName_ExceptionMessage {#InvalidBlackListResourceName-ExceptionMessage}
+```
+public static final String InvalidBlackListResourceName_ExceptionMessage
+```
+
+
+### InvalidEditionType_ExceptionMessage {#InvalidEditionType-ExceptionMessage}
+```
+public static final String InvalidEditionType_ExceptionMessage
+```
+
+
+### InvalidLicenseSignature_ExceptionMessage {#InvalidLicenseSignature-ExceptionMessage}
+```
+public static final String InvalidLicenseSignature_ExceptionMessage
+```
+
+
+### InvalidProduct_ExceptionMessage {#InvalidProduct-ExceptionMessage}
+```
+public static final String InvalidProduct_ExceptionMessage
+```
+
+
+### InvalidSignatureBlackList_ExceptionMessage {#InvalidSignatureBlackList-ExceptionMessage}
+```
+public static final String InvalidSignatureBlackList_ExceptionMessage
+```
+
+
+### throwBlackListedLicense() {#throwBlackListedLicense--}
+```
+public static void throwBlackListedLicense()
+```
+
+
+
+
+### throwExpiredLicense() {#throwExpiredLicense--}
+```
+public static void throwExpiredLicense()
+```
+
+
+
+
+### throwInvalidBlackListResourceName() {#throwInvalidBlackListResourceName--}
+```
+public static void throwInvalidBlackListResourceName()
+```
+
+
+
+
+### throwInvalidEditionType() {#throwInvalidEditionType--}
+```
+public static void throwInvalidEditionType()
+```
+
+
+
+
+### throwInvalidLicense() {#throwInvalidLicense--}
+```
+public static void throwInvalidLicense()
+```
+
+
+
+
+### throwInvalidProduct() {#throwInvalidProduct--}
+```
+public static void throwInvalidProduct()
+```
+
+
+
+
+### throwInvalidSignatureBlackList() {#throwInvalidSignatureBlackList--}
+```
+public static void throwInvalidSignatureBlackList()
+```
+
+
+
+

--- a/netherlands/java/com.aspose.note/loadoptions/_index.md
+++ b/netherlands/java/com.aspose.note/loadoptions/_index.md
@@ -1,0 +1,83 @@
+---
+title: "LoadOptions"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Opties die worden gebruikt om een document te laden."
+type: docs
+weight: 46
+url: /nl/java/com.aspose.note/loadoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LoadOptions
+```
+
+Opties die worden gebruikt om een document te laden.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [LoadOptions()](#LoadOptions--) | Initialiseert een nieuw exemplaar van de `LoadOptions`-klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getDocumentPassword()](#getDocumentPassword--) | Haalt een wachtwoord op of stelt een wachtwoord in voor de versleutelde documentinhoud. |
+| [getLoadHistory()](#getLoadHistory--) | Haalt een waarde op of stelt een waarde in die aangeeft of een documentlader de geschiedenis moet negeren. |
+| [setDocumentPassword(String value)](#setDocumentPassword-java.lang.String-) | Haalt een wachtwoord op of stelt een wachtwoord in voor de versleutelde documentinhoud. |
+| [setLoadHistory(boolean value)](#setLoadHistory-boolean-) | Haalt een waarde op of stelt een waarde in die aangeeft of een documentlader de geschiedenis moet negeren. |
+### LoadOptions() {#LoadOptions--}
+```
+public LoadOptions()
+```
+
+
+Initialiseert een nieuw exemplaar van de `LoadOptions`-klasse.
+
+### getDocumentPassword() {#getDocumentPassword--}
+```
+public String getDocumentPassword()
+```
+
+
+Haalt een wachtwoord op of stelt een wachtwoord in voor de versleutelde documentinhoud. De waarde wordt genegeerd als het document niet met een wachtwoord is beveiligd.
+
+**Returns:**
+java.lang.String
+### getLoadHistory() {#getLoadHistory--}
+```
+public boolean getLoadHistory()
+```
+
+
+Haalt een waarde op of stelt een waarde in die aangeeft of een documentlader de geschiedenis moet negeren. Gebruik deze optie om het geheugen- en CPU-gebruik te verminderen. Standaardwaarde is `true`.
+
+**Returns:**
+boolean
+### setDocumentPassword(String value) {#setDocumentPassword-java.lang.String-}
+```
+public void setDocumentPassword(String value)
+```
+
+
+Haalt een wachtwoord op of stelt een wachtwoord in voor de versleutelde documentinhoud. De waarde wordt genegeerd als het document niet met een wachtwoord is beveiligd.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+
+### setLoadHistory(boolean value) {#setLoadHistory-boolean-}
+```
+public void setLoadHistory(boolean value)
+```
+
+
+Haalt een waarde op of stelt een waarde in die aangeeft of een documentlader de geschiedenis moet negeren. Gebruik deze optie om het geheugen- en CPU-gebruik te verminderen. Standaardwaarde is `true`.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+

--- a/netherlands/java/com.aspose.note/localeoptions/_index.md
+++ b/netherlands/java/com.aspose.note/localeoptions/_index.md
@@ -1,0 +1,65 @@
+---
+title: "LocaleOptions"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Het type LocaleOptions specificeert de locale-configuratie voor Aspose.Note."
+type: docs
+weight: 47
+url: /nl/java/com.aspose.note/localeoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LocaleOptions
+```
+
+Het type LocaleOptions specificeert de locale-configuratie voor Aspose.Note.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [LocaleOptions()](#LocaleOptions--) |  |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [clear()](#clear--) | Verwijdert de standaardlocale voor Aspose.Note. |
+| [getLocale()](#getLocale--) | Haal de momenteel actuele standaardlocale op voor Aspose.Note |
+| [setLocale(Locale local)](#setLocale-java.util.Locale-) | Stel de standaardlocale in voor Aspose.Note. |
+### LocaleOptions() {#LocaleOptions--}
+```
+public LocaleOptions()
+```
+
+
+### clear() {#clear--}
+```
+public static void clear()
+```
+
+
+Verwijdert de standaardlocale voor Aspose.Note. De standaardlocale voor Java zal worden gebruikt.
+
+### getLocale() {#getLocale--}
+```
+public static Locale getLocale()
+```
+
+
+Haal de momenteel actuele standaardlocale op voor Aspose.Note
+
+**Returns:**
+java.util.Locale - Locale‑instantie
+### setLocale(Locale local) {#setLocale-java.util.Locale-}
+```
+public static void setLocale(Locale local)
+```
+
+
+Stel de standaardlocale in voor Aspose.Note.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| lokaal | java.util.Locale | Locale‑instantie |
+

--- a/netherlands/java/com.aspose.note/loop/_index.md
+++ b/netherlands/java/com.aspose.note/loop/_index.md
@@ -1,0 +1,100 @@
+---
+title: "Loop"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een lus voor."
+type: docs
+weight: 48
+url: /nl/java/com.aspose.note/loop/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node)
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode)
+```
+public class Loop extends Node implements IOutlineElementChildNode
+```
+
+Stelt een lus voor.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [Loop()](#Loop--) | Initialiseert een nieuw exemplaar van de `Loop`-klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | Accepteert de bezoeker van de node. |
+| [getHyperlinkUrl()](#getHyperlinkUrl--) | Haalt de hyperlink op. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | Haalt de laatst gewijzigde tijd op. |
+| [setHyperlinkUrl(String value)](#setHyperlinkUrl-java.lang.String-) | Stelt de hyperlink in. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | Stelt de laatste wijzigingstijd in. |
+### Loop() {#Loop--}
+```
+public Loop()
+```
+
+
+Initialiseert een nieuw exemplaar van de `Loop`-klasse.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+Accepteert de bezoeker van de node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | Het object van een klasse die afgeleid is van de `DocumentVisitor`. |
+
+### getHyperlinkUrl() {#getHyperlinkUrl--}
+```
+public String getHyperlinkUrl()
+```
+
+
+Haalt de hyperlink op.
+
+**Returns:**
+java.lang.String
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+Haalt de laatst gewijzigde tijd op.
+
+**Returns:**
+java.util.Date
+### setHyperlinkUrl(String value) {#setHyperlinkUrl-java.lang.String-}
+```
+public void setHyperlinkUrl(String value)
+```
+
+
+Stelt de hyperlink in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+Stelt de laatste wijzigingstijd in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Date |  |
+

--- a/netherlands/java/com.aspose.note/margins/_index.md
+++ b/netherlands/java/com.aspose.note/margins/_index.md
@@ -1,0 +1,283 @@
+---
+title: "Margins"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Specificeert de afmetingen van de marges van een knooppunt."
+type: docs
+weight: 49
+url: /nl/java/com.aspose.note/margins/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.lang.Struct
+
+**All Implemented Interfaces:**
+com.aspose.ms.System.IEquatable
+```
+public class Margins extends Struct<Margins> implements System.IEquatable<Margins>
+```
+
+Specificeert de afmetingen van de marges van een knooppunt.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [Margins()](#Margins--) |  |
+| [Margins(float left, float right, float top, float bottom)](#Margins-float-float-float-float-) | Initialiseert een nieuw exemplaar van de `Margins` struct met de opgegeven linker-, rechter-, boven- en ondermarges. |
+## Velden
+
+| Veld | Beschrijving |
+| --- | --- |
+| [Empty](#Empty) | De lege marges. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [Clone()](#Clone--) |  |
+| [CloneTo(Margins that)](#CloneTo-com.aspose.note.Margins-) |  |
+| [clone()](#clone--) |  |
+| [equals(Margins other)](#equals-com.aspose.note.Margins-) |  |
+| [equals(Margins obj1, Margins obj2)](#equals-com.aspose.note.Margins-com.aspose.note.Margins-) |  |
+| [equals(Object obj)](#equals-java.lang.Object-) | Test of twee `T:Margins` structuren gelijk zijn. |
+| [getBottom()](#getBottom--) | Haalt of stelt de ondermargebreedte in. |
+| [getLeft()](#getLeft--) | Haalt of stelt de linkermargebreedte in. |
+| [getRight()](#getRight--) | Haalt of stelt de rechtermargebreedte in. |
+| [getTop()](#getTop--) | Haalt of stelt de bovenmargebreedte in. |
+| [op_Equality(Margins lhs, Margins rhs)](#op-Equality-com.aspose.note.Margins-com.aspose.note.Margins-) | Test of twee `T:Margins` structuren gelijk zijn. |
+| [op_Inequality(Margins lhs, Margins rhs)](#op-Inequality-com.aspose.note.Margins-com.aspose.note.Margins-) | Test of twee `T:Margins` structuren niet gelijk zijn. |
+| [setBottom(float value)](#setBottom-float-) | Haalt of stelt de ondermargebreedte in. |
+| [setLeft(float value)](#setLeft-float-) | Haalt of stelt de linkermargebreedte in. |
+| [setRight(float value)](#setRight-float-) | Haalt of stelt de rechtermargebreedte in. |
+| [setTop(float value)](#setTop-float-) | Haalt of stelt de bovenmargebreedte in. |
+### Margins() {#Margins--}
+```
+public Margins()
+```
+
+
+### Margins(float left, float right, float top, float bottom) {#Margins-float-float-float-float-}
+```
+public Margins(float left, float right, float top, float bottom)
+```
+
+
+Initialiseert een nieuw exemplaar van de `Margins` struct met de opgegeven linker-, rechter-, boven- en ondermarges.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| links | float | De breedte van de linkermarge. |
+| rechts | float | De breedte van de rechtermarge. |
+| boven | float | De breedte van de bovenmarge. |
+| onder | float | De breedte van de onderste marge. |
+
+### Empty {#Empty}
+```
+public static final Margins Empty
+```
+
+
+De lege marges.
+
+### Clone() {#Clone--}
+```
+public Margins Clone()
+```
+
+
+
+
+**Returns:**
+[Margins](../../com.aspose.note/margins)
+### CloneTo(Margins that) {#CloneTo-com.aspose.note.Margins-}
+```
+public void CloneTo(Margins that)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| that | [Margins](../../com.aspose.note/margins) |  |
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### equals(Margins other) {#equals-com.aspose.note.Margins-}
+```
+public boolean equals(Margins other)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| other | [Margins](../../com.aspose.note/margins) |  |
+
+**Returns:**
+boolean
+### equals(Margins obj1, Margins obj2) {#equals-com.aspose.note.Margins-com.aspose.note.Margins-}
+```
+public static boolean equals(Margins obj1, Margins obj2)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| obj1 | [Margins](../../com.aspose.note/margins) |  |
+| obj2 | [Margins](../../com.aspose.note/margins) |  |
+
+**Returns:**
+boolean
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Test of twee `T:Margins` structuren gelijk zijn.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| obj | java.lang.Object | Elk object. |
+
+**Returns:**
+boolean - De `bool`.
+### getBottom() {#getBottom--}
+```
+public float getBottom()
+```
+
+
+Haalt of stelt de ondermargebreedte in.
+
+**Returns:**
+float
+### getLeft() {#getLeft--}
+```
+public float getLeft()
+```
+
+
+Haalt of stelt de linkermargebreedte in.
+
+**Returns:**
+float
+### getRight() {#getRight--}
+```
+public float getRight()
+```
+
+
+Haalt of stelt de rechtermargebreedte in.
+
+**Returns:**
+float
+### getTop() {#getTop--}
+```
+public float getTop()
+```
+
+
+Haalt of stelt de bovenmargebreedte in.
+
+**Returns:**
+float
+### op_Equality(Margins lhs, Margins rhs) {#op-Equality-com.aspose.note.Margins-com.aspose.note.Margins-}
+```
+public static boolean op_Equality(Margins lhs, Margins rhs)
+```
+
+
+Test of twee `T:Margins` structuren gelijk zijn.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| lhs | [Margins](../../com.aspose.note/margins) | De `T:Margins`-structuur. |
+| rhs | [Margins](../../com.aspose.note/margins) | De `T:Margins`-structuur waarmee vergeleken moet worden. |
+
+**Returns:**
+boolean - De `bool`.
+### op_Inequality(Margins lhs, Margins rhs) {#op-Inequality-com.aspose.note.Margins-com.aspose.note.Margins-}
+```
+public static boolean op_Inequality(Margins lhs, Margins rhs)
+```
+
+
+Test of twee `T:Margins` structuren niet gelijk zijn.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| lhs | [Margins](../../com.aspose.note/margins) | De `T:Margins`-structuur. |
+| rhs | [Margins](../../com.aspose.note/margins) | De `T:Margins`-structuur waarmee vergeleken moet worden. |
+
+**Returns:**
+boolean - De `bool`.
+### setBottom(float value) {#setBottom-float-}
+```
+public void setBottom(float value)
+```
+
+
+Haalt of stelt de ondermargebreedte in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+
+### setLeft(float value) {#setLeft-float-}
+```
+public void setLeft(float value)
+```
+
+
+Haalt of stelt de linkermargebreedte in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+
+### setRight(float value) {#setRight-float-}
+```
+public void setRight(float value)
+```
+
+
+Haalt of stelt de rechtermargebreedte in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+
+### setTop(float value) {#setTop-float-}
+```
+public void setTop(float value)
+```
+
+
+Haalt of stelt de bovenmargebreedte in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+

--- a/netherlands/java/com.aspose.note/metered/_index.md
+++ b/netherlands/java/com.aspose.note/metered/_index.md
@@ -1,0 +1,108 @@
+---
+title: "Metered"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Biedt methoden om een gemeten sleutel in te stellen."
+type: docs
+weight: 50
+url: /nl/java/com.aspose.note/metered/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Metered
+```
+
+Biedt methoden om een gemeten sleutel in te stellen.
+
+--------------------
+
+&gt; ```
+&gt; In dit voorbeeld wordt geprobeerd om de openbare en privésleutel van metered in te stellen
+&gt; ``````
+
+  [C#]
+
+Metered metered = new Metered();
+metered.SetMeteredKey("PublicKey", "PrivateKey");
+  [Visual Basic]
+Dim metered As Metered = New Metered
+metered.SetMeteredKey("PublicKey", "PrivateKey")
+  
+```
+
+the component jar file:
+
+```
+
+Metered metered = new Metered();
+metered.setMeteredKey("PublicKey", "PrivateKey");
+  
+```
+
+
+## Constructors
+
+| Constructor | Description |
+| --- | --- |
+| [Metered()](#Metered--) |  |
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getConsumptionCredit()](#getConsumptionCredit--) | Gets consumption credit. |
+| [getConsumptionQuantity()](#getConsumptionQuantity--) | Gets consumption file size. |
+| [resetMeteredKey()](#resetMeteredKey--) | Removes previously setup license. |
+| [setMeteredKey(String publicKey, String privateKey)](#setMeteredKey-java.lang.String-java.lang.String-) | Sets metered public and private keys. |
+### Metered() {#Metered--}
+```
+public Metered()
+```
+
+
+### getConsumptionCredit() {#getConsumptionCredit--}
+```
+public static BigDecimal getConsumptionCredit()
+```
+
+
+Gets consumption credit.
+
+**Returns:**
+java.math.BigDecimal - Returns the number of consumed credit points.
+### getConsumptionQuantity() {#getConsumptionQuantity--}
+```
+public static BigDecimal getConsumptionQuantity()
+```
+
+
+Gets consumption file size.
+
+**Returns:**
+java.math.BigDecimal - Returns the number of consumed bytes.
+### resetMeteredKey() {#resetMeteredKey--}
+```
+public final void resetMeteredKey()
+```
+
+
+Removes previously setup license.
+
+### setMeteredKey(String publicKey, String privateKey) {#setMeteredKey-java.lang.String-java.lang.String-}
+```
+public final void setMeteredKey(String publicKey, String privateKey)
+```
+
+
+Sets metered public and private keys.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| publicKey | java.lang.String | The public key. |
+| privateKey | java.lang.String | The private key.
+
+--------------------
+
+If you purchase metered license, this API should be called on application startup, normally, this is enough. However, if metered fails to upload consumption data during 24 hours period, the license will be set to evaluation status. To avoid such case, you should regularly check the license status If it is evaluation status, call this API again. |
+

--- a/netherlands/java/com.aspose.note/node/_index.md
+++ b/netherlands/java/com.aspose.note/node/_index.md
@@ -1,0 +1,120 @@
+---
+title: "Node"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De basisklasse voor alle knooppunten van een Aspose.Note-document."
+type: docs
+weight: 51
+url: /nl/java/com.aspose.note/node/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.note.INode](../../com.aspose.note/inode)
+```
+public abstract class Node implements INode
+```
+
+De basisklasse voor alle knooppunten van een Aspose.Note-document.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | Accepteert de bezoeker van de node. |
+| [getDocument()](#getDocument--) | Haalt het document van de node op. |
+| [getNextSibling()](#getNextSibling--) | Haalt de volgende node op op hetzelfde node-boomniveau. |
+| [getNodeId()](#getNodeId--) | Haalt de ID van de node op. |
+| [getNodeType()](#getNodeType--) | Haalt het node-type op. |
+| [getParentNode()](#getParentNode--) | Haalt de bovenliggende node op. |
+| [getPreviousSibling()](#getPreviousSibling--) | Haalt de vorige node op op hetzelfde node-boomniveau. |
+| [isComposite()](#isComposite--) | Haalt een waarde op die aangeeft of dit knooppunt samengesteld is. |
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public abstract void accept(DocumentVisitor visitor)
+```
+
+
+Accepteert de bezoeker van de node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | Het object van een klasse die afgeleid is van de `DocumentVisitor`. |
+
+### getDocument() {#getDocument--}
+```
+public Document getDocument()
+```
+
+
+Haalt het document van de node op.
+
+Waarde: Het document.
+
+**Returns:**
+[Document](../../com.aspose.note/document)
+### getNextSibling() {#getNextSibling--}
+```
+public INode getNextSibling()
+```
+
+
+Haalt de volgende node op op hetzelfde node-boomniveau.
+
+Waarde: De volgende sibling.
+
+**Returns:**
+[INode](../../com.aspose.note/inode)
+### getNodeId() {#getNodeId--}
+```
+public ExtendedGuid getNodeId()
+```
+
+
+Haalt de ID van de node op.
+
+**Returns:**
+[ExtendedGuid](../../com.aspose.note.revision.types/extendedguid)
+### getNodeType() {#getNodeType--}
+```
+public int getNodeType()
+```
+
+
+Haalt het node-type op.
+
+**Returns:**
+int
+### getParentNode() {#getParentNode--}
+```
+public ICompositeNode getParentNode()
+```
+
+
+Haalt de bovenliggende node op.
+
+**Returns:**
+[ICompositeNode](../../com.aspose.note/icompositenode)
+### getPreviousSibling() {#getPreviousSibling--}
+```
+public INode getPreviousSibling()
+```
+
+
+Haalt de vorige node op op hetzelfde node-boomniveau.
+
+Waarde: De vorige sibling.
+
+**Returns:**
+[INode](../../com.aspose.note/inode)
+### isComposite() {#isComposite--}
+```
+public boolean isComposite()
+```
+
+
+Haalt een waarde op die aangeeft of dit knooppunt samengesteld is. Indien waar kan het knooppunt onderliggende knooppunten hebben.
+
+**Returns:**
+boolean

--- a/netherlands/java/com.aspose.note/nodetype/_index.md
+++ b/netherlands/java/com.aspose.note/nodetype/_index.md
@@ -1,0 +1,182 @@
+---
+title: "NodeType"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Specificeert het type van het knooppunt."
+type: docs
+weight: 52
+url: /nl/java/com.aspose.note/nodetype/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class NodeType extends System.Enum
+```
+
+Specificeert het type van het knooppunt.
+## Velden
+
+| Veld | Beschrijving |
+| --- | --- |
+| [AttachedFile](#AttachedFile) | Specificeert dat het knooppunt een `AttachedFile` is. |
+| [Document](#Document) | Specificeert dat het knooppunt een `Document` is. |
+| [Image](#Image) | Specificeert dat het knooppunt een `Image` is. |
+| [InkDrawing](#InkDrawing) | Specificeert dat het knooppunt een [InkDrawing](../../com.aspose.note/nodetype\#InkDrawing) is. |
+| [InkParagraph](#InkParagraph) | Specificeert dat het knooppunt een [InkParagraph](../../com.aspose.note/nodetype\#InkParagraph) is. |
+| [InkWord](#InkWord) | Specificeert dat het knooppunt een [InkWord](../../com.aspose.note/nodetype\#InkWord) is. |
+| [Loop](#Loop) | Specificeert dat het knooppunt een [Loop](../../com.aspose.note/nodetype\#Loop) is. |
+| [Outline](#Outline) | Specificeert dat het knooppunt een `Outline` is. |
+| [OutlineElement](#OutlineElement) | Specificeert dat het knooppunt een `OutlineElement` is. |
+| [OutlineGroup](#OutlineGroup) | Specificeert dat het knooppunt een `OutlineGroup` is. |
+| [Page](#Page) | Specificeert dat het knooppunt een `Page` is. |
+| [PageSeries](#PageSeries) | Specificeert dat het knooppunt een `PageSeries` is. |
+| [RichText](#RichText) | Specificeert dat het knooppunt een `RichText` is. |
+| [Section](#Section) | Specificeert dat het knooppunt een `Section` is. |
+| [Table](#Table) | Specificeert dat het knooppunt een `Table` is. |
+| [TableCell](#TableCell) | Specificeert dat het knooppunt een `TableCell` is. |
+| [TableRow](#TableRow) | Specificeert dat het knooppunt een `TableRow` is. |
+| [Title](#Title) | Specificeert dat het knooppunt een `Title` is. |
+### AttachedFile {#AttachedFile}
+```
+public static final int AttachedFile
+```
+
+
+Specificeert dat het knooppunt een `AttachedFile` is.
+
+### Document {#Document}
+```
+public static final int Document
+```
+
+
+Specificeert dat het knooppunt een `Document` is.
+
+### Image {#Image}
+```
+public static final int Image
+```
+
+
+Specificeert dat het knooppunt een `Image` is.
+
+### InkDrawing {#InkDrawing}
+```
+public static final int InkDrawing
+```
+
+
+Specificeert dat het knooppunt een [InkDrawing](../../com.aspose.note/nodetype\#InkDrawing) is.
+
+### InkParagraph {#InkParagraph}
+```
+public static final int InkParagraph
+```
+
+
+Specificeert dat het knooppunt een [InkParagraph](../../com.aspose.note/nodetype\#InkParagraph) is.
+
+### InkWord {#InkWord}
+```
+public static final int InkWord
+```
+
+
+Specificeert dat het knooppunt een [InkWord](../../com.aspose.note/nodetype\#InkWord) is.
+
+### Loop {#Loop}
+```
+public static final int Loop
+```
+
+
+Specificeert dat het knooppunt een [Loop](../../com.aspose.note/nodetype\#Loop) is.
+
+### Outline {#Outline}
+```
+public static final int Outline
+```
+
+
+Specificeert dat het knooppunt een `Outline` is.
+
+### OutlineElement {#OutlineElement}
+```
+public static final int OutlineElement
+```
+
+
+Specificeert dat het knooppunt een `OutlineElement` is.
+
+### OutlineGroup {#OutlineGroup}
+```
+public static final int OutlineGroup
+```
+
+
+Specificeert dat het knooppunt een `OutlineGroup` is.
+
+### Page {#Page}
+```
+public static final int Page
+```
+
+
+Specificeert dat het knooppunt een `Page` is.
+
+### PageSeries {#PageSeries}
+```
+public static final int PageSeries
+```
+
+
+Specificeert dat het knooppunt een `PageSeries` is.
+
+### RichText {#RichText}
+```
+public static final int RichText
+```
+
+
+Specificeert dat het knooppunt een `RichText` is.
+
+### Section {#Section}
+```
+public static final int Section
+```
+
+
+Specificeert dat het knooppunt een `Section` is.
+
+### Table {#Table}
+```
+public static final int Table
+```
+
+
+Specificeert dat het knooppunt een `Table` is.
+
+### TableCell {#TableCell}
+```
+public static final int TableCell
+```
+
+
+Specificeert dat het knooppunt een `TableCell` is.
+
+### TableRow {#TableRow}
+```
+public static final int TableRow
+```
+
+
+Specificeert dat het knooppunt een `TableRow` is.
+
+### Title {#Title}
+```
+public static final int Title
+```
+
+
+Specificeert dat het knooppunt een `Title` is.
+

--- a/netherlands/java/com.aspose.note/notebook/_index.md
+++ b/netherlands/java/com.aspose.note/notebook/_index.md
@@ -1,0 +1,438 @@
+---
+title: "Notitieboek"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een Aspose.Note-notitieblok voor."
+type: docs
+weight: 56
+url: /nl/java/com.aspose.note/notebook/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.note.INotebookChildNode](../../com.aspose.note/inotebookchildnode), com.aspose.ms.System.Collections.Generic.IGenericEnumerable
+```
+public class Notebook implements INotebookChildNode, System.Collections.Generic.IGenericEnumerable<INotebookChildNode>
+```
+
+Stelt een Aspose.Note-notitieblok voor.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [Notebook()](#Notebook--) | Initialiseert een nieuw exemplaar van de `Notebook`-klasse. |
+| [Notebook(String filePath)](#Notebook-java.lang.String-) | Initialiseert een nieuw exemplaar van de `Notebook`-klasse. |
+| [Notebook(String filePath, NotebookLoadOptions loadOptions)](#Notebook-java.lang.String-com.aspose.note.NotebookLoadOptions-) | Initialiseert een nieuw exemplaar van de `Notebook`-klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [&lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass)](#-T1-getChildNodes-java.lang.Class-T1--) | Haalt alle kindknopen op op basis van het knooptype. |
+| [appendChild(INotebookChildNode newChild)](#appendChild-com.aspose.note.INotebookChildNode-) | Voegt de knoop toe aan het einde van de lijst. |
+| [getColor()](#getColor--) | Haalt de kleur op of stelt deze in. |
+| [getCount()](#getCount--) | Haalt het aantal elementen op dat in de `Notebook` zit. |
+| [getDisplayName()](#getDisplayName--) | Haalt de weergavenaam op of stelt deze in. |
+| [getFileFormat()](#getFileFormat--) | Haalt het bestandsformaat op (OneNote 2010, OneNote Online). |
+| [getGuid()](#getGuid--) | Haalt de wereldwijd unieke id van het object op. |
+| [getGuidInternal()](#getGuidInternal--) |  |
+| [get_Item(int index)](#get-Item-int-) | Haalt een kindknoop van het notitieboek op op basis van de opgegeven index. |
+| [isHistoryEnabled()](#isHistoryEnabled--) | Haalt een waarde op of stelt deze in die aangeeft of de geschiedenis is ingeschakeld. |
+| [iterator()](#iterator--) | Retourneert een enumerator die door de kindknopen van de `Notebook` iterereert. |
+| [loadChildDocument(InputStream stream)](#loadChildDocument-java.io.InputStream-) | Voegt een kinddocumentknoop toe. |
+| [loadChildDocument(InputStream stream, LoadOptions loadOptions)](#loadChildDocument-java.io.InputStream-com.aspose.note.LoadOptions-) | Voegt een kinddocumentknoop toe. |
+| [loadChildDocument(String filePath)](#loadChildDocument-java.lang.String-) | Voegt een kinddocumentknoop toe. |
+| [loadChildDocument(String filePath, LoadOptions loadOptions)](#loadChildDocument-java.lang.String-com.aspose.note.LoadOptions-) | Voegt een kinddocumentknoop toe. |
+| [loadChildNotebook(String filePath)](#loadChildNotebook-java.lang.String-) | Voegt een kindnotitieboekknoop toe. |
+| [loadChildNotebook(String filePath, NotebookLoadOptions loadOptions)](#loadChildNotebook-java.lang.String-com.aspose.note.NotebookLoadOptions-) | Voegt een kindnotitieboekknoop toe. |
+| [removeChild(INotebookChildNode oldChild)](#removeChild-com.aspose.note.INotebookChildNode-) | Verwijdert de kindknoop. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | Slaat het OneNote-document op naar een stream. |
+| [save(OutputStream stream, NotebookSaveOptions options)](#save-java.io.OutputStream-com.aspose.note.NotebookSaveOptions-) | Slaat het OneNote-document op naar een stream met de opgegeven opslagopties. |
+| [save(OutputStream stream, int format)](#save-java.io.OutputStream-int-) | Slaat het OneNote-document op naar een stream in het opgegeven formaat. |
+| [save(String fileName)](#save-java.lang.String-) | Slaat het OneNote-document op naar een bestand. |
+| [save(String fileName, NotebookSaveOptions options)](#save-java.lang.String-com.aspose.note.NotebookSaveOptions-) | Slaat het OneNote-document op naar een bestand met de opgegeven opslagopties. |
+| [save(String fileName, int format)](#save-java.lang.String-int-) | Slaat het OneNote-document op naar een bestand in het opgegeven formaat. |
+| [setColor(Color value)](#setColor-java.awt.Color-) | Haalt de kleur op of stelt deze in. |
+| [setDisplayName(String value)](#setDisplayName-java.lang.String-) | Haalt de weergavenaam op of stelt deze in. |
+| [setHistoryEnabled(boolean value)](#setHistoryEnabled-boolean-) | Haalt een waarde op of stelt deze in die aangeeft of de geschiedenis is ingeschakeld. |
+### Notebook() {#Notebook--}
+```
+public Notebook()
+```
+
+
+Initialiseert een nieuw exemplaar van de `Notebook`-klasse.
+
+### Notebook(String filePath) {#Notebook-java.lang.String-}
+```
+public Notebook(String filePath)
+```
+
+
+Initialiseert een nieuw exemplaar van de `Notebook`-klasse. Opent een bestaand OneNote-notitieboek vanuit een bestand.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| filePath | java.lang.String | Het bestandspad. |
+
+### Notebook(String filePath, NotebookLoadOptions loadOptions) {#Notebook-java.lang.String-com.aspose.note.NotebookLoadOptions-}
+```
+public Notebook(String filePath, NotebookLoadOptions loadOptions)
+```
+
+
+Initialiseert een nieuw exemplaar van de `Notebook`-klasse. Opent een bestaande OneNote-notebook vanuit een bestand. Staat toe extra opties op te geven, zoals een laadsstrategie voor kinderen (\"lazy\"/instant).
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| filePath | java.lang.String | Het bestandspad. |
+| loadOptions | [NotebookLoadOptions](../../com.aspose.note/notebookloadoptions) | De laadopties. |
+
+### &lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass) {#-T1-getChildNodes-java.lang.Class-T1--}
+```
+public List<T1> <T1>getChildNodes(Class<T1> typeParameterClass)
+```
+
+
+Haalt alle kindknopen op op basis van het knooptype.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| typeParameterClass | java.lang.Class&lt;T1&gt; |  |
+
+**Returns:**
+java.util.List&lt;T1&gt; - Een lijst van kindknooppunten.
+
+`T1`: Het type van elementen in de geretourneerde lijst.
+### appendChild(INotebookChildNode newChild) {#appendChild-com.aspose.note.INotebookChildNode-}
+```
+public INotebookChildNode appendChild(INotebookChildNode newChild)
+```
+
+
+Voegt de knoop toe aan het einde van de lijst.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| newChild | [INotebookChildNode](../../com.aspose.note/inotebookchildnode) | Het toe te voegen knooppunt. |
+
+**Returns:**
+[INotebookChildNode](../../com.aspose.note/inotebookchildnode) - The added node.
+### getColor() {#getColor--}
+```
+public Color getColor()
+```
+
+
+Haalt de kleur op of stelt deze in.
+
+**Returns:**
+java.awt.Color
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Haalt het aantal elementen op dat in de `Notebook` zit.
+
+**Returns:**
+int
+### getDisplayName() {#getDisplayName--}
+```
+public String getDisplayName()
+```
+
+
+Haalt de weergavenaam op of stelt deze in.
+
+**Returns:**
+java.lang.String
+### getFileFormat() {#getFileFormat--}
+```
+public int getFileFormat()
+```
+
+
+Haalt het bestandsformaat op (OneNote 2010, OneNote Online).
+
+**Returns:**
+int
+### getGuid() {#getGuid--}
+```
+public UUID getGuid()
+```
+
+
+Haalt de wereldwijd unieke id van het object op.
+
+Waarde: De GUID.
+
+**Returns:**
+java.util.UUID
+### getGuidInternal() {#getGuidInternal--}
+```
+public System.Guid getGuidInternal()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Guid
+### get_Item(int index) {#get-Item-int-}
+```
+public INotebookChildNode get_Item(int index)
+```
+
+
+Haalt een kindknoop van het notitieboek op op basis van de opgegeven index.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| index | int | Index naar kindknooppunt. |
+
+**Returns:**
+[INotebookChildNode](../../com.aspose.note/inotebookchildnode) - The child node on the `index` position.
+### isHistoryEnabled() {#isHistoryEnabled--}
+```
+public boolean isHistoryEnabled()
+```
+
+
+Haalt een waarde op of stelt deze in die aangeeft of de geschiedenis is ingeschakeld.
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public System.Collections.Generic.IGenericEnumerator<INotebookChildNode> iterator()
+```
+
+
+Retourneert een enumerator die door de kindknopen van de `Notebook` iterereert.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;com.aspose.note.INotebookChildNode&gt; - Een `IEnumerator`.
+### loadChildDocument(InputStream stream) {#loadChildDocument-java.io.InputStream-}
+```
+public void loadChildDocument(InputStream stream)
+```
+
+
+Voegt een kinddocumentknooppunt toe. Opent een bestaand OneNote-document vanuit een stream.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| stroom | java.io.InputStream | De stream. |
+
+### loadChildDocument(InputStream stream, LoadOptions loadOptions) {#loadChildDocument-java.io.InputStream-com.aspose.note.LoadOptions-}
+```
+public void loadChildDocument(InputStream stream, LoadOptions loadOptions)
+```
+
+
+Voegt een kinddocumentknooppunt toe. Opent een bestaand OneNote-document vanuit een stream. Staat toe extra laadopties op te geven.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| stroom | java.io.InputStream | De stream. |
+| loadOptions | [LoadOptions](../../com.aspose.note/loadoptions) | De laadopties. |
+
+### loadChildDocument(String filePath) {#loadChildDocument-java.lang.String-}
+```
+public void loadChildDocument(String filePath)
+```
+
+
+Voegt een kinddocumentknooppunt toe. Opent een bestaand OneNote-document vanuit een bestand.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| filePath | java.lang.String | Het bestandspad. |
+
+### loadChildDocument(String filePath, LoadOptions loadOptions) {#loadChildDocument-java.lang.String-com.aspose.note.LoadOptions-}
+```
+public void loadChildDocument(String filePath, LoadOptions loadOptions)
+```
+
+
+Voegt een kinddocumentknooppunt toe. Opent een bestaand OneNote-document vanuit een bestand. Staat toe extra laadopties op te geven.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| filePath | java.lang.String | Het bestandspad. |
+| loadOptions | [LoadOptions](../../com.aspose.note/loadoptions) | De laadopties. |
+
+### loadChildNotebook(String filePath) {#loadChildNotebook-java.lang.String-}
+```
+public void loadChildNotebook(String filePath)
+```
+
+
+Voegt een kindnotebookknooppunt toe. Opent een bestaande OneNote-notebook vanuit een bestand.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| filePath | java.lang.String | Het bestandspad. |
+
+### loadChildNotebook(String filePath, NotebookLoadOptions loadOptions) {#loadChildNotebook-java.lang.String-com.aspose.note.NotebookLoadOptions-}
+```
+public void loadChildNotebook(String filePath, NotebookLoadOptions loadOptions)
+```
+
+
+Voegt een kindnotebookknooppunt toe. Opent een bestaande OneNote-notebook vanuit een bestand. Staat toe extra laadopties op te geven.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| filePath | java.lang.String | Het bestandspad. |
+| loadOptions | [NotebookLoadOptions](../../com.aspose.note/notebookloadoptions) | De laadopties. |
+
+### removeChild(INotebookChildNode oldChild) {#removeChild-com.aspose.note.INotebookChildNode-}
+```
+public INotebookChildNode removeChild(INotebookChildNode oldChild)
+```
+
+
+Verwijdert de kindknoop.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| oldChild | [INotebookChildNode](../../com.aspose.note/inotebookchildnode) | Het te verwijderen knooppunt. |
+
+**Returns:**
+[INotebookChildNode](../../com.aspose.note/inotebookchildnode) - The removed node.
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+Slaat het OneNote-document op naar een stream.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| stroom | java.io.OutputStream | De stream. |
+
+### save(OutputStream stream, NotebookSaveOptions options) {#save-java.io.OutputStream-com.aspose.note.NotebookSaveOptions-}
+```
+public void save(OutputStream stream, NotebookSaveOptions options)
+```
+
+
+Slaat het OneNote-document op naar een stream met de opgegeven opslagopties.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| stroom | java.io.OutputStream | De stream. |
+| options | [NotebookSaveOptions](../../com.aspose.note/notebooksaveoptions) | Specificeert de opties hoe het document wordt opgeslagen. |
+
+### save(OutputStream stream, int format) {#save-java.io.OutputStream-int-}
+```
+public void save(OutputStream stream, int format)
+```
+
+
+Slaat het OneNote-document op naar een stream in het opgegeven formaat.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| stroom | java.io.OutputStream | De stream. |
+| format | int | Het formaat waarin het document moet worden opgeslagen. |
+
+### save(String fileName) {#save-java.lang.String-}
+```
+public void save(String fileName)
+```
+
+
+Slaat het OneNote-document op naar een bestand.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| fileName | java.lang.String | De volledige naam voor het bestand. Als er al een bestand met de opgegeven volledige naam bestaat, wordt het bestaande bestand overschreven. |
+
+### save(String fileName, NotebookSaveOptions options) {#save-java.lang.String-com.aspose.note.NotebookSaveOptions-}
+```
+public void save(String fileName, NotebookSaveOptions options)
+```
+
+
+Slaat het OneNote-document op naar een bestand met de opgegeven opslagopties.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| fileName | java.lang.String | De volledige naam voor het bestand. Als er al een bestand met de opgegeven volledige naam bestaat, wordt het bestaande bestand overschreven. |
+| options | [NotebookSaveOptions](../../com.aspose.note/notebooksaveoptions) | Specificeert de opties hoe het document in een bestand wordt opgeslagen. |
+
+### save(String fileName, int format) {#save-java.lang.String-int-}
+```
+public void save(String fileName, int format)
+```
+
+
+Slaat het OneNote-document op naar een bestand in het opgegeven formaat.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| fileName | java.lang.String | De volledige naam voor het bestand. Als er al een bestand met de opgegeven volledige naam bestaat, wordt het bestaande bestand overschreven. |
+| format | int | Het formaat waarin het document moet worden opgeslagen. |
+
+### setColor(Color value) {#setColor-java.awt.Color-}
+```
+public void setColor(Color value)
+```
+
+
+Haalt de kleur op of stelt deze in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.awt.Color |  |
+
+### setDisplayName(String value) {#setDisplayName-java.lang.String-}
+```
+public void setDisplayName(String value)
+```
+
+
+Haalt de weergavenaam op of stelt deze in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+
+### setHistoryEnabled(boolean value) {#setHistoryEnabled-boolean-}
+```
+public void setHistoryEnabled(boolean value)
+```
+
+
+Haalt een waarde op of stelt deze in die aangeeft of de geschiedenis is ingeschakeld.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+

--- a/netherlands/java/com.aspose.note/notebookimagesaveoptions/_index.md
+++ b/netherlands/java/com.aspose.note/notebookimagesaveoptions/_index.md
@@ -1,0 +1,34 @@
+---
+title: "NotebookImageSaveOptions"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Staat toe extra opties op te geven bij het renderen van notitieblokpagina's naar afbeeldingen."
+type: docs
+weight: 57
+url: /nl/java/com.aspose.note/notebookimagesaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.NotebookSaveOptions](../../com.aspose.note/notebooksaveoptions), com.aspose.note.NotebookSaveOptionsGeneric
+```
+public class NotebookImageSaveOptions extends NotebookSaveOptionsGeneric<ImageSaveOptions>
+```
+
+Staat toe extra opties op te geven bij het renderen van notitieblokpagina's naar afbeeldingen.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [NotebookImageSaveOptions(int format)](#NotebookImageSaveOptions-int-) | Initialiseert een nieuw exemplaar van de `NotebookImageSaveOptions` klasse. |
+### NotebookImageSaveOptions(int format) {#NotebookImageSaveOptions-int-}
+```
+public NotebookImageSaveOptions(int format)
+```
+
+
+Initialiseert een nieuw exemplaar van de `NotebookImageSaveOptions` klasse.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| format | int | Het formaat waarin het notitieboek wordt opgeslagen. |
+

--- a/netherlands/java/com.aspose.note/notebookloadoptions/_index.md
+++ b/netherlands/java/com.aspose.note/notebookloadoptions/_index.md
@@ -1,0 +1,99 @@
+---
+title: "NotebookLoadOptions"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Opties die worden gebruikt om een notitieblok te laden."
+type: docs
+weight: 58
+url: /nl/java/com.aspose.note/notebookloadoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class NotebookLoadOptions
+```
+
+Opties die worden gebruikt om een notitieblok te laden.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [NotebookLoadOptions()](#NotebookLoadOptions--) | Initialiseert een nieuw exemplaar van de `NotebookLoadOptions` klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getDeferredLoading()](#getDeferredLoading--) | Haalt op of stelt een waarde in die aangeeft of onderliggende documenten later expliciet geladen moeten worden. |
+| [getInstantLoading()](#getInstantLoading--) | Haalt op of stelt een waarde in die aangeeft of onderliggende documenten geladen moeten worden terwijl het bovenliggende document wordt geladen. |
+| [setDeferredLoading(boolean value)](#setDeferredLoading-boolean-) | Haalt op of stelt een waarde in die aangeeft of onderliggende documenten later expliciet geladen moeten worden. |
+| [setInstantLoading(boolean value)](#setInstantLoading-boolean-) | Haalt op of stelt een waarde in die aangeeft of onderliggende documenten geladen moeten worden terwijl het bovenliggende document wordt geladen. |
+### NotebookLoadOptions() {#NotebookLoadOptions--}
+```
+public NotebookLoadOptions()
+```
+
+
+Initialiseert een nieuw exemplaar van de `NotebookLoadOptions` klasse.
+
+### getDeferredLoading() {#getDeferredLoading--}
+```
+public final boolean getDeferredLoading()
+```
+
+
+Haalt op of stelt een waarde in die aangeeft of onderliggende documenten later expliciet geladen moeten worden.
+
+--------------------
+
+Standaardwaarde is `false`, dus subdocumenten worden impliciet geladen. Waarde `true` geeft aan dat de gebruiker `Notebook.loadChildDocument` moet aanroepen of voor elk subknooppunt van het notitieboek nadat het notitieboek zelf is geladen. Als de waarde `true` is, wordt de optie `NotebookLoadOptions.instantLoading` genegeerd. Als het notitieboek wordt geladen vanuit een stream, is de waarde altijd `true` ondanks dat deze expliciet door de gebruiker op `false` is ingesteld.
+
+**Returns:**
+boolean
+### getInstantLoading() {#getInstantLoading--}
+```
+public boolean getInstantLoading()
+```
+
+
+Haalt op of stelt een waarde in die aangeeft of onderliggende documenten geladen moeten worden terwijl het bovenliggende document wordt geladen.
+
+--------------------
+
+Standaardwaarde is `false`, dus subdocumenten worden "lui" geladen, d.w.z. hun laden moet worden uitgesteld tot een directe toegang tot een specifiek kind. Waarde `true` geeft aan dat hun laden onmiddellijk moet gebeuren.
+
+**Returns:**
+boolean
+### setDeferredLoading(boolean value) {#setDeferredLoading-boolean-}
+```
+public final void setDeferredLoading(boolean value)
+```
+
+
+Haalt op of stelt een waarde in die aangeeft of onderliggende documenten later expliciet geladen moeten worden.
+
+--------------------
+
+Standaardwaarde is `false`, dus subdocumenten worden impliciet geladen. Waarde `true` geeft aan dat de gebruiker `Notebook.loadChildDocument` moet aanroepen of voor elk subknooppunt van het notitieboek nadat het notitieboek zelf is geladen. Als de waarde `true` is, wordt de optie `NotebookLoadOptions.instantLoading` genegeerd. Als het notitieboek wordt geladen vanuit een stream, is de waarde altijd `true` ondanks dat deze expliciet door de gebruiker op `false` is ingesteld.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+### setInstantLoading(boolean value) {#setInstantLoading-boolean-}
+```
+public void setInstantLoading(boolean value)
+```
+
+
+Haalt op of stelt een waarde in die aangeeft of onderliggende documenten geladen moeten worden terwijl het bovenliggende document wordt geladen.
+
+--------------------
+
+Standaardwaarde is `false`, dus subdocumenten worden "lui" geladen, d.w.z. hun laden moet worden uitgesteld tot een directe toegang tot een specifiek kind. Waarde `true` geeft aan dat hun laden onmiddellijk moet gebeuren.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+

--- a/netherlands/java/com.aspose.note/notebookonesaveoptions/_index.md
+++ b/netherlands/java/com.aspose.note/notebookonesaveoptions/_index.md
@@ -1,0 +1,29 @@
+---
+title: "NotebookOneSaveOptions"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Staat toe extra opties op te geven bij het opslaan van een notitieblok in OneNote-indeling."
+type: docs
+weight: 59
+url: /nl/java/com.aspose.note/notebookonesaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.NotebookSaveOptions](../../com.aspose.note/notebooksaveoptions), com.aspose.note.NotebookSaveOptionsGeneric
+```
+public class NotebookOneSaveOptions extends NotebookSaveOptionsGeneric<OneSaveOptions>
+```
+
+Staat toe extra opties op te geven bij het opslaan van een notitieblok in OneNote-indeling.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [NotebookOneSaveOptions()](#NotebookOneSaveOptions--) | Initialiseert een nieuw exemplaar van de `NotebookOneSaveOptions` klasse. |
+### NotebookOneSaveOptions() {#NotebookOneSaveOptions--}
+```
+public NotebookOneSaveOptions()
+```
+
+
+Initialiseert een nieuw exemplaar van de `NotebookOneSaveOptions` klasse.
+

--- a/netherlands/java/com.aspose.note/notebookpdfsaveoptions/_index.md
+++ b/netherlands/java/com.aspose.note/notebookpdfsaveoptions/_index.md
@@ -1,0 +1,29 @@
+---
+title: "NotebookPdfSaveOptions"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Staat toe extra opties op te geven bij het renderen van notitieblokpagina's naar PDF."
+type: docs
+weight: 60
+url: /nl/java/com.aspose.note/notebookpdfsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.NotebookSaveOptions](../../com.aspose.note/notebooksaveoptions), com.aspose.note.NotebookSaveOptionsGeneric
+```
+public class NotebookPdfSaveOptions extends NotebookSaveOptionsGeneric<PdfSaveOptions>
+```
+
+Staat toe extra opties op te geven bij het renderen van notitieblokpagina's naar PDF.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [NotebookPdfSaveOptions()](#NotebookPdfSaveOptions--) | Initialiseert een nieuw exemplaar van de `NotebookPdfSaveOptions` klasse. |
+### NotebookPdfSaveOptions() {#NotebookPdfSaveOptions--}
+```
+public NotebookPdfSaveOptions()
+```
+
+
+Initialiseert een nieuw exemplaar van de `NotebookPdfSaveOptions` klasse.
+

--- a/netherlands/java/com.aspose.note/notebooksaveoptions/_index.md
+++ b/netherlands/java/com.aspose.note/notebooksaveoptions/_index.md
@@ -1,0 +1,100 @@
+---
+title: "NotebookSaveOptions"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Een abstracte basisklasse die notitieblok-opslagopties voor een specifiek formaat voorstelt."
+type: docs
+weight: 61
+url: /nl/java/com.aspose.note/notebooksaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class NotebookSaveOptions
+```
+
+Een abstracte basisklasse die notitieblok-opslagopties voor een specifiek formaat voorstelt.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getDeferredSaving()](#getDeferredSaving--) | Haalt op of stelt een waarde in die aangeeft of kinddocumenten expliciet moeten worden opgeslagen. |
+| [getDocumentSaveOptionsInternal()](#getDocumentSaveOptionsInternal--) | Haalt de opslagopties op voor alle kinddocumenten van het notitieboek. |
+| [getFlatten()](#getFlatten--) | Haalt op of stelt een waarde in die aangeeft of de hiërarchie van notebook-kinderen plat wordt opgeslagen. |
+| [getSaveFormat()](#getSaveFormat--) | Haalt het formaat op waarin het notitieboek wordt opgeslagen. |
+| [setDeferredSaving(boolean value)](#setDeferredSaving-boolean-) | Haalt op of stelt een waarde in die aangeeft of kinddocumenten expliciet moeten worden opgeslagen. |
+| [setFlatten(boolean value)](#setFlatten-boolean-) | Haalt op of stelt een waarde in die aangeeft of de hiërarchie van notebook-kinderen plat wordt opgeslagen. |
+### getDeferredSaving() {#getDeferredSaving--}
+```
+public boolean getDeferredSaving()
+```
+
+
+Haalt op of stelt een waarde in die aangeeft of kinddocumenten expliciet moeten worden opgeslagen.
+
+--------------------
+
+Standaardwaarde is `false`, dus subdocumenten worden impliciet opgeslagen. Waarde `true` geeft aan dat de gebruiker elk kindknooppunt van het notitieboek expliciet moet opslaan. Als het notitieboek naar een stream wordt opgeslagen, is de waarde altijd `true` ondanks dat deze expliciet door de gebruiker op `false` is ingesteld.
+
+**Returns:**
+boolean
+### getDocumentSaveOptionsInternal() {#getDocumentSaveOptionsInternal--}
+```
+public abstract SaveOptions getDocumentSaveOptionsInternal()
+```
+
+
+Haalt de opslagopties op voor alle kinddocumenten van het notitieboek.
+
+**Returns:**
+[SaveOptions](../../com.aspose.note/saveoptions) - The `SaveOptions`.
+### getFlatten() {#getFlatten--}
+```
+public boolean getFlatten()
+```
+
+
+Haalt op of stelt een waarde in die aangeeft of de hiërarchie van notebook-kinderen plat wordt opgeslagen.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public abstract int getSaveFormat()
+```
+
+
+Haalt het formaat op waarin het notitieboek wordt opgeslagen.
+
+**Returns:**
+int
+### setDeferredSaving(boolean value) {#setDeferredSaving-boolean-}
+```
+public void setDeferredSaving(boolean value)
+```
+
+
+Haalt op of stelt een waarde in die aangeeft of kinddocumenten expliciet moeten worden opgeslagen.
+
+--------------------
+
+Standaardwaarde is `false`, dus subdocumenten worden impliciet opgeslagen. Waarde `true` geeft aan dat de gebruiker elk kindknooppunt van het notitieboek expliciet moet opslaan. Als het notitieboek naar een stream wordt opgeslagen, is de waarde altijd `true` ondanks dat deze expliciet door de gebruiker op `false` is ingesteld.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+### setFlatten(boolean value) {#setFlatten-boolean-}
+```
+public void setFlatten(boolean value)
+```
+
+
+Haalt op of stelt een waarde in die aangeeft of de hiërarchie van notebook-kinderen plat wordt opgeslagen.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+

--- a/netherlands/java/com.aspose.note/notebooksaveoptionsgeneric/_index.md
+++ b/netherlands/java/com.aspose.note/notebooksaveoptionsgeneric/_index.md
@@ -1,0 +1,68 @@
+---
+title: "NotebookSaveOptionsGeneric"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Een abstracte basisklasse die notitieblok-opslagopties voor een specifiek formaat voorstelt en gemeenschappelijke opslagopties biedt voor alle onderliggende knooppunten van het document."
+type: docs
+weight: 62
+url: /nl/java/com.aspose.note/notebooksaveoptionsgeneric/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.NotebookSaveOptions](../../com.aspose.note/notebooksaveoptions)
+```
+public abstract class NotebookSaveOptionsGeneric<TDocumentSaveOptions> extends NotebookSaveOptions
+```
+
+Een abstracte basisklasse die notitieblok-opslagopties voor een specifiek formaat voorstelt en gemeenschappelijke opslagopties biedt voor alle onderliggende knooppunten van het document.
+
+`TDocumentSaveOptions`: De opslagopties voor alle onderliggende documenten van het notitieboek.
+
+TDocumentSaveOptions :
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [NotebookSaveOptionsGeneric()](#NotebookSaveOptionsGeneric--) |  |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getDocumentSaveOptions()](#getDocumentSaveOptions--) | Haalt of stelt de opslagopties in voor alle onderliggende documenten van het notitieboek. |
+| [getDocumentSaveOptionsInternal()](#getDocumentSaveOptionsInternal--) | Haalt de opslagopties op voor alle kinddocumenten van het notitieboek. |
+| [getSaveFormat()](#getSaveFormat--) | Haalt het formaat op waarin het notitieboek wordt opgeslagen. |
+### NotebookSaveOptionsGeneric() {#NotebookSaveOptionsGeneric--}
+```
+public NotebookSaveOptionsGeneric()
+```
+
+
+### getDocumentSaveOptions() {#getDocumentSaveOptions--}
+```
+public TDocumentSaveOptions getDocumentSaveOptions()
+```
+
+
+Haalt of stelt de opslagopties in voor alle onderliggende documenten van het notitieboek.
+
+**Returns:**
+TDocumentSaveOptions
+### getDocumentSaveOptionsInternal() {#getDocumentSaveOptionsInternal--}
+```
+public SaveOptions getDocumentSaveOptionsInternal()
+```
+
+
+Haalt de opslagopties op voor alle kinddocumenten van het notitieboek.
+
+**Returns:**
+[SaveOptions](../../com.aspose.note/saveoptions) - The `SaveOptions`.
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Haalt het formaat op waarin het notitieboek wordt opgeslagen.
+
+**Returns:**
+int

--- a/netherlands/java/com.aspose.note/notecheckbox/_index.md
+++ b/netherlands/java/com.aspose.note/notecheckbox/_index.md
@@ -1,0 +1,883 @@
+---
+title: "NoteCheckBox"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een notitag voor die hun status kan schakelen tussen voltooid en onvoltooid."
+type: docs
+weight: 53
+url: /nl/java/com.aspose.note/notecheckbox/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.note.TagExtended, [com.aspose.note.CheckBox](../../com.aspose.note/checkbox)
+
+**All Implemented Interfaces:**
+[com.aspose.note.INoteTag](../../com.aspose.note/inotetag), com.aspose.ms.System.IEquatable
+```
+public class NoteCheckBox extends CheckBox implements INoteTag, System.IEquatable<NoteCheckBox>
+```
+
+Stelt een notitag voor die hun status kan schakelen tussen voltooid en onvoltooid.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [createBlueCheckBox()](#createBlueCheckBox--) | * Maakt een nieuw notitie‑tag met BlueCheckBoxEmpty‑pictogram en standaardlabel. |
+| [createBlueCheckBox(String label)](#createBlueCheckBox-java.lang.String-) | * Maakt een nieuw notitie‑selectievakje met BlueCheckBoxEmpty‑pictogram en opgegeven label. |
+| [createBlueCheckBox1()](#createBlueCheckBox1--) | * Maakt een nieuw notitie‑tag met BlueCheckBox1Empty‑pictogram en standaardlabel. |
+| [createBlueCheckBox1(String label)](#createBlueCheckBox1-java.lang.String-) | * Maakt een nieuw notitie‑selectievakje met BlueCheckBox1Empty‑pictogram en opgegeven label. |
+| [createBlueCheckBox2()](#createBlueCheckBox2--) | * Maakt een nieuw notitie‑tag met BlueCheckBox2Empty‑pictogram en standaardlabel. |
+| [createBlueCheckBox2(String label)](#createBlueCheckBox2-java.lang.String-) | * Maakt een nieuw notitie‑selectievakje met BlueCheckBox2Empty‑pictogram en opgegeven label. |
+| [createBlueCheckBox3()](#createBlueCheckBox3--) | * Maakt een nieuw notitie‑tag met BlueCheckBox3Empty‑pictogram en standaardlabel. |
+| [createBlueCheckBox3(String label)](#createBlueCheckBox3-java.lang.String-) | * Maakt een nieuw notitie‑selectievakje met BlueCheckBox3Empty‑pictogram en opgegeven label. |
+| [createBlueExclamationCheckBox()](#createBlueExclamationCheckBox--) | * Maakt een nieuw notitie‑tag met BlueExclamationCheckBoxEmpty‑pictogram en standaardlabel. |
+| [createBlueExclamationCheckBox(String label)](#createBlueExclamationCheckBox-java.lang.String-) | * Maakt een nieuw notitie‑selectievakje met BlueExclamationCheckBoxEmpty‑pictogram en opgegeven label. |
+| [createBlueFlagCheckBox()](#createBlueFlagCheckBox--) | * Maakt een nieuw notitie‑tag met BlueFlagCheckBoxEmpty‑pictogram en standaardlabel. |
+| [createBlueFlagCheckBox(String label)](#createBlueFlagCheckBox-java.lang.String-) | * Maakt een nieuw notitie‑selectievakje met BlueFlagCheckBoxEmpty‑pictogram en opgegeven label. |
+| [createBluePersonCheckBox()](#createBluePersonCheckBox--) | * Maakt een nieuw notitie‑tag met BluePersonCheckBoxEmpty pictogram en standaardlabel. |
+| [createBluePersonCheckBox(String label)](#createBluePersonCheckBox-java.lang.String-) | * Maakt een nieuw notitie‑checkbox met BluePersonCheckBoxEmpty pictogram en opgegeven label. |
+| [createBlueRightArrowCheckBox()](#createBlueRightArrowCheckBox--) | * Maakt een nieuw notitie‑tag met BlueRightArrowCheckBoxEmpty pictogram en standaardlabel. |
+| [createBlueRightArrowCheckBox(String label)](#createBlueRightArrowCheckBox-java.lang.String-) | * Maakt een nieuw notitie‑checkbox met BlueRightArrowCheckBoxEmpty pictogram en opgegeven label. |
+| [createBlueStarCheckBox()](#createBlueStarCheckBox--) | * Maakt een nieuw notitie‑tag met BlueStarCheckBoxEmpty pictogram en standaardlabel. |
+| [createBlueStarCheckBox(String label)](#createBlueStarCheckBox-java.lang.String-) | * Maakt een nieuw notitie‑checkbox met BlueStarCheckBoxEmpty pictogram en opgegeven label. |
+| [createGreenCheckBox()](#createGreenCheckBox--) | * Maakt een nieuw notitie‑tag met GreenCheckBoxEmpty pictogram en standaardlabel. |
+| [createGreenCheckBox(String label)](#createGreenCheckBox-java.lang.String-) | * Maakt een nieuw notitie‑checkbox met GreenCheckBoxEmpty pictogram en opgegeven label. |
+| [createGreenCheckBox1()](#createGreenCheckBox1--) | * Maakt een nieuw notitie‑tag met GreenCheckBox1Empty pictogram en standaardlabel. |
+| [createGreenCheckBox1(String label)](#createGreenCheckBox1-java.lang.String-) | * Maakt een nieuw notitie‑checkbox met GreenCheckBox1Empty pictogram en opgegeven label. |
+| [createGreenCheckBox2()](#createGreenCheckBox2--) | * Maakt een nieuw notitie‑tag met GreenCheckBox2Empty pictogram en standaardlabel. |
+| [createGreenCheckBox2(String label)](#createGreenCheckBox2-java.lang.String-) | * Maakt een nieuw notitie‑checkbox met GreenCheckBox2Empty pictogram en opgegeven label. |
+| [createGreenCheckBox3()](#createGreenCheckBox3--) | * Maakt een nieuw notitie‑tag met GreenCheckBox3Empty pictogram en standaardlabel. |
+| [createGreenCheckBox3(String label)](#createGreenCheckBox3-java.lang.String-) | * Maakt een nieuw notitie‑checkbox met GreenCheckBox3Empty pictogram en opgegeven label. |
+| [createGreenExclamationCheckBox()](#createGreenExclamationCheckBox--) | * Maakt een nieuw notitie‑tag met GreenExclamationCheckBoxEmpty pictogram en standaardlabel. |
+| [createGreenExclamationCheckBox(String label)](#createGreenExclamationCheckBox-java.lang.String-) | * Maakt een nieuw notitie‑checkbox met GreenExclamationCheckBoxEmpty pictogram en opgegeven label. |
+| [createGreenFlagCheckBox()](#createGreenFlagCheckBox--) | * Maakt een nieuw notitie‑tag met GreenFlagCheckBoxEmpty pictogram en standaardlabel. |
+| [createGreenFlagCheckBox(String label)](#createGreenFlagCheckBox-java.lang.String-) | * Maakt een nieuw notitie‑checkbox met GreenFlagCheckBoxEmpty pictogram en opgegeven label. |
+| [createGreenPersonCheckBox()](#createGreenPersonCheckBox--) | * Maakt een nieuw notitie‑tag met GreenPersonCheckBoxEmpty pictogram en standaardlabel. |
+| [createGreenPersonCheckBox(String label)](#createGreenPersonCheckBox-java.lang.String-) | * Maakt een nieuw notitie‑checkbox met GreenPersonCheckBoxEmpty pictogram en opgegeven label. |
+| [createGreenRightArrowCheckBox()](#createGreenRightArrowCheckBox--) | * Maakt een nieuw notitie‑tag met GreenRightArrowCheckBoxEmpty pictogram en standaardlabel. |
+| [createGreenRightArrowCheckBox(String label)](#createGreenRightArrowCheckBox-java.lang.String-) | * Maakt een nieuw notitie‑checkbox met GreenRightArrowCheckBoxEmpty pictogram en opgegeven label. |
+| [createGreenStarCheckBox()](#createGreenStarCheckBox--) | * Maakt een nieuw notitie‑tag met GreenStarCheckBoxEmpty pictogram en standaardlabel. |
+| [createGreenStarCheckBox(String label)](#createGreenStarCheckBox-java.lang.String-) | * Maakt een nieuw notitie‑checkbox met GreenStarCheckBoxEmpty pictogram en opgegeven label. |
+| [createRedFlagCheckBox()](#createRedFlagCheckBox--) | * Maakt een nieuw notitie‑tag met RedFlagCheckBoxEmpty pictogram en standaardlabel. |
+| [createRedFlagCheckBox(String label)](#createRedFlagCheckBox-java.lang.String-) | * Maakt een nieuw notitie‑selectievakje met RedFlagCheckBoxEmpty‑pictogram en opgegeven label. |
+| [createYellowCheckBox()](#createYellowCheckBox--) | * Maakt een nieuw notitie‑tag met YellowCheckBoxEmpty‑pictogram en standaardlabel. |
+| [createYellowCheckBox(String label)](#createYellowCheckBox-java.lang.String-) | * Maakt een nieuw notitie‑selectievakje met YellowCheckBoxEmpty‑pictogram en opgegeven label. |
+| [createYellowCheckBox1()](#createYellowCheckBox1--) | * Maakt een nieuw notitie‑tag met YellowCheckBox1Empty‑pictogram en standaardlabel. |
+| [createYellowCheckBox1(String label)](#createYellowCheckBox1-java.lang.String-) | * Maakt een nieuw notitie‑selectievakje met YellowCheckBox1Empty‑pictogram en opgegeven label. |
+| [createYellowCheckBox2()](#createYellowCheckBox2--) | * Maakt een nieuw notitie‑tag met YellowCheckBox2Empty‑pictogram en standaardlabel. |
+| [createYellowCheckBox2(String label)](#createYellowCheckBox2-java.lang.String-) | * Maakt een nieuw notitie‑selectievakje met YellowCheckBox2Empty‑pictogram en opgegeven label. |
+| [createYellowCheckBox3()](#createYellowCheckBox3--) | * Maakt een nieuw notitie‑tag met YellowCheckBox3Empty‑pictogram en standaardlabel. |
+| [createYellowCheckBox3(String label)](#createYellowCheckBox3-java.lang.String-) | * Maakt een nieuw notitie‑selectievakje met YellowCheckBox3Empty‑pictogram en opgegeven label. |
+| [createYellowExclamationCheckBox()](#createYellowExclamationCheckBox--) | * Maakt een nieuw notitie‑tag met YellowExclamationCheckBoxEmpty‑pictogram en standaardlabel. |
+| [createYellowExclamationCheckBox(String label)](#createYellowExclamationCheckBox-java.lang.String-) | * Maakt een nieuw notitie‑selectievakje met YellowExclamationCheckBoxEmpty‑pictogram en opgegeven label. |
+| [createYellowPersonCheckBox()](#createYellowPersonCheckBox--) | * Maakt een nieuw notitie‑tag met YellowPersonCheckBoxEmpty‑pictogram en standaardlabel. |
+| [createYellowPersonCheckBox(String label)](#createYellowPersonCheckBox-java.lang.String-) | * Maakt een nieuw notitie‑selectievakje met YellowPersonCheckBoxEmpty‑pictogram en opgegeven label. |
+| [createYellowRightArrowCheckBox()](#createYellowRightArrowCheckBox--) | * Maakt een nieuw notitie‑tag met YellowRightArrowCheckBoxEmpty‑pictogram en standaardlabel. |
+| [createYellowRightArrowCheckBox(String label)](#createYellowRightArrowCheckBox-java.lang.String-) | * Maakt een nieuw notitie‑selectievakje met YellowRightArrowCheckBoxEmpty‑pictogram en opgegeven label. |
+| [createYellowStarCheckBox()](#createYellowStarCheckBox--) | * Maakt een nieuw notitie‑tag met YellowStarCheckBoxEmpty‑pictogram en standaardlabel. |
+| [createYellowStarCheckBox(String label)](#createYellowStarCheckBox-java.lang.String-) | * Maakt een nieuw notitie‑selectievakje met YellowStarCheckBoxEmpty‑pictogram en opgegeven label. |
+| [equals(NoteCheckBox other)](#equals-com.aspose.note.NoteCheckBox-) | Bepaalt of het opgegeven object gelijk is aan het huidige object. |
+| [equals(Object obj)](#equals-java.lang.Object-) | Bepaalt of het opgegeven object gelijk is aan het huidige object. |
+| [getFontColor()](#getFontColor--) | Haalt de letterkleur op of stelt deze in. |
+| [getHighlight()](#getHighlight--) | Haalt de markeerkleur op of stelt deze in. |
+| [getIcon()](#getIcon--) | Haalt het pictogram op of stelt dit in. |
+| [getLabel()](#getLabel--) | Haalt de labeltekst op of stelt deze in. |
+| [hashCode()](#hashCode--) | Dient als een hash-functie voor het type. |
+| [setFontColor(Color value)](#setFontColor-java.awt.Color-) | Haalt de letterkleur op of stelt deze in. |
+| [setHighlight(Color value)](#setHighlight-java.awt.Color-) | Haalt de markeerkleur op of stelt deze in. |
+| [setLabel(String value)](#setLabel-java.lang.String-) | Haalt de labeltekst op of stelt deze in. |
+### createBlueCheckBox() {#createBlueCheckBox--}
+```
+public static NoteCheckBox createBlueCheckBox()
+```
+
+
+* Maakt een nieuw notitie‑tag met BlueCheckBoxEmpty‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox(String label) {#createBlueCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createBlueCheckBox(String label)
+```
+
+
+* Maakt een nieuw notitie‑selectievakje met BlueCheckBoxEmpty‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox1() {#createBlueCheckBox1--}
+```
+public static NoteCheckBox createBlueCheckBox1()
+```
+
+
+* Maakt een nieuw notitie‑tag met BlueCheckBox1Empty‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox1(String label) {#createBlueCheckBox1-java.lang.String-}
+```
+public static NoteCheckBox createBlueCheckBox1(String label)
+```
+
+
+* Maakt een nieuw notitie‑selectievakje met BlueCheckBox1Empty‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox2() {#createBlueCheckBox2--}
+```
+public static NoteCheckBox createBlueCheckBox2()
+```
+
+
+* Maakt een nieuw notitie‑tag met BlueCheckBox2Empty‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox2(String label) {#createBlueCheckBox2-java.lang.String-}
+```
+public static NoteCheckBox createBlueCheckBox2(String label)
+```
+
+
+* Maakt een nieuw notitie‑selectievakje met BlueCheckBox2Empty‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox3() {#createBlueCheckBox3--}
+```
+public static NoteCheckBox createBlueCheckBox3()
+```
+
+
+* Maakt een nieuw notitie‑tag met BlueCheckBox3Empty‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueCheckBox3(String label) {#createBlueCheckBox3-java.lang.String-}
+```
+public static NoteCheckBox createBlueCheckBox3(String label)
+```
+
+
+* Maakt een nieuw notitie‑selectievakje met BlueCheckBox3Empty‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueExclamationCheckBox() {#createBlueExclamationCheckBox--}
+```
+public static NoteCheckBox createBlueExclamationCheckBox()
+```
+
+
+* Maakt een nieuw notitie‑tag met BlueExclamationCheckBoxEmpty‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueExclamationCheckBox(String label) {#createBlueExclamationCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createBlueExclamationCheckBox(String label)
+```
+
+
+* Maakt een nieuw notitie‑selectievakje met BlueExclamationCheckBoxEmpty‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueFlagCheckBox() {#createBlueFlagCheckBox--}
+```
+public static NoteCheckBox createBlueFlagCheckBox()
+```
+
+
+* Maakt een nieuw notitie‑tag met BlueFlagCheckBoxEmpty‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueFlagCheckBox(String label) {#createBlueFlagCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createBlueFlagCheckBox(String label)
+```
+
+
+* Maakt een nieuw notitie‑selectievakje met BlueFlagCheckBoxEmpty‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBluePersonCheckBox() {#createBluePersonCheckBox--}
+```
+public static NoteCheckBox createBluePersonCheckBox()
+```
+
+
+* Maakt een nieuw notitie‑tag met BluePersonCheckBoxEmpty pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBluePersonCheckBox(String label) {#createBluePersonCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createBluePersonCheckBox(String label)
+```
+
+
+* Maakt een nieuw notitie‑checkbox met BluePersonCheckBoxEmpty pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueRightArrowCheckBox() {#createBlueRightArrowCheckBox--}
+```
+public static NoteCheckBox createBlueRightArrowCheckBox()
+```
+
+
+* Maakt een nieuw notitie‑tag met BlueRightArrowCheckBoxEmpty pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueRightArrowCheckBox(String label) {#createBlueRightArrowCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createBlueRightArrowCheckBox(String label)
+```
+
+
+* Maakt een nieuw notitie‑checkbox met BlueRightArrowCheckBoxEmpty pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueStarCheckBox() {#createBlueStarCheckBox--}
+```
+public static NoteCheckBox createBlueStarCheckBox()
+```
+
+
+* Maakt een nieuw notitie‑tag met BlueStarCheckBoxEmpty pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createBlueStarCheckBox(String label) {#createBlueStarCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createBlueStarCheckBox(String label)
+```
+
+
+* Maakt een nieuw notitie‑checkbox met BlueStarCheckBoxEmpty pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox() {#createGreenCheckBox--}
+```
+public static NoteCheckBox createGreenCheckBox()
+```
+
+
+* Maakt een nieuw notitie‑tag met GreenCheckBoxEmpty pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox(String label) {#createGreenCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createGreenCheckBox(String label)
+```
+
+
+* Maakt een nieuw notitie‑checkbox met GreenCheckBoxEmpty pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox1() {#createGreenCheckBox1--}
+```
+public static NoteCheckBox createGreenCheckBox1()
+```
+
+
+* Maakt een nieuw notitie‑tag met GreenCheckBox1Empty pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox1(String label) {#createGreenCheckBox1-java.lang.String-}
+```
+public static NoteCheckBox createGreenCheckBox1(String label)
+```
+
+
+* Maakt een nieuw notitie‑checkbox met GreenCheckBox1Empty pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox2() {#createGreenCheckBox2--}
+```
+public static NoteCheckBox createGreenCheckBox2()
+```
+
+
+* Maakt een nieuw notitie‑tag met GreenCheckBox2Empty pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox2(String label) {#createGreenCheckBox2-java.lang.String-}
+```
+public static NoteCheckBox createGreenCheckBox2(String label)
+```
+
+
+* Maakt een nieuw notitie‑checkbox met GreenCheckBox2Empty pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox3() {#createGreenCheckBox3--}
+```
+public static NoteCheckBox createGreenCheckBox3()
+```
+
+
+* Maakt een nieuw notitie‑tag met GreenCheckBox3Empty pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenCheckBox3(String label) {#createGreenCheckBox3-java.lang.String-}
+```
+public static NoteCheckBox createGreenCheckBox3(String label)
+```
+
+
+* Maakt een nieuw notitie‑checkbox met GreenCheckBox3Empty pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenExclamationCheckBox() {#createGreenExclamationCheckBox--}
+```
+public static NoteCheckBox createGreenExclamationCheckBox()
+```
+
+
+* Maakt een nieuw notitie‑tag met GreenExclamationCheckBoxEmpty pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenExclamationCheckBox(String label) {#createGreenExclamationCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createGreenExclamationCheckBox(String label)
+```
+
+
+* Maakt een nieuw notitie‑checkbox met GreenExclamationCheckBoxEmpty pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenFlagCheckBox() {#createGreenFlagCheckBox--}
+```
+public static NoteCheckBox createGreenFlagCheckBox()
+```
+
+
+* Maakt een nieuw notitie‑tag met GreenFlagCheckBoxEmpty pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenFlagCheckBox(String label) {#createGreenFlagCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createGreenFlagCheckBox(String label)
+```
+
+
+* Maakt een nieuw notitie‑checkbox met GreenFlagCheckBoxEmpty pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenPersonCheckBox() {#createGreenPersonCheckBox--}
+```
+public static NoteCheckBox createGreenPersonCheckBox()
+```
+
+
+* Maakt een nieuw notitie‑tag met GreenPersonCheckBoxEmpty pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenPersonCheckBox(String label) {#createGreenPersonCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createGreenPersonCheckBox(String label)
+```
+
+
+* Maakt een nieuw notitie‑checkbox met GreenPersonCheckBoxEmpty pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenRightArrowCheckBox() {#createGreenRightArrowCheckBox--}
+```
+public static NoteCheckBox createGreenRightArrowCheckBox()
+```
+
+
+* Maakt een nieuw notitie‑tag met GreenRightArrowCheckBoxEmpty pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenRightArrowCheckBox(String label) {#createGreenRightArrowCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createGreenRightArrowCheckBox(String label)
+```
+
+
+* Maakt een nieuw notitie‑checkbox met GreenRightArrowCheckBoxEmpty pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenStarCheckBox() {#createGreenStarCheckBox--}
+```
+public static NoteCheckBox createGreenStarCheckBox()
+```
+
+
+* Maakt een nieuw notitie‑tag met GreenStarCheckBoxEmpty pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createGreenStarCheckBox(String label) {#createGreenStarCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createGreenStarCheckBox(String label)
+```
+
+
+* Maakt een nieuw notitie‑checkbox met GreenStarCheckBoxEmpty pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createRedFlagCheckBox() {#createRedFlagCheckBox--}
+```
+public static NoteCheckBox createRedFlagCheckBox()
+```
+
+
+* Maakt een nieuw notitie‑tag met RedFlagCheckBoxEmpty pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createRedFlagCheckBox(String label) {#createRedFlagCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createRedFlagCheckBox(String label)
+```
+
+
+* Maakt een nieuw notitie‑selectievakje met RedFlagCheckBoxEmpty‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox() {#createYellowCheckBox--}
+```
+public static NoteCheckBox createYellowCheckBox()
+```
+
+
+* Maakt een nieuw notitie‑tag met YellowCheckBoxEmpty‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox(String label) {#createYellowCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createYellowCheckBox(String label)
+```
+
+
+* Maakt een nieuw notitie‑selectievakje met YellowCheckBoxEmpty‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox1() {#createYellowCheckBox1--}
+```
+public static NoteCheckBox createYellowCheckBox1()
+```
+
+
+* Maakt een nieuw notitie‑tag met YellowCheckBox1Empty‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox1(String label) {#createYellowCheckBox1-java.lang.String-}
+```
+public static NoteCheckBox createYellowCheckBox1(String label)
+```
+
+
+* Maakt een nieuw notitie‑selectievakje met YellowCheckBox1Empty‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox2() {#createYellowCheckBox2--}
+```
+public static NoteCheckBox createYellowCheckBox2()
+```
+
+
+* Maakt een nieuw notitie‑tag met YellowCheckBox2Empty‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox2(String label) {#createYellowCheckBox2-java.lang.String-}
+```
+public static NoteCheckBox createYellowCheckBox2(String label)
+```
+
+
+* Maakt een nieuw notitie‑selectievakje met YellowCheckBox2Empty‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox3() {#createYellowCheckBox3--}
+```
+public static NoteCheckBox createYellowCheckBox3()
+```
+
+
+* Maakt een nieuw notitie‑tag met YellowCheckBox3Empty‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowCheckBox3(String label) {#createYellowCheckBox3-java.lang.String-}
+```
+public static NoteCheckBox createYellowCheckBox3(String label)
+```
+
+
+* Maakt een nieuw notitie‑selectievakje met YellowCheckBox3Empty‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowExclamationCheckBox() {#createYellowExclamationCheckBox--}
+```
+public static NoteCheckBox createYellowExclamationCheckBox()
+```
+
+
+* Maakt een nieuw notitie‑tag met YellowExclamationCheckBoxEmpty‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowExclamationCheckBox(String label) {#createYellowExclamationCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createYellowExclamationCheckBox(String label)
+```
+
+
+* Maakt een nieuw notitie‑selectievakje met YellowExclamationCheckBoxEmpty‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowPersonCheckBox() {#createYellowPersonCheckBox--}
+```
+public static NoteCheckBox createYellowPersonCheckBox()
+```
+
+
+* Maakt een nieuw notitie‑tag met YellowPersonCheckBoxEmpty‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowPersonCheckBox(String label) {#createYellowPersonCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createYellowPersonCheckBox(String label)
+```
+
+
+* Maakt een nieuw notitie‑selectievakje met YellowPersonCheckBoxEmpty‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowRightArrowCheckBox() {#createYellowRightArrowCheckBox--}
+```
+public static NoteCheckBox createYellowRightArrowCheckBox()
+```
+
+
+* Maakt een nieuw notitie‑tag met YellowRightArrowCheckBoxEmpty‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowRightArrowCheckBox(String label) {#createYellowRightArrowCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createYellowRightArrowCheckBox(String label)
+```
+
+
+* Maakt een nieuw notitie‑selectievakje met YellowRightArrowCheckBoxEmpty‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowStarCheckBox() {#createYellowStarCheckBox--}
+```
+public static NoteCheckBox createYellowStarCheckBox()
+```
+
+
+* Maakt een nieuw notitie‑tag met YellowStarCheckBoxEmpty‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### createYellowStarCheckBox(String label) {#createYellowStarCheckBox-java.lang.String-}
+```
+public static NoteCheckBox createYellowStarCheckBox(String label)
+```
+
+
+* Maakt een nieuw notitie‑selectievakje met YellowStarCheckBoxEmpty‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteCheckBox](../../com.aspose.note/notecheckbox) - The [NoteCheckBox](../../com.aspose.note/notecheckbox).
+### equals(NoteCheckBox other) {#equals-com.aspose.note.NoteCheckBox-}
+```
+public final boolean equals(NoteCheckBox other)
+```
+
+
+Bepaalt of het opgegeven object gelijk is aan het huidige object.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| other | [NoteCheckBox](../../com.aspose.note/notecheckbox) | Het object. |
+
+**Returns:**
+boolean - De `boolean`.
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Bepaalt of het opgegeven object gelijk is aan het huidige object.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| obj | java.lang.Object | Het object. |
+
+**Returns:**
+boolean - De `boolean`.
+### getFontColor() {#getFontColor--}
+```
+public final Color getFontColor()
+```
+
+
+Haalt de letterkleur op of stelt deze in.
+
+**Returns:**
+java.awt.Color
+### getHighlight() {#getHighlight--}
+```
+public final Color getHighlight()
+```
+
+
+Haalt de markeerkleur op of stelt deze in.
+
+**Returns:**
+java.awt.Color
+### getIcon() {#getIcon--}
+```
+public int getIcon()
+```
+
+
+Haalt het pictogram op of stelt dit in.
+
+Waarde: De [TagIcon](../../com.aspose.note.infrastructure/tagicon).
+
+**Returns:**
+int
+### getLabel() {#getLabel--}
+```
+public final String getLabel()
+```
+
+
+Haalt de labeltekst op of stelt deze in.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als een hash-functie voor het type.
+
+**Returns:**
+int - De `int`.
+### setFontColor(Color value) {#setFontColor-java.awt.Color-}
+```
+public final void setFontColor(Color value)
+```
+
+
+Haalt de letterkleur op of stelt deze in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.awt.Color |  |
+
+### setHighlight(Color value) {#setHighlight-java.awt.Color-}
+```
+public final void setHighlight(Color value)
+```
+
+
+Haalt de markeerkleur op of stelt deze in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.awt.Color |  |
+
+### setLabel(String value) {#setLabel-java.lang.String-}
+```
+public final void setLabel(String value)
+```
+
+
+Haalt de labeltekst op of stelt deze in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+

--- a/netherlands/java/com.aspose.note/notetag/_index.md
+++ b/netherlands/java/com.aspose.note/notetag/_index.md
@@ -1,0 +1,3262 @@
+---
+title: "NoteTag"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een notitag voor."
+type: docs
+weight: 54
+url: /nl/java/com.aspose.note/notetag/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.note.TagExtended
+
+**All Implemented Interfaces:**
+[com.aspose.note.INoteTag](../../com.aspose.note/inotetag), com.aspose.ms.System.IEquatable
+```
+public final class NoteTag extends TagExtended implements INoteTag, System.IEquatable<NoteTag>
+```
+
+Stelt een notitag voor.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [NoteTag()](#NoteTag--) | Initialiseert een nieuw exemplaar van de [NoteTag](../../com.aspose.note/notetag) klasse zonder pictogram. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [createAwardRibbon()](#createAwardRibbon--) | \* Maakt een nieuw notitie‑tag met het AwardRibbon‑pictogram en standaardlabel. |
+| [createAwardRibbon(String label)](#createAwardRibbon-java.lang.String-) | \* Maakt een nieuw notitie‑tag met het AwardRibbon‑pictogram en opgegeven label. |
+| [createBinoculars()](#createBinoculars--) | \* Maakt een nieuw notitie‑tag met het Binoculars‑pictogram en standaardlabel. |
+| [createBinoculars(String label)](#createBinoculars-java.lang.String-) | \* Maakt een nieuw notitie‑tag met het Binoculars‑pictogram en opgegeven label. |
+| [createBlankPaperWithLines()](#createBlankPaperWithLines--) | \* Maakt een nieuw notitie‑tag met het BlankPaperWithLines‑pictogram en standaardlabel. |
+| [createBlankPaperWithLines(String label)](#createBlankPaperWithLines-java.lang.String-) | \* Maakt een nieuw notitie‑tag met het BlankPaperWithLines‑pictogram en opgegeven label. |
+| [createBlueCheckMark()](#createBlueCheckMark--) | \* Maakt een nieuw notitie‑tag met het BlueCheckMark‑pictogram en standaardlabel. |
+| [createBlueCheckMark(String label)](#createBlueCheckMark-java.lang.String-) | \* Maakt een nieuw notitie‑tag met het BlueCheckMark‑pictogram en opgegeven label. |
+| [createBlueCircle()](#createBlueCircle--) | \* Maakt een nieuw notitie‑tag met het BlueCircle‑pictogram en standaardlabel. |
+| [createBlueCircle(String label)](#createBlueCircle-java.lang.String-) | \* Maakt een nieuw notitie‑tag met het BlueCircle‑pictogram en opgegeven label. |
+| [createBlueCircle1()](#createBlueCircle1--) | \* Maakt een nieuw notitie‑tag met het BlueCircle1‑pictogram en standaardlabel. |
+| [createBlueCircle1(String label)](#createBlueCircle1-java.lang.String-) | \* Maakt een nieuw notitie‑tag met het BlueCircle1‑pictogram en opgegeven label. |
+| [createBlueCircle2()](#createBlueCircle2--) | \* Maakt een nieuw notitie‑tag met het BlueCircle2‑pictogram en standaardlabel. |
+| [createBlueCircle2(String label)](#createBlueCircle2-java.lang.String-) | \* Maakt een nieuw notitie‑tag met het BlueCircle2‑pictogram en opgegeven label. |
+| [createBlueCircle3()](#createBlueCircle3--) | \* Maakt een nieuw notitie‑tag met het BlueCircle3‑pictogram en standaardlabel. |
+| [createBlueCircle3(String label)](#createBlueCircle3-java.lang.String-) | \* Maakt een nieuw notitie‑tag met het BlueCircle3‑pictogram en opgegeven label. |
+| [createBlueDownArrow()](#createBlueDownArrow--) | \* Maakt een nieuw notitie‑tag met het BlueDownArrow‑pictogram en standaardlabel. |
+| [createBlueDownArrow(String label)](#createBlueDownArrow-java.lang.String-) | \* Maakt een nieuw notitie‑tag met het BlueDownArrow‑pictogram en opgegeven label. |
+| [createBlueEightPointStar()](#createBlueEightPointStar--) | \* Maakt een nieuw notitie‑tag met het BlueEightPointStar‑pictogram en standaardlabel. |
+| [createBlueEightPointStar(String label)](#createBlueEightPointStar-java.lang.String-) | \* Maakt een nieuw notitie‑tag met het BlueEightPointStar‑pictogram en opgegeven label. |
+| [createBlueFollowUpFlag()](#createBlueFollowUpFlag--) | \* Maakt een nieuw notitie‑tag met het BlueFollowUpFlag‑pictogram en standaardlabel. |
+| [createBlueFollowUpFlag(String label)](#createBlueFollowUpFlag-java.lang.String-) | \* Maakt een nieuw notitie‑tag met BlueFollowUpFlag pictogram en opgegeven label. |
+| [createBlueLeftArrow()](#createBlueLeftArrow--) | \* Maakt een nieuw notitie‑tag met BlueLeftArrow pictogram en standaardlabel. |
+| [createBlueLeftArrow(String label)](#createBlueLeftArrow-java.lang.String-) | \* Maakt een nieuw notitie‑tag met BlueLeftArrow pictogram en opgegeven label. |
+| [createBlueRightArrow()](#createBlueRightArrow--) | \* Maakt een nieuw notitie‑tag met BlueRightArrow pictogram en standaardlabel. |
+| [createBlueRightArrow(String label)](#createBlueRightArrow-java.lang.String-) | \* Maakt een nieuw notitie‑tag met BlueRightArrow pictogram en opgegeven label. |
+| [createBlueSolidTarget()](#createBlueSolidTarget--) | \* Maakt een nieuw notitie‑tag met BlueSolidTarget pictogram en standaardlabel. |
+| [createBlueSolidTarget(String label)](#createBlueSolidTarget-java.lang.String-) | \* Maakt een nieuw notitie‑tag met BlueSolidTarget pictogram en opgegeven label. |
+| [createBlueSquare()](#createBlueSquare--) | \* Maakt een nieuw notitie‑tag met BlueSquare pictogram en standaardlabel. |
+| [createBlueSquare(String label)](#createBlueSquare-java.lang.String-) | \* Maakt een nieuw notitie‑tag met BlueSquare pictogram en opgegeven label. |
+| [createBlueStar()](#createBlueStar--) | \* Maakt een nieuw notitie‑tag met BlueStar pictogram en standaardlabel. |
+| [createBlueStar(String label)](#createBlueStar-java.lang.String-) | \* Maakt een nieuw notitie‑tag met BlueStar pictogram en opgegeven label. |
+| [createBlueSun()](#createBlueSun--) | \* Maakt een nieuw notitie‑tag met BlueSun pictogram en standaardlabel. |
+| [createBlueSun(String label)](#createBlueSun-java.lang.String-) | \* Maakt een nieuw notitie‑tag met BlueSun pictogram en opgegeven label. |
+| [createBlueTarget()](#createBlueTarget--) | \* Maakt een nieuw notitie‑tag met BlueTarget pictogram en standaardlabel. |
+| [createBlueTarget(String label)](#createBlueTarget-java.lang.String-) | \* Maakt een nieuw notitie‑tag met BlueTarget pictogram en opgegeven label. |
+| [createBlueTriangle()](#createBlueTriangle--) | \* Maakt een nieuw notitie‑tag met BlueTriangle pictogram en standaardlabel. |
+| [createBlueTriangle(String label)](#createBlueTriangle-java.lang.String-) | \* Maakt een nieuw notitie‑tag met BlueTriangle pictogram en opgegeven label. |
+| [createBlueUmbrella()](#createBlueUmbrella--) | \* Maakt een nieuw notitie‑tag met BlueUmbrella pictogram en standaardlabel. |
+| [createBlueUmbrella(String label)](#createBlueUmbrella-java.lang.String-) | \* Maakt een nieuw notitie‑tag met BlueUmbrella pictogram en opgegeven label. |
+| [createBlueUpArrow()](#createBlueUpArrow--) | \* Maakt een nieuw notitie‑tag met BlueUpArrow pictogram en standaardlabel. |
+| [createBlueUpArrow(String label)](#createBlueUpArrow-java.lang.String-) | \* Maakt een nieuw notitie‑tag met BlueUpArrow pictogram en opgegeven label. |
+| [createBlueXNo()](#createBlueXNo--) | \* Maakt een nieuw notitie‑tag met BlueXNo pictogram en standaardlabel. |
+| [createBlueXNo(String label)](#createBlueXNo-java.lang.String-) | \* Maakt een nieuw notitie‑tag met BlueXNo pictogram en opgegeven label. |
+| [createBlueXWithDots()](#createBlueXWithDots--) | \* Maakt een nieuw notitie‑tag met BlueXWithDots pictogram en standaardlabel. |
+| [createBlueXWithDots(String label)](#createBlueXWithDots-java.lang.String-) | \* Maakt een nieuw notitie‑tag met BlueXWithDots pictogram en opgegeven label. |
+| [createCalendarDateWithClock()](#createCalendarDateWithClock--) | \* Maakt een nieuw notitietag met CalendarDateWithClock pictogram en standaardlabel. |
+| [createCalendarDateWithClock(String label)](#createCalendarDateWithClock-java.lang.String-) | \* Maakt een nieuw notitietag met CalendarDateWithClock pictogram en opgegeven label. |
+| [createCar()](#createCar--) | \* Maakt een nieuw notitietag met Car pictogram en standaardlabel. |
+| [createCar(String label)](#createCar-java.lang.String-) | \* Maakt een nieuw notitietag met Car pictogram en opgegeven label. |
+| [createClosedEnvelope()](#createClosedEnvelope--) | \* Maakt een nieuw notitietag met ClosedEnvelope pictogram en standaardlabel. |
+| [createClosedEnvelope(String label)](#createClosedEnvelope-java.lang.String-) | \* Maakt een nieuw notitietag met ClosedEnvelope pictogram en opgegeven label. |
+| [createCloud()](#createCloud--) | \* Maakt een nieuw notitietag met Cloud pictogram en standaardlabel. |
+| [createCloud(String label)](#createCloud-java.lang.String-) | \* Maakt een nieuw notitietag met Cloud pictogram en opgegeven label. |
+| [createCoinsWithWindowBackdrop()](#createCoinsWithWindowBackdrop--) | \* Maakt een nieuw notitietag met CoinsWithWindowBackdrop pictogram en standaardlabel. |
+| [createCoinsWithWindowBackdrop(String label)](#createCoinsWithWindowBackdrop-java.lang.String-) | \* Maakt een nieuw notitietag met CoinsWithWindowBackdrop pictogram en opgegeven label. |
+| [createCommentBubble()](#createCommentBubble--) | \* Maakt een nieuw notitietag met CommentBubble pictogram en standaardlabel. |
+| [createCommentBubble(String label)](#createCommentBubble-java.lang.String-) | \* Maakt een nieuw notitietag met CommentBubble pictogram en opgegeven label. |
+| [createContactInformation()](#createContactInformation--) | \* Maakt een nieuw notitietag met ContactInformation pictogram en standaardlabel. |
+| [createContactInformation(String label)](#createContactInformation-java.lang.String-) | \* Maakt een nieuw notitietag met ContactInformation pictogram en opgegeven label. |
+| [createContactPersonOnCard()](#createContactPersonOnCard--) | \* Maakt een nieuw notitietag met ContactPersonOnCard pictogram en standaardlabel. |
+| [createContactPersonOnCard(String label)](#createContactPersonOnCard-java.lang.String-) | \* Maakt een nieuw notitietag met ContactPersonOnCard pictogram en opgegeven label. |
+| [createDollarSign()](#createDollarSign--) | \* Maakt een nieuw notitietag met DollarSign pictogram en standaardlabel. |
+| [createDollarSign(String label)](#createDollarSign-java.lang.String-) | \* Maakt een nieuw notitietag met DollarSign pictogram en opgegeven label. |
+| [createEMailMessage()](#createEMailMessage--) | \* Maakt een nieuw notitietag met EMailMessage pictogram en standaardlabel. |
+| [createEMailMessage(String label)](#createEMailMessage-java.lang.String-) | \* Maakt een nieuw notitietag met EMailMessage pictogram en opgegeven label. |
+| [createFrowningFace()](#createFrowningFace--) | \* Maakt een nieuw notitietag met FrowningFace pictogram en standaardlabel. |
+| [createFrowningFace(String label)](#createFrowningFace-java.lang.String-) | \* Maakt een nieuw notitietag met FrowningFace pictogram en opgegeven label. |
+| [createGlobe()](#createGlobe--) | \* Maakt een nieuw notitietag met Globe pictogram en standaardlabel. |
+| [createGlobe(String label)](#createGlobe-java.lang.String-) | \* Maakt een nieuw notitietag met Globe pictogram en opgegeven label. |
+| [createGreenCheckMark()](#createGreenCheckMark--) | \* Maakt een nieuw notitietag met GreenCheckMark pictogram en standaardlabel. |
+| [createGreenCheckMark(String label)](#createGreenCheckMark-java.lang.String-) | \* Maakt een nieuw notitag met GreenCheckMark-pictogram en opgegeven label. |
+| [createGreenCircle()](#createGreenCircle--) | \* Maakt een nieuw notitag met GreenCircle-pictogram en standaardlabel. |
+| [createGreenCircle(String label)](#createGreenCircle-java.lang.String-) | \* Maakt een nieuw notitag met GreenCircle-pictogram en opgegeven label. |
+| [createGreenCircle1()](#createGreenCircle1--) | \* Maakt een nieuw notitag met GreenCircle1-pictogram en standaardlabel. |
+| [createGreenCircle1(String label)](#createGreenCircle1-java.lang.String-) | \* Maakt een nieuw notitag met GreenCircle1-pictogram en opgegeven label. |
+| [createGreenCircle2()](#createGreenCircle2--) | \* Maakt een nieuw notitag met GreenCircle2-pictogram en standaardlabel. |
+| [createGreenCircle2(String label)](#createGreenCircle2-java.lang.String-) | \* Maakt een nieuw notitag met GreenCircle2-pictogram en opgegeven label. |
+| [createGreenCircle3()](#createGreenCircle3--) | \* Maakt een nieuw notitag met GreenCircle3-pictogram en standaardlabel. |
+| [createGreenCircle3(String label)](#createGreenCircle3-java.lang.String-) | \* Maakt een nieuw notitag met GreenCircle3-pictogram en opgegeven label. |
+| [createGreenDownArrow()](#createGreenDownArrow--) | \* Maakt een nieuw notitag met GreenDownArrow-pictogram en standaardlabel. |
+| [createGreenDownArrow(String label)](#createGreenDownArrow-java.lang.String-) | \* Maakt een nieuw notitag met GreenDownArrow-pictogram en opgegeven label. |
+| [createGreenEightPointStar()](#createGreenEightPointStar--) | \* Maakt een nieuw notitag met GreenEightPointStar-pictogram en standaardlabel. |
+| [createGreenEightPointStar(String label)](#createGreenEightPointStar-java.lang.String-) | \* Maakt een nieuw notitag met GreenEightPointStar-pictogram en opgegeven label. |
+| [createGreenLeftArrow()](#createGreenLeftArrow--) | \* Maakt een nieuw notitag met GreenLeftArrow-pictogram en standaardlabel. |
+| [createGreenLeftArrow(String label)](#createGreenLeftArrow-java.lang.String-) | \* Maakt een nieuw notitag met GreenLeftArrow-pictogram en opgegeven label. |
+| [createGreenRightArrow()](#createGreenRightArrow--) | \* Maakt een nieuw notitag met GreenRightArrow-pictogram en standaardlabel. |
+| [createGreenRightArrow(String label)](#createGreenRightArrow-java.lang.String-) | \* Maakt een nieuw notitag met GreenRightArrow-pictogram en opgegeven label. |
+| [createGreenSolidArrow()](#createGreenSolidArrow--) | \* Maakt een nieuw notitag met GreenSolidArrow-pictogram en standaardlabel. |
+| [createGreenSolidArrow(String label)](#createGreenSolidArrow-java.lang.String-) | \* Maakt een nieuw notitag met GreenSolidArrow-pictogram en opgegeven label. |
+| [createGreenSquare()](#createGreenSquare--) | \* Maakt een nieuw notitag met GreenSquare-pictogram en standaardlabel. |
+| [createGreenSquare(String label)](#createGreenSquare-java.lang.String-) | \* Maakt een nieuw notitag met GreenSquare-pictogram en opgegeven label. |
+| [createGreenStar()](#createGreenStar--) | \* Maakt een nieuw notitag met GreenStar-pictogram en standaardlabel. |
+| [createGreenStar(String label)](#createGreenStar-java.lang.String-) | \* Maakt een nieuw notitag met GreenStar-pictogram en opgegeven label. |
+| [createGreenSun()](#createGreenSun--) | \* Maakt een nieuw notitag met GreenSun-pictogram en standaardlabel. |
+| [createGreenSun(String label)](#createGreenSun-java.lang.String-) | \* Maakt een nieuw notitag met GreenSun-pictogram en opgegeven label. |
+| [createGreenTarget()](#createGreenTarget--) | * Maakt een nieuw notitie-tag met GreenTarget-pictogram en standaardlabel. |
+| [createGreenTarget(String label)](#createGreenTarget-java.lang.String-) | * Maakt een nieuw notitie-tag met GreenTarget-pictogram en gespecificeerd label. |
+| [createGreenTriangle()](#createGreenTriangle--) | * Maakt een nieuw notitie-tag met GreenTriangle-pictogram en standaardlabel. |
+| [createGreenTriangle(String label)](#createGreenTriangle-java.lang.String-) | * Maakt een nieuw notitie-tag met GreenTriangle-pictogram en gespecificeerd label. |
+| [createGreenUmbrella()](#createGreenUmbrella--) | * Maakt een nieuw notitie-tag met GreenUmbrella-pictogram en standaardlabel. |
+| [createGreenUmbrella(String label)](#createGreenUmbrella-java.lang.String-) | * Maakt een nieuw notitie-tag met GreenUmbrella-pictogram en gespecificeerd label. |
+| [createGreenUpArrow()](#createGreenUpArrow--) | * Maakt een nieuw notitie-tag met GreenUpArrow-pictogram en standaardlabel. |
+| [createGreenUpArrow(String label)](#createGreenUpArrow-java.lang.String-) | * Maakt een nieuw notitie-tag met GreenUpArrow-pictogram en gespecificeerd label. |
+| [createGreenXNo()](#createGreenXNo--) | * Maakt een nieuw notitie-tag met GreenXNo-pictogram en standaardlabel. |
+| [createGreenXNo(String label)](#createGreenXNo-java.lang.String-) | * Maakt een nieuw notitie-tag met GreenXNo-pictogram en gespecificeerd label. |
+| [createGreenXWithDots()](#createGreenXWithDots--) | * Maakt een nieuw notitie-tag met GreenXWithDots-pictogram en standaardlabel. |
+| [createGreenXWithDots(String label)](#createGreenXWithDots-java.lang.String-) | * Maakt een nieuw notitie-tag met GreenXWithDots-pictogram en gespecificeerd label. |
+| [createHeart()](#createHeart--) | * Maakt een nieuw notitie-tag met Heart-pictogram en standaardlabel. |
+| [createHeart(String label)](#createHeart-java.lang.String-) | * Maakt een nieuw notitie-tag met Heart-pictogram en gespecificeerd label. |
+| [createHighPriority()](#createHighPriority--) | * Maakt een nieuw notitie-tag met HighPriority-pictogram en standaardlabel. |
+| [createHighPriority(String label)](#createHighPriority-java.lang.String-) | * Maakt een nieuw notitie-tag met HighPriority-pictogram en gespecificeerd label. |
+| [createHome()](#createHome--) | * Maakt een nieuw notitie-tag met Home-pictogram en standaardlabel. |
+| [createHome(String label)](#createHome-java.lang.String-) | * Maakt een nieuw notitie-tag met Home-pictogram en gespecificeerd label. |
+| [createHyperlinkGlobe()](#createHyperlinkGlobe--) | * Maakt een nieuw notitie-tag met HyperlinkGlobe-pictogram en standaardlabel. |
+| [createHyperlinkGlobe(String label)](#createHyperlinkGlobe-java.lang.String-) | * Maakt een nieuw notitie-tag met HyperlinkGlobe-pictogram en gespecificeerd label. |
+| [createInstantMessagingContactPerson()](#createInstantMessagingContactPerson--) | * Maakt een nieuw notitie-tag met InstantMessagingContactPerson-pictogram en standaardlabel. |
+| [createInstantMessagingContactPerson(String label)](#createInstantMessagingContactPerson-java.lang.String-) | * Maakt een nieuw notitie-tag met InstantMessagingContactPerson-pictogram en gespecificeerd label. |
+| [createLaptop()](#createLaptop--) | * Maakt een nieuw notitie-tag met Laptop-pictogram en standaardlabel. |
+| [createLaptop(String label)](#createLaptop-java.lang.String-) | * Maakt een nieuw notitie-tag met Laptop-pictogram en gespecificeerd label. |
+| [createLightBulb()](#createLightBulb--) | * Maakt een nieuw notitie-tag met LightBulb-pictogram en standaardlabel. |
+| [createLightBulb(String label)](#createLightBulb-java.lang.String-) | * Maakt een nieuw notitagetag met LightBulb-pictogram en opgegeven label. |
+| [createLightningBolt()](#createLightningBolt--) | * Maakt een nieuw notitagetag met LightningBolt-pictogram en standaardlabel. |
+| [createLightningBolt(String label)](#createLightningBolt-java.lang.String-) | * Maakt een nieuw notitagetag met LightningBolt-pictogram en opgegeven label. |
+| [createMeeting()](#createMeeting--) | * Maakt een nieuw notitagetag met Meeting-pictogram en standaardlabel. |
+| [createMeeting(String label)](#createMeeting-java.lang.String-) | * Maakt een nieuw notitagetag met Meeting-pictogram en opgegeven label. |
+| [createMobilePhone()](#createMobilePhone--) | * Maakt een nieuw notitagetag met MobilePhone-pictogram en standaardlabel. |
+| [createMobilePhone(String label)](#createMobilePhone-java.lang.String-) | * Maakt een nieuw notitagetag met MobilePhone-pictogram en opgegeven label. |
+| [createMovieClip()](#createMovieClip--) | * Maakt een nieuw notitagetag met MovieClip-pictogram en standaardlabel. |
+| [createMovieClip(String label)](#createMovieClip-java.lang.String-) | * Maakt een nieuw notitagetag met MovieClip-pictogram en opgegeven label. |
+| [createMusicalNote()](#createMusicalNote--) | * Maakt een nieuw notitagetag met MusicalNote-pictogram en standaardlabel. |
+| [createMusicalNote(String label)](#createMusicalNote-java.lang.String-) | * Maakt een nieuw notitagetag met MusicalNote-pictogram en opgegeven label. |
+| [createNoIcon()](#createNoIcon--) | * Maakt een nieuw notitagetag zonder pictogram en standaardlabel. |
+| [createNoIcon(String label)](#createNoIcon-java.lang.String-) | * Maakt een nieuw notitagetag zonder pictogram. |
+| [createNotebookWithClock()](#createNotebookWithClock--) | * Maakt een nieuw notitagetag met NotebookWithClock-pictogram en standaardlabel. |
+| [createNotebookWithClock(String label)](#createNotebookWithClock-java.lang.String-) | * Maakt een nieuw notitagetag met NotebookWithClock-pictogram en opgegeven label. |
+| [createOpenBook()](#createOpenBook--) | * Maakt een nieuw notitagetag met OpenBook-pictogram en standaardlabel. |
+| [createOpenBook(String label)](#createOpenBook-java.lang.String-) | * Maakt een nieuw notitagetag met OpenBook-pictogram en opgegeven label. |
+| [createOpenEnvelope()](#createOpenEnvelope--) | * Maakt een nieuw notitagetag met OpenEnvelope-pictogram en standaardlabel. |
+| [createOpenEnvelope(String label)](#createOpenEnvelope-java.lang.String-) | * Maakt een nieuw notitagetag met OpenEnvelope-pictogram en opgegeven label. |
+| [createOrangeSquare()](#createOrangeSquare--) | * Maakt een nieuw notitagetag met OrangeSquare-pictogram en standaardlabel. |
+| [createOrangeSquare(String label)](#createOrangeSquare-java.lang.String-) | * Maakt een nieuw notitagetag met OrangeSquare-pictogram en opgegeven label. |
+| [createPadlock()](#createPadlock--) | * Maakt een nieuw notitagetag met Padlock-pictogram en standaardlabel. |
+| [createPadlock(String label)](#createPadlock-java.lang.String-) | * Maakt een nieuw notitagetag met Padlock-pictogram en opgegeven label. |
+| [createPaperClip()](#createPaperClip--) | * Maakt een nieuw notitagetag met PaperClip-pictogram en standaardlabel. |
+| [createPaperClip(String label)](#createPaperClip-java.lang.String-) | * Maakt een nieuw notitagetag met PaperClip-pictogram en opgegeven label. |
+| [createPen()](#createPen--) | \* Maakt een nieuwe notitie-tag met Pen-pictogram en standaardlabel. |
+| [createPen(String label)](#createPen-java.lang.String-) | \* Maakt een nieuwe notitie-tag met Pen-pictogram en opgegeven label. |
+| [createPersonWithExclamationMark()](#createPersonWithExclamationMark--) | \* Maakt een nieuwe notitie-tag met PersonWithExclamationMark-pictogram en standaardlabel. |
+| [createPersonWithExclamationMark(String label)](#createPersonWithExclamationMark-java.lang.String-) | \* Maakt een nieuwe notitie-tag met PersonWithExclamationMark-pictogram en opgegeven label. |
+| [createPinkSquare()](#createPinkSquare--) | \* Maakt een nieuwe notitie-tag met PinkSquare-pictogram en standaardlabel. |
+| [createPinkSquare(String label)](#createPinkSquare-java.lang.String-) | \* Maakt een nieuwe notitie-tag met PinkSquare-pictogram en opgegeven label. |
+| [createPlane()](#createPlane--) | \* Maakt een nieuwe notitie-tag met Plane-pictogram en standaardlabel. |
+| [createPlane(String label)](#createPlane-java.lang.String-) | \* Maakt een nieuwe notitie-tag met Plane-pictogram en opgegeven label. |
+| [createPresentationSlide()](#createPresentationSlide--) | \* Maakt een nieuwe notitie-tag met PresentationSlide-pictogram en standaardlabel. |
+| [createPresentationSlide(String label)](#createPresentationSlide-java.lang.String-) | \* Maakt een nieuwe notitie-tag met PresentationSlide-pictogram en opgegeven label. |
+| [createPushpin()](#createPushpin--) | \* Maakt een nieuwe notitie-tag met Pushpin-pictogram en standaardlabel. |
+| [createPushpin(String label)](#createPushpin-java.lang.String-) | \* Maakt een nieuwe notitie-tag met Pushpin-pictogram en opgegeven label. |
+| [createQuestionBalloon()](#createQuestionBalloon--) | \* Maakt een nieuwe notitie-tag met QuestionBalloon-pictogram en standaardlabel. |
+| [createQuestionBalloon(String label)](#createQuestionBalloon-java.lang.String-) | \* Maakt een nieuwe notitie-tag met QuestionBalloon-pictogram en opgegeven label. |
+| [createQuestionMark()](#createQuestionMark--) | \* Maakt een nieuwe notitie-tag met QuestionMark-pictogram en standaardlabel. |
+| [createQuestionMark(String label)](#createQuestionMark-java.lang.String-) | \* Maakt een nieuwe notitie-tag met QuestionMark-pictogram en opgegeven label. |
+| [createQuotationMark()](#createQuotationMark--) | \* Maakt een nieuwe notitie-tag met QuotationMark-pictogram en standaardlabel. |
+| [createQuotationMark(String label)](#createQuotationMark-java.lang.String-) | \* Maakt een nieuwe notitie-tag met QuotationMark-pictogram en opgegeven label. |
+| [createRedSquare()](#createRedSquare--) | \* Maakt een nieuwe notitie-tag met RedSquare-pictogram en standaardlabel. |
+| [createRedSquare(String label)](#createRedSquare-java.lang.String-) | \* Maakt een nieuwe notitie-tag met RedSquare-pictogram en opgegeven label. |
+| [createReminderBell()](#createReminderBell--) | \* Maakt een nieuwe notitie-tag met ReminderBell-pictogram en standaardlabel. |
+| [createReminderBell(String label)](#createReminderBell-java.lang.String-) | \* Maakt een nieuwe notitie-tag met ReminderBell-pictogram en opgegeven label. |
+| [createResearch()](#createResearch--) | \* Maakt een nieuwe notitie-tag met Research-pictogram en standaardlabel. |
+| [createResearch(String label)](#createResearch-java.lang.String-) | \* Maakt een nieuwe notitie-tag met Research-pictogram en opgegeven label. |
+| [createRoseOnStem()](#createRoseOnStem--) | \* Maakt een nieuwe notitie-tag met RoseOnStem-pictogram en standaardlabel. |
+| [createRoseOnStem(String label)](#createRoseOnStem-java.lang.String-) | \* Maakt een nieuw notitie‑tag met RoseOnStem pictogram en opgegeven label. |
+| [createScheduledTask()](#createScheduledTask--) | \* Maakt een nieuw notitie‑tag met ScheduledTask pictogram en standaardlabel. |
+| [createScheduledTask(String label)](#createScheduledTask-java.lang.String-) | \* Maakt een nieuw notitie‑tag met ScheduledTask pictogram en opgegeven label. |
+| [createSmilingFace()](#createSmilingFace--) | \* Maakt een nieuw notitie‑tag met SmilingFace pictogram en standaardlabel. |
+| [createSmilingFace(String label)](#createSmilingFace-java.lang.String-) | \* Maakt een nieuw notitie‑tag met SmilingFace pictogram en opgegeven label. |
+| [createSunflower()](#createSunflower--) | \* Maakt een nieuw notitie‑tag met Sunflower pictogram en standaardlabel. |
+| [createSunflower(String label)](#createSunflower-java.lang.String-) | \* Maakt een nieuw notitie‑tag met Sunflower pictogram en opgegeven label. |
+| [createTelephoneWithClock()](#createTelephoneWithClock--) | \* Maakt een nieuw notitie‑tag met TelephoneWithClock pictogram en standaardlabel. |
+| [createTelephoneWithClock(String label)](#createTelephoneWithClock-java.lang.String-) | \* Maakt een nieuw notitie‑tag met TelephoneWithClock pictogram en opgegeven label. |
+| [createTimeSensitive()](#createTimeSensitive--) | \* Maakt een nieuw notitie‑tag met TimeSensitive pictogram en standaardlabel. |
+| [createTimeSensitive(String label)](#createTimeSensitive-java.lang.String-) | \* Maakt een nieuw notitie‑tag met TimeSensitive pictogram en opgegeven label. |
+| [createTwoPeople()](#createTwoPeople--) | \* Maakt een nieuw notitie‑tag met TwoPeople pictogram en standaardlabel. |
+| [createTwoPeople(String label)](#createTwoPeople-java.lang.String-) | \* Maakt een nieuw notitie‑tag met TwoPeople pictogram en opgegeven label. |
+| [createYellowCheckMark()](#createYellowCheckMark--) | \* Maakt een nieuw notitie‑tag met YellowCheckMark pictogram en standaardlabel. |
+| [createYellowCheckMark(String label)](#createYellowCheckMark-java.lang.String-) | \* Maakt een nieuw notitie‑tag met YellowCheckMark pictogram en opgegeven label. |
+| [createYellowCircle()](#createYellowCircle--) | \* Maakt een nieuw notitie‑tag met YellowCircle pictogram en standaardlabel. |
+| [createYellowCircle(String label)](#createYellowCircle-java.lang.String-) | \* Maakt een nieuw notitie‑tag met YellowCircle pictogram en opgegeven label. |
+| [createYellowCircle1()](#createYellowCircle1--) | \* Maakt een nieuw notitie‑tag met YellowCircle1 pictogram en standaardlabel. |
+| [createYellowCircle1(String label)](#createYellowCircle1-java.lang.String-) | \* Maakt een nieuw notitie‑tag met YellowCircle1 pictogram en opgegeven label. |
+| [createYellowCircle2()](#createYellowCircle2--) | \* Maakt een nieuw notitie‑tag met YellowCircle2 pictogram en standaardlabel. |
+| [createYellowCircle2(String label)](#createYellowCircle2-java.lang.String-) | \* Maakt een nieuw notitie‑tag met YellowCircle2 pictogram en opgegeven label. |
+| [createYellowCircle3()](#createYellowCircle3--) | \* Maakt een nieuw notitie‑tag met YellowCircle3 pictogram en standaardlabel. |
+| [createYellowCircle3(String label)](#createYellowCircle3-java.lang.String-) | \* Maakt een nieuw notitie‑tag met YellowCircle3 pictogram en opgegeven label. |
+| [createYellowDownArrow()](#createYellowDownArrow--) | \* Maakt een nieuw notitie‑tag met YellowDownArrow pictogram en standaardlabel. |
+| [createYellowDownArrow(String label)](#createYellowDownArrow-java.lang.String-) | \* Maakt een nieuw notitie‑tag met YellowDownArrow pictogram en opgegeven label. |
+| [createYellowEightPointStar()](#createYellowEightPointStar--) | \* Maakt een nieuwe notitie-tag met YellowEightPointStar pictogram en standaardlabel. |
+| [createYellowEightPointStar(String label)](#createYellowEightPointStar-java.lang.String-) | \* Maakt een nieuwe notitie-tag met YellowEightPointStar pictogram en opgegeven label. |
+| [createYellowKey()](#createYellowKey--) | \* Maakt een nieuwe notitie-tag met YellowKey pictogram en standaardlabel. |
+| [createYellowKey(String label)](#createYellowKey-java.lang.String-) | \* Maakt een nieuwe notitie-tag met YellowKey pictogram en opgegeven label. |
+| [createYellowLeftArrow()](#createYellowLeftArrow--) | \* Maakt een nieuwe notitie-tag met YellowLeftArrow pictogram en standaardlabel. |
+| [createYellowLeftArrow(String label)](#createYellowLeftArrow-java.lang.String-) | \* Maakt een nieuwe notitie-tag met YellowLeftArrow pictogram en opgegeven label. |
+| [createYellowRightArrow()](#createYellowRightArrow--) | \* Maakt een nieuwe notitie-tag met YellowRightArrow pictogram en standaardlabel. |
+| [createYellowRightArrow(String label)](#createYellowRightArrow-java.lang.String-) | \* Maakt een nieuwe notitie-tag met YellowRightArrow pictogram en opgegeven label. |
+| [createYellowSolidTarget()](#createYellowSolidTarget--) | \* Maakt een nieuwe notitie-tag met YellowSolidTarget pictogram en standaardlabel. |
+| [createYellowSolidTarget(String label)](#createYellowSolidTarget-java.lang.String-) | \* Maakt een nieuwe notitie-tag met YellowSolidTarget pictogram en opgegeven label. |
+| [createYellowSquare()](#createYellowSquare--) | \* Maakt een nieuwe notitie-tag met YellowSquare pictogram en standaardlabel. |
+| [createYellowSquare(String label)](#createYellowSquare-java.lang.String-) | \* Maakt een nieuwe notitie-tag met YellowSquare pictogram en opgegeven label. |
+| [createYellowStar()](#createYellowStar--) | \* Maakt een nieuwe notitie-tag met YellowStar pictogram en standaardlabel. |
+| [createYellowStar(String label)](#createYellowStar-java.lang.String-) | \* Maakt een nieuwe notitie-tag met YellowStar pictogram en opgegeven label. |
+| [createYellowSun()](#createYellowSun--) | \* Maakt een nieuwe notitie-tag met YellowSun pictogram en standaardlabel. |
+| [createYellowSun(String label)](#createYellowSun-java.lang.String-) | \* Maakt een nieuwe notitie-tag met YellowSun pictogram en opgegeven label. |
+| [createYellowTarget()](#createYellowTarget--) | \* Maakt een nieuwe notitie-tag met YellowTarget pictogram en standaardlabel. |
+| [createYellowTarget(String label)](#createYellowTarget-java.lang.String-) | \* Maakt een nieuwe notitie-tag met YellowTarget pictogram en opgegeven label. |
+| [createYellowTriangle()](#createYellowTriangle--) | \* Maakt een nieuwe notitie-tag met YellowTriangle pictogram en standaardlabel. |
+| [createYellowTriangle(String label)](#createYellowTriangle-java.lang.String-) | \* Maakt een nieuwe notitie-tag met YellowTriangle pictogram en opgegeven label. |
+| [createYellowUmbrella()](#createYellowUmbrella--) | \* Maakt een nieuwe notitie-tag met YellowUmbrella pictogram en standaardlabel. |
+| [createYellowUmbrella(String label)](#createYellowUmbrella-java.lang.String-) | \* Maakt een nieuwe notitie-tag met YellowUmbrella pictogram en opgegeven label. |
+| [createYellowUpArrow()](#createYellowUpArrow--) | \* Maakt een nieuwe notitie-tag met YellowUpArrow pictogram en standaardlabel. |
+| [createYellowUpArrow(String label)](#createYellowUpArrow-java.lang.String-) | \* Maakt een nieuwe notitie-tag met YellowUpArrow pictogram en opgegeven label. |
+| [createYellowX()](#createYellowX--) | \* Maakt een nieuwe notitie-tag met YellowX pictogram en standaardlabel. |
+| [createYellowX(String label)](#createYellowX-java.lang.String-) | * Maakt een nieuw notitie-tag met YellowX-pictogram en opgegeven label. |
+| [createYellowXWithDots()](#createYellowXWithDots--) | * Maakt een nieuw notitie-tag met YellowXWithDots-pictogram en standaardlabel. |
+| [createYellowXWithDots(String label)](#createYellowXWithDots-java.lang.String-) | * Maakt een nieuw notitie-tag met YellowXWithDots-pictogram en opgegeven label. |
+| [equals(NoteTag other)](#equals-com.aspose.note.NoteTag-) | Bepaalt of het opgegeven object gelijk is aan het huidige object. |
+| [equals(Object obj)](#equals-java.lang.Object-) | Bepaalt of het opgegeven object gelijk is aan het huidige object. |
+| [getCompletedTime()](#getCompletedTime--) | Haalt het voltooid tijdstip op of stelt het in. |
+| [getCreationTime()](#getCreationTime--) | Haalt het aanmaaktijdstip op of stelt het in. |
+| [getFontColor()](#getFontColor--) | Haalt de letterkleur op of stelt deze in. |
+| [getHighlight()](#getHighlight--) | Haalt de markeerkleur op of stelt deze in. |
+| [getIcon()](#getIcon--) | Haalt het pictogram op of stelt dit in. |
+| [getLabel()](#getLabel--) | Haalt de labeltekst op. |
+| [getStatus()](#getStatus--) | Haalt de status op of stelt deze in. |
+| [hashCode()](#hashCode--) | Dient als een hash-functie voor het type. |
+| [setCreationTime(Date value)](#setCreationTime-java.util.Date-) | Haalt het aanmaaktijdstip op of stelt het in. |
+| [setFontColor(Color value)](#setFontColor-java.awt.Color-) | Haalt de letterkleur op of stelt deze in. |
+| [setHighlight(Color value)](#setHighlight-java.awt.Color-) | Haalt de markeerkleur op of stelt deze in. |
+| [setIcon(int value)](#setIcon-int-) | Haalt het pictogram op of stelt dit in. |
+| [setLabel(String value)](#setLabel-java.lang.String-) | Stelt de labeltekst in. |
+### NoteTag() {#NoteTag--}
+```
+public NoteTag()
+```
+
+
+Initialiseert een nieuw exemplaar van de [NoteTag](../../com.aspose.note/notetag) klasse zonder pictogram.
+
+### createAwardRibbon() {#createAwardRibbon--}
+```
+public static NoteTag createAwardRibbon()
+```
+
+
+\* Maakt een nieuw notitie‑tag met het AwardRibbon‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createAwardRibbon(String label) {#createAwardRibbon-java.lang.String-}
+```
+public static NoteTag createAwardRibbon(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met het AwardRibbon‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBinoculars() {#createBinoculars--}
+```
+public static NoteTag createBinoculars()
+```
+
+
+\* Maakt een nieuw notitie‑tag met het Binoculars‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBinoculars(String label) {#createBinoculars-java.lang.String-}
+```
+public static NoteTag createBinoculars(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met het Binoculars‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlankPaperWithLines() {#createBlankPaperWithLines--}
+```
+public static NoteTag createBlankPaperWithLines()
+```
+
+
+\* Maakt een nieuw notitie‑tag met het BlankPaperWithLines‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlankPaperWithLines(String label) {#createBlankPaperWithLines-java.lang.String-}
+```
+public static NoteTag createBlankPaperWithLines(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met het BlankPaperWithLines‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCheckMark() {#createBlueCheckMark--}
+```
+public static NoteTag createBlueCheckMark()
+```
+
+
+\* Maakt een nieuw notitie‑tag met het BlueCheckMark‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCheckMark(String label) {#createBlueCheckMark-java.lang.String-}
+```
+public static NoteTag createBlueCheckMark(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met het BlueCheckMark‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle() {#createBlueCircle--}
+```
+public static NoteTag createBlueCircle()
+```
+
+
+\* Maakt een nieuw notitie‑tag met het BlueCircle‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle(String label) {#createBlueCircle-java.lang.String-}
+```
+public static NoteTag createBlueCircle(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met het BlueCircle‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle1() {#createBlueCircle1--}
+```
+public static NoteTag createBlueCircle1()
+```
+
+
+\* Maakt een nieuw notitie‑tag met het BlueCircle1‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle1(String label) {#createBlueCircle1-java.lang.String-}
+```
+public static NoteTag createBlueCircle1(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met het BlueCircle1‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle2() {#createBlueCircle2--}
+```
+public static NoteTag createBlueCircle2()
+```
+
+
+\* Maakt een nieuw notitie‑tag met het BlueCircle2‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle2(String label) {#createBlueCircle2-java.lang.String-}
+```
+public static NoteTag createBlueCircle2(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met het BlueCircle2‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle3() {#createBlueCircle3--}
+```
+public static NoteTag createBlueCircle3()
+```
+
+
+\* Maakt een nieuw notitie‑tag met het BlueCircle3‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueCircle3(String label) {#createBlueCircle3-java.lang.String-}
+```
+public static NoteTag createBlueCircle3(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met het BlueCircle3‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueDownArrow() {#createBlueDownArrow--}
+```
+public static NoteTag createBlueDownArrow()
+```
+
+
+\* Maakt een nieuw notitie‑tag met het BlueDownArrow‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueDownArrow(String label) {#createBlueDownArrow-java.lang.String-}
+```
+public static NoteTag createBlueDownArrow(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met het BlueDownArrow‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueEightPointStar() {#createBlueEightPointStar--}
+```
+public static NoteTag createBlueEightPointStar()
+```
+
+
+\* Maakt een nieuw notitie‑tag met het BlueEightPointStar‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueEightPointStar(String label) {#createBlueEightPointStar-java.lang.String-}
+```
+public static NoteTag createBlueEightPointStar(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met het BlueEightPointStar‑pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueFollowUpFlag() {#createBlueFollowUpFlag--}
+```
+public static NoteTag createBlueFollowUpFlag()
+```
+
+
+\* Maakt een nieuw notitie‑tag met het BlueFollowUpFlag‑pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueFollowUpFlag(String label) {#createBlueFollowUpFlag-java.lang.String-}
+```
+public static NoteTag createBlueFollowUpFlag(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueFollowUpFlag pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueLeftArrow() {#createBlueLeftArrow--}
+```
+public static NoteTag createBlueLeftArrow()
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueLeftArrow pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueLeftArrow(String label) {#createBlueLeftArrow-java.lang.String-}
+```
+public static NoteTag createBlueLeftArrow(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueLeftArrow pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueRightArrow() {#createBlueRightArrow--}
+```
+public static NoteTag createBlueRightArrow()
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueRightArrow pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueRightArrow(String label) {#createBlueRightArrow-java.lang.String-}
+```
+public static NoteTag createBlueRightArrow(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueRightArrow pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueSolidTarget() {#createBlueSolidTarget--}
+```
+public static NoteTag createBlueSolidTarget()
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueSolidTarget pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueSolidTarget(String label) {#createBlueSolidTarget-java.lang.String-}
+```
+public static NoteTag createBlueSolidTarget(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueSolidTarget pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueSquare() {#createBlueSquare--}
+```
+public static NoteTag createBlueSquare()
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueSquare pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueSquare(String label) {#createBlueSquare-java.lang.String-}
+```
+public static NoteTag createBlueSquare(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueSquare pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueStar() {#createBlueStar--}
+```
+public static NoteTag createBlueStar()
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueStar pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueStar(String label) {#createBlueStar-java.lang.String-}
+```
+public static NoteTag createBlueStar(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueStar pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueSun() {#createBlueSun--}
+```
+public static NoteTag createBlueSun()
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueSun pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueSun(String label) {#createBlueSun-java.lang.String-}
+```
+public static NoteTag createBlueSun(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueSun pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueTarget() {#createBlueTarget--}
+```
+public static NoteTag createBlueTarget()
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueTarget pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueTarget(String label) {#createBlueTarget-java.lang.String-}
+```
+public static NoteTag createBlueTarget(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueTarget pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueTriangle() {#createBlueTriangle--}
+```
+public static NoteTag createBlueTriangle()
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueTriangle pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueTriangle(String label) {#createBlueTriangle-java.lang.String-}
+```
+public static NoteTag createBlueTriangle(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueTriangle pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueUmbrella() {#createBlueUmbrella--}
+```
+public static NoteTag createBlueUmbrella()
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueUmbrella pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueUmbrella(String label) {#createBlueUmbrella-java.lang.String-}
+```
+public static NoteTag createBlueUmbrella(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueUmbrella pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueUpArrow() {#createBlueUpArrow--}
+```
+public static NoteTag createBlueUpArrow()
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueUpArrow pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueUpArrow(String label) {#createBlueUpArrow-java.lang.String-}
+```
+public static NoteTag createBlueUpArrow(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueUpArrow pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueXNo() {#createBlueXNo--}
+```
+public static NoteTag createBlueXNo()
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueXNo pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueXNo(String label) {#createBlueXNo-java.lang.String-}
+```
+public static NoteTag createBlueXNo(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueXNo pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueXWithDots() {#createBlueXWithDots--}
+```
+public static NoteTag createBlueXWithDots()
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueXWithDots pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createBlueXWithDots(String label) {#createBlueXWithDots-java.lang.String-}
+```
+public static NoteTag createBlueXWithDots(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met BlueXWithDots pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCalendarDateWithClock() {#createCalendarDateWithClock--}
+```
+public static NoteTag createCalendarDateWithClock()
+```
+
+
+\* Maakt een nieuw notitietag met CalendarDateWithClock pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCalendarDateWithClock(String label) {#createCalendarDateWithClock-java.lang.String-}
+```
+public static NoteTag createCalendarDateWithClock(String label)
+```
+
+
+\* Maakt een nieuw notitietag met CalendarDateWithClock pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCar() {#createCar--}
+```
+public static NoteTag createCar()
+```
+
+
+\* Maakt een nieuw notitietag met Car pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCar(String label) {#createCar-java.lang.String-}
+```
+public static NoteTag createCar(String label)
+```
+
+
+\* Maakt een nieuw notitietag met Car pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createClosedEnvelope() {#createClosedEnvelope--}
+```
+public static NoteTag createClosedEnvelope()
+```
+
+
+\* Maakt een nieuw notitietag met ClosedEnvelope pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createClosedEnvelope(String label) {#createClosedEnvelope-java.lang.String-}
+```
+public static NoteTag createClosedEnvelope(String label)
+```
+
+
+\* Maakt een nieuw notitietag met ClosedEnvelope pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCloud() {#createCloud--}
+```
+public static NoteTag createCloud()
+```
+
+
+\* Maakt een nieuw notitietag met Cloud pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCloud(String label) {#createCloud-java.lang.String-}
+```
+public static NoteTag createCloud(String label)
+```
+
+
+\* Maakt een nieuw notitietag met Cloud pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCoinsWithWindowBackdrop() {#createCoinsWithWindowBackdrop--}
+```
+public static NoteTag createCoinsWithWindowBackdrop()
+```
+
+
+\* Maakt een nieuw notitietag met CoinsWithWindowBackdrop pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCoinsWithWindowBackdrop(String label) {#createCoinsWithWindowBackdrop-java.lang.String-}
+```
+public static NoteTag createCoinsWithWindowBackdrop(String label)
+```
+
+
+\* Maakt een nieuw notitietag met CoinsWithWindowBackdrop pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCommentBubble() {#createCommentBubble--}
+```
+public static NoteTag createCommentBubble()
+```
+
+
+\* Maakt een nieuw notitietag met CommentBubble pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createCommentBubble(String label) {#createCommentBubble-java.lang.String-}
+```
+public static NoteTag createCommentBubble(String label)
+```
+
+
+\* Maakt een nieuw notitietag met CommentBubble pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createContactInformation() {#createContactInformation--}
+```
+public static NoteTag createContactInformation()
+```
+
+
+\* Maakt een nieuw notitietag met ContactInformation pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createContactInformation(String label) {#createContactInformation-java.lang.String-}
+```
+public static NoteTag createContactInformation(String label)
+```
+
+
+\* Maakt een nieuw notitietag met ContactInformation pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createContactPersonOnCard() {#createContactPersonOnCard--}
+```
+public static NoteTag createContactPersonOnCard()
+```
+
+
+\* Maakt een nieuw notitietag met ContactPersonOnCard pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createContactPersonOnCard(String label) {#createContactPersonOnCard-java.lang.String-}
+```
+public static NoteTag createContactPersonOnCard(String label)
+```
+
+
+\* Maakt een nieuw notitietag met ContactPersonOnCard pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createDollarSign() {#createDollarSign--}
+```
+public static NoteTag createDollarSign()
+```
+
+
+\* Maakt een nieuw notitietag met DollarSign pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createDollarSign(String label) {#createDollarSign-java.lang.String-}
+```
+public static NoteTag createDollarSign(String label)
+```
+
+
+\* Maakt een nieuw notitietag met DollarSign pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createEMailMessage() {#createEMailMessage--}
+```
+public static NoteTag createEMailMessage()
+```
+
+
+\* Maakt een nieuw notitietag met EMailMessage pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createEMailMessage(String label) {#createEMailMessage-java.lang.String-}
+```
+public static NoteTag createEMailMessage(String label)
+```
+
+
+\* Maakt een nieuw notitietag met EMailMessage pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createFrowningFace() {#createFrowningFace--}
+```
+public static NoteTag createFrowningFace()
+```
+
+
+\* Maakt een nieuw notitietag met FrowningFace pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createFrowningFace(String label) {#createFrowningFace-java.lang.String-}
+```
+public static NoteTag createFrowningFace(String label)
+```
+
+
+\* Maakt een nieuw notitietag met FrowningFace pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGlobe() {#createGlobe--}
+```
+public static NoteTag createGlobe()
+```
+
+
+\* Maakt een nieuw notitietag met Globe pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGlobe(String label) {#createGlobe-java.lang.String-}
+```
+public static NoteTag createGlobe(String label)
+```
+
+
+\* Maakt een nieuw notitietag met Globe pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCheckMark() {#createGreenCheckMark--}
+```
+public static NoteTag createGreenCheckMark()
+```
+
+
+\* Maakt een nieuw notitietag met GreenCheckMark pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCheckMark(String label) {#createGreenCheckMark-java.lang.String-}
+```
+public static NoteTag createGreenCheckMark(String label)
+```
+
+
+\* Maakt een nieuw notitag met GreenCheckMark-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle() {#createGreenCircle--}
+```
+public static NoteTag createGreenCircle()
+```
+
+
+\* Maakt een nieuw notitag met GreenCircle-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle(String label) {#createGreenCircle-java.lang.String-}
+```
+public static NoteTag createGreenCircle(String label)
+```
+
+
+\* Maakt een nieuw notitag met GreenCircle-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle1() {#createGreenCircle1--}
+```
+public static NoteTag createGreenCircle1()
+```
+
+
+\* Maakt een nieuw notitag met GreenCircle1-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle1(String label) {#createGreenCircle1-java.lang.String-}
+```
+public static NoteTag createGreenCircle1(String label)
+```
+
+
+\* Maakt een nieuw notitag met GreenCircle1-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle2() {#createGreenCircle2--}
+```
+public static NoteTag createGreenCircle2()
+```
+
+
+\* Maakt een nieuw notitag met GreenCircle2-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle2(String label) {#createGreenCircle2-java.lang.String-}
+```
+public static NoteTag createGreenCircle2(String label)
+```
+
+
+\* Maakt een nieuw notitag met GreenCircle2-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle3() {#createGreenCircle3--}
+```
+public static NoteTag createGreenCircle3()
+```
+
+
+\* Maakt een nieuw notitag met GreenCircle3-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenCircle3(String label) {#createGreenCircle3-java.lang.String-}
+```
+public static NoteTag createGreenCircle3(String label)
+```
+
+
+\* Maakt een nieuw notitag met GreenCircle3-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenDownArrow() {#createGreenDownArrow--}
+```
+public static NoteTag createGreenDownArrow()
+```
+
+
+\* Maakt een nieuw notitag met GreenDownArrow-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenDownArrow(String label) {#createGreenDownArrow-java.lang.String-}
+```
+public static NoteTag createGreenDownArrow(String label)
+```
+
+
+\* Maakt een nieuw notitag met GreenDownArrow-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenEightPointStar() {#createGreenEightPointStar--}
+```
+public static NoteTag createGreenEightPointStar()
+```
+
+
+\* Maakt een nieuw notitag met GreenEightPointStar-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenEightPointStar(String label) {#createGreenEightPointStar-java.lang.String-}
+```
+public static NoteTag createGreenEightPointStar(String label)
+```
+
+
+\* Maakt een nieuw notitag met GreenEightPointStar-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenLeftArrow() {#createGreenLeftArrow--}
+```
+public static NoteTag createGreenLeftArrow()
+```
+
+
+\* Maakt een nieuw notitag met GreenLeftArrow-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenLeftArrow(String label) {#createGreenLeftArrow-java.lang.String-}
+```
+public static NoteTag createGreenLeftArrow(String label)
+```
+
+
+\* Maakt een nieuw notitag met GreenLeftArrow-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenRightArrow() {#createGreenRightArrow--}
+```
+public static NoteTag createGreenRightArrow()
+```
+
+
+\* Maakt een nieuw notitag met GreenRightArrow-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenRightArrow(String label) {#createGreenRightArrow-java.lang.String-}
+```
+public static NoteTag createGreenRightArrow(String label)
+```
+
+
+\* Maakt een nieuw notitag met GreenRightArrow-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenSolidArrow() {#createGreenSolidArrow--}
+```
+public static NoteTag createGreenSolidArrow()
+```
+
+
+\* Maakt een nieuw notitag met GreenSolidArrow-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenSolidArrow(String label) {#createGreenSolidArrow-java.lang.String-}
+```
+public static NoteTag createGreenSolidArrow(String label)
+```
+
+
+\* Maakt een nieuw notitag met GreenSolidArrow-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenSquare() {#createGreenSquare--}
+```
+public static NoteTag createGreenSquare()
+```
+
+
+\* Maakt een nieuw notitag met GreenSquare-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenSquare(String label) {#createGreenSquare-java.lang.String-}
+```
+public static NoteTag createGreenSquare(String label)
+```
+
+
+\* Maakt een nieuw notitag met GreenSquare-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenStar() {#createGreenStar--}
+```
+public static NoteTag createGreenStar()
+```
+
+
+\* Maakt een nieuw notitag met GreenStar-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenStar(String label) {#createGreenStar-java.lang.String-}
+```
+public static NoteTag createGreenStar(String label)
+```
+
+
+\* Maakt een nieuw notitag met GreenStar-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenSun() {#createGreenSun--}
+```
+public static NoteTag createGreenSun()
+```
+
+
+\* Maakt een nieuw notitag met GreenSun-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenSun(String label) {#createGreenSun-java.lang.String-}
+```
+public static NoteTag createGreenSun(String label)
+```
+
+
+\* Maakt een nieuw notitag met GreenSun-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenTarget() {#createGreenTarget--}
+```
+public static NoteTag createGreenTarget()
+```
+
+
+* Maakt een nieuw notitie-tag met GreenTarget-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenTarget(String label) {#createGreenTarget-java.lang.String-}
+```
+public static NoteTag createGreenTarget(String label)
+```
+
+
+* Maakt een nieuw notitie-tag met GreenTarget-pictogram en gespecificeerd label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenTriangle() {#createGreenTriangle--}
+```
+public static NoteTag createGreenTriangle()
+```
+
+
+* Maakt een nieuw notitie-tag met GreenTriangle-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenTriangle(String label) {#createGreenTriangle-java.lang.String-}
+```
+public static NoteTag createGreenTriangle(String label)
+```
+
+
+* Maakt een nieuw notitie-tag met GreenTriangle-pictogram en gespecificeerd label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenUmbrella() {#createGreenUmbrella--}
+```
+public static NoteTag createGreenUmbrella()
+```
+
+
+* Maakt een nieuw notitie-tag met GreenUmbrella-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenUmbrella(String label) {#createGreenUmbrella-java.lang.String-}
+```
+public static NoteTag createGreenUmbrella(String label)
+```
+
+
+* Maakt een nieuw notitie-tag met GreenUmbrella-pictogram en gespecificeerd label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenUpArrow() {#createGreenUpArrow--}
+```
+public static NoteTag createGreenUpArrow()
+```
+
+
+* Maakt een nieuw notitie-tag met GreenUpArrow-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenUpArrow(String label) {#createGreenUpArrow-java.lang.String-}
+```
+public static NoteTag createGreenUpArrow(String label)
+```
+
+
+* Maakt een nieuw notitie-tag met GreenUpArrow-pictogram en gespecificeerd label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenXNo() {#createGreenXNo--}
+```
+public static NoteTag createGreenXNo()
+```
+
+
+* Maakt een nieuw notitie-tag met GreenXNo-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenXNo(String label) {#createGreenXNo-java.lang.String-}
+```
+public static NoteTag createGreenXNo(String label)
+```
+
+
+* Maakt een nieuw notitie-tag met GreenXNo-pictogram en gespecificeerd label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenXWithDots() {#createGreenXWithDots--}
+```
+public static NoteTag createGreenXWithDots()
+```
+
+
+* Maakt een nieuw notitie-tag met GreenXWithDots-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createGreenXWithDots(String label) {#createGreenXWithDots-java.lang.String-}
+```
+public static NoteTag createGreenXWithDots(String label)
+```
+
+
+* Maakt een nieuw notitie-tag met GreenXWithDots-pictogram en gespecificeerd label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHeart() {#createHeart--}
+```
+public static NoteTag createHeart()
+```
+
+
+* Maakt een nieuw notitie-tag met Heart-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHeart(String label) {#createHeart-java.lang.String-}
+```
+public static NoteTag createHeart(String label)
+```
+
+
+* Maakt een nieuw notitie-tag met Heart-pictogram en gespecificeerd label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHighPriority() {#createHighPriority--}
+```
+public static NoteTag createHighPriority()
+```
+
+
+* Maakt een nieuw notitie-tag met HighPriority-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHighPriority(String label) {#createHighPriority-java.lang.String-}
+```
+public static NoteTag createHighPriority(String label)
+```
+
+
+* Maakt een nieuw notitie-tag met HighPriority-pictogram en gespecificeerd label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHome() {#createHome--}
+```
+public static NoteTag createHome()
+```
+
+
+* Maakt een nieuw notitie-tag met Home-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHome(String label) {#createHome-java.lang.String-}
+```
+public static NoteTag createHome(String label)
+```
+
+
+* Maakt een nieuw notitie-tag met Home-pictogram en gespecificeerd label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHyperlinkGlobe() {#createHyperlinkGlobe--}
+```
+public static NoteTag createHyperlinkGlobe()
+```
+
+
+* Maakt een nieuw notitie-tag met HyperlinkGlobe-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createHyperlinkGlobe(String label) {#createHyperlinkGlobe-java.lang.String-}
+```
+public static NoteTag createHyperlinkGlobe(String label)
+```
+
+
+* Maakt een nieuw notitie-tag met HyperlinkGlobe-pictogram en gespecificeerd label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createInstantMessagingContactPerson() {#createInstantMessagingContactPerson--}
+```
+public static NoteTag createInstantMessagingContactPerson()
+```
+
+
+* Maakt een nieuw notitie-tag met InstantMessagingContactPerson-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createInstantMessagingContactPerson(String label) {#createInstantMessagingContactPerson-java.lang.String-}
+```
+public static NoteTag createInstantMessagingContactPerson(String label)
+```
+
+
+* Maakt een nieuw notitie-tag met InstantMessagingContactPerson-pictogram en gespecificeerd label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createLaptop() {#createLaptop--}
+```
+public static NoteTag createLaptop()
+```
+
+
+* Maakt een nieuw notitie-tag met Laptop-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createLaptop(String label) {#createLaptop-java.lang.String-}
+```
+public static NoteTag createLaptop(String label)
+```
+
+
+* Maakt een nieuw notitie-tag met Laptop-pictogram en gespecificeerd label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createLightBulb() {#createLightBulb--}
+```
+public static NoteTag createLightBulb()
+```
+
+
+* Maakt een nieuw notitie-tag met LightBulb-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createLightBulb(String label) {#createLightBulb-java.lang.String-}
+```
+public static NoteTag createLightBulb(String label)
+```
+
+
+* Maakt een nieuw notitagetag met LightBulb-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createLightningBolt() {#createLightningBolt--}
+```
+public static NoteTag createLightningBolt()
+```
+
+
+* Maakt een nieuw notitagetag met LightningBolt-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createLightningBolt(String label) {#createLightningBolt-java.lang.String-}
+```
+public static NoteTag createLightningBolt(String label)
+```
+
+
+* Maakt een nieuw notitagetag met LightningBolt-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMeeting() {#createMeeting--}
+```
+public static NoteTag createMeeting()
+```
+
+
+* Maakt een nieuw notitagetag met Meeting-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMeeting(String label) {#createMeeting-java.lang.String-}
+```
+public static NoteTag createMeeting(String label)
+```
+
+
+* Maakt een nieuw notitagetag met Meeting-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMobilePhone() {#createMobilePhone--}
+```
+public static NoteTag createMobilePhone()
+```
+
+
+* Maakt een nieuw notitagetag met MobilePhone-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMobilePhone(String label) {#createMobilePhone-java.lang.String-}
+```
+public static NoteTag createMobilePhone(String label)
+```
+
+
+* Maakt een nieuw notitagetag met MobilePhone-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMovieClip() {#createMovieClip--}
+```
+public static NoteTag createMovieClip()
+```
+
+
+* Maakt een nieuw notitagetag met MovieClip-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMovieClip(String label) {#createMovieClip-java.lang.String-}
+```
+public static NoteTag createMovieClip(String label)
+```
+
+
+* Maakt een nieuw notitagetag met MovieClip-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMusicalNote() {#createMusicalNote--}
+```
+public static NoteTag createMusicalNote()
+```
+
+
+* Maakt een nieuw notitagetag met MusicalNote-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createMusicalNote(String label) {#createMusicalNote-java.lang.String-}
+```
+public static NoteTag createMusicalNote(String label)
+```
+
+
+* Maakt een nieuw notitagetag met MusicalNote-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createNoIcon() {#createNoIcon--}
+```
+public static NoteTag createNoIcon()
+```
+
+
+* Maakt een nieuw notitagetag zonder pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createNoIcon(String label) {#createNoIcon-java.lang.String-}
+```
+public static NoteTag createNoIcon(String label)
+```
+
+
+* Maakt een nieuw notitie-tag zonder pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createNotebookWithClock() {#createNotebookWithClock--}
+```
+public static NoteTag createNotebookWithClock()
+```
+
+
+* Maakt een nieuw notitagetag met NotebookWithClock-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createNotebookWithClock(String label) {#createNotebookWithClock-java.lang.String-}
+```
+public static NoteTag createNotebookWithClock(String label)
+```
+
+
+* Maakt een nieuw notitagetag met NotebookWithClock-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createOpenBook() {#createOpenBook--}
+```
+public static NoteTag createOpenBook()
+```
+
+
+* Maakt een nieuw notitagetag met OpenBook-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createOpenBook(String label) {#createOpenBook-java.lang.String-}
+```
+public static NoteTag createOpenBook(String label)
+```
+
+
+* Maakt een nieuw notitagetag met OpenBook-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createOpenEnvelope() {#createOpenEnvelope--}
+```
+public static NoteTag createOpenEnvelope()
+```
+
+
+* Maakt een nieuw notitagetag met OpenEnvelope-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createOpenEnvelope(String label) {#createOpenEnvelope-java.lang.String-}
+```
+public static NoteTag createOpenEnvelope(String label)
+```
+
+
+* Maakt een nieuw notitagetag met OpenEnvelope-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createOrangeSquare() {#createOrangeSquare--}
+```
+public static NoteTag createOrangeSquare()
+```
+
+
+* Maakt een nieuw notitagetag met OrangeSquare-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createOrangeSquare(String label) {#createOrangeSquare-java.lang.String-}
+```
+public static NoteTag createOrangeSquare(String label)
+```
+
+
+* Maakt een nieuw notitagetag met OrangeSquare-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPadlock() {#createPadlock--}
+```
+public static NoteTag createPadlock()
+```
+
+
+* Maakt een nieuw notitagetag met Padlock-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPadlock(String label) {#createPadlock-java.lang.String-}
+```
+public static NoteTag createPadlock(String label)
+```
+
+
+* Maakt een nieuw notitagetag met Padlock-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPaperClip() {#createPaperClip--}
+```
+public static NoteTag createPaperClip()
+```
+
+
+* Maakt een nieuw notitagetag met PaperClip-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPaperClip(String label) {#createPaperClip-java.lang.String-}
+```
+public static NoteTag createPaperClip(String label)
+```
+
+
+* Maakt een nieuw notitagetag met PaperClip-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPen() {#createPen--}
+```
+public static NoteTag createPen()
+```
+
+
+\* Maakt een nieuwe notitie-tag met Pen-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPen(String label) {#createPen-java.lang.String-}
+```
+public static NoteTag createPen(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met Pen-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPersonWithExclamationMark() {#createPersonWithExclamationMark--}
+```
+public static NoteTag createPersonWithExclamationMark()
+```
+
+
+\* Maakt een nieuwe notitie-tag met PersonWithExclamationMark-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPersonWithExclamationMark(String label) {#createPersonWithExclamationMark-java.lang.String-}
+```
+public static NoteTag createPersonWithExclamationMark(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met PersonWithExclamationMark-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPinkSquare() {#createPinkSquare--}
+```
+public static NoteTag createPinkSquare()
+```
+
+
+\* Maakt een nieuwe notitie-tag met PinkSquare-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPinkSquare(String label) {#createPinkSquare-java.lang.String-}
+```
+public static NoteTag createPinkSquare(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met PinkSquare-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPlane() {#createPlane--}
+```
+public static NoteTag createPlane()
+```
+
+
+\* Maakt een nieuwe notitie-tag met Plane-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPlane(String label) {#createPlane-java.lang.String-}
+```
+public static NoteTag createPlane(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met Plane-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPresentationSlide() {#createPresentationSlide--}
+```
+public static NoteTag createPresentationSlide()
+```
+
+
+\* Maakt een nieuwe notitie-tag met PresentationSlide-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPresentationSlide(String label) {#createPresentationSlide-java.lang.String-}
+```
+public static NoteTag createPresentationSlide(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met PresentationSlide-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPushpin() {#createPushpin--}
+```
+public static NoteTag createPushpin()
+```
+
+
+\* Maakt een nieuwe notitie-tag met Pushpin-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createPushpin(String label) {#createPushpin-java.lang.String-}
+```
+public static NoteTag createPushpin(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met Pushpin-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createQuestionBalloon() {#createQuestionBalloon--}
+```
+public static NoteTag createQuestionBalloon()
+```
+
+
+\* Maakt een nieuwe notitie-tag met QuestionBalloon-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createQuestionBalloon(String label) {#createQuestionBalloon-java.lang.String-}
+```
+public static NoteTag createQuestionBalloon(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met QuestionBalloon-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createQuestionMark() {#createQuestionMark--}
+```
+public static NoteTag createQuestionMark()
+```
+
+
+\* Maakt een nieuwe notitie-tag met QuestionMark-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createQuestionMark(String label) {#createQuestionMark-java.lang.String-}
+```
+public static NoteTag createQuestionMark(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met QuestionMark-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createQuotationMark() {#createQuotationMark--}
+```
+public static NoteTag createQuotationMark()
+```
+
+
+\* Maakt een nieuwe notitie-tag met QuotationMark-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createQuotationMark(String label) {#createQuotationMark-java.lang.String-}
+```
+public static NoteTag createQuotationMark(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met QuotationMark-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createRedSquare() {#createRedSquare--}
+```
+public static NoteTag createRedSquare()
+```
+
+
+\* Maakt een nieuwe notitie-tag met RedSquare-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createRedSquare(String label) {#createRedSquare-java.lang.String-}
+```
+public static NoteTag createRedSquare(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met RedSquare-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createReminderBell() {#createReminderBell--}
+```
+public static NoteTag createReminderBell()
+```
+
+
+\* Maakt een nieuwe notitie-tag met ReminderBell-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createReminderBell(String label) {#createReminderBell-java.lang.String-}
+```
+public static NoteTag createReminderBell(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met ReminderBell-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createResearch() {#createResearch--}
+```
+public static NoteTag createResearch()
+```
+
+
+\* Maakt een nieuwe notitie-tag met Research-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createResearch(String label) {#createResearch-java.lang.String-}
+```
+public static NoteTag createResearch(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met Research-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createRoseOnStem() {#createRoseOnStem--}
+```
+public static NoteTag createRoseOnStem()
+```
+
+
+\* Maakt een nieuwe notitie-tag met RoseOnStem-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createRoseOnStem(String label) {#createRoseOnStem-java.lang.String-}
+```
+public static NoteTag createRoseOnStem(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met RoseOnStem pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createScheduledTask() {#createScheduledTask--}
+```
+public static NoteTag createScheduledTask()
+```
+
+
+\* Maakt een nieuw notitie‑tag met ScheduledTask pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createScheduledTask(String label) {#createScheduledTask-java.lang.String-}
+```
+public static NoteTag createScheduledTask(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met ScheduledTask pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createSmilingFace() {#createSmilingFace--}
+```
+public static NoteTag createSmilingFace()
+```
+
+
+\* Maakt een nieuw notitie‑tag met SmilingFace pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createSmilingFace(String label) {#createSmilingFace-java.lang.String-}
+```
+public static NoteTag createSmilingFace(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met SmilingFace pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createSunflower() {#createSunflower--}
+```
+public static NoteTag createSunflower()
+```
+
+
+\* Maakt een nieuw notitie‑tag met Sunflower pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createSunflower(String label) {#createSunflower-java.lang.String-}
+```
+public static NoteTag createSunflower(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met Sunflower pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createTelephoneWithClock() {#createTelephoneWithClock--}
+```
+public static NoteTag createTelephoneWithClock()
+```
+
+
+\* Maakt een nieuw notitie‑tag met TelephoneWithClock pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createTelephoneWithClock(String label) {#createTelephoneWithClock-java.lang.String-}
+```
+public static NoteTag createTelephoneWithClock(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met TelephoneWithClock pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createTimeSensitive() {#createTimeSensitive--}
+```
+public static NoteTag createTimeSensitive()
+```
+
+
+\* Maakt een nieuw notitie‑tag met TimeSensitive pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createTimeSensitive(String label) {#createTimeSensitive-java.lang.String-}
+```
+public static NoteTag createTimeSensitive(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met TimeSensitive pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createTwoPeople() {#createTwoPeople--}
+```
+public static NoteTag createTwoPeople()
+```
+
+
+\* Maakt een nieuw notitie‑tag met TwoPeople pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createTwoPeople(String label) {#createTwoPeople-java.lang.String-}
+```
+public static NoteTag createTwoPeople(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met TwoPeople pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCheckMark() {#createYellowCheckMark--}
+```
+public static NoteTag createYellowCheckMark()
+```
+
+
+\* Maakt een nieuw notitie‑tag met YellowCheckMark pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCheckMark(String label) {#createYellowCheckMark-java.lang.String-}
+```
+public static NoteTag createYellowCheckMark(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met YellowCheckMark pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle() {#createYellowCircle--}
+```
+public static NoteTag createYellowCircle()
+```
+
+
+\* Maakt een nieuw notitie‑tag met YellowCircle pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle(String label) {#createYellowCircle-java.lang.String-}
+```
+public static NoteTag createYellowCircle(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met YellowCircle pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle1() {#createYellowCircle1--}
+```
+public static NoteTag createYellowCircle1()
+```
+
+
+\* Maakt een nieuw notitie‑tag met YellowCircle1 pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle1(String label) {#createYellowCircle1-java.lang.String-}
+```
+public static NoteTag createYellowCircle1(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met YellowCircle1 pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle2() {#createYellowCircle2--}
+```
+public static NoteTag createYellowCircle2()
+```
+
+
+\* Maakt een nieuw notitie‑tag met YellowCircle2 pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle2(String label) {#createYellowCircle2-java.lang.String-}
+```
+public static NoteTag createYellowCircle2(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met YellowCircle2 pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle3() {#createYellowCircle3--}
+```
+public static NoteTag createYellowCircle3()
+```
+
+
+\* Maakt een nieuw notitie‑tag met YellowCircle3 pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowCircle3(String label) {#createYellowCircle3-java.lang.String-}
+```
+public static NoteTag createYellowCircle3(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met YellowCircle3 pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowDownArrow() {#createYellowDownArrow--}
+```
+public static NoteTag createYellowDownArrow()
+```
+
+
+\* Maakt een nieuw notitie‑tag met YellowDownArrow pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowDownArrow(String label) {#createYellowDownArrow-java.lang.String-}
+```
+public static NoteTag createYellowDownArrow(String label)
+```
+
+
+\* Maakt een nieuw notitie‑tag met YellowDownArrow pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowEightPointStar() {#createYellowEightPointStar--}
+```
+public static NoteTag createYellowEightPointStar()
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowEightPointStar pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowEightPointStar(String label) {#createYellowEightPointStar-java.lang.String-}
+```
+public static NoteTag createYellowEightPointStar(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowEightPointStar pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowKey() {#createYellowKey--}
+```
+public static NoteTag createYellowKey()
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowKey pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowKey(String label) {#createYellowKey-java.lang.String-}
+```
+public static NoteTag createYellowKey(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowKey pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowLeftArrow() {#createYellowLeftArrow--}
+```
+public static NoteTag createYellowLeftArrow()
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowLeftArrow pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowLeftArrow(String label) {#createYellowLeftArrow-java.lang.String-}
+```
+public static NoteTag createYellowLeftArrow(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowLeftArrow pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowRightArrow() {#createYellowRightArrow--}
+```
+public static NoteTag createYellowRightArrow()
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowRightArrow pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowRightArrow(String label) {#createYellowRightArrow-java.lang.String-}
+```
+public static NoteTag createYellowRightArrow(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowRightArrow pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowSolidTarget() {#createYellowSolidTarget--}
+```
+public static NoteTag createYellowSolidTarget()
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowSolidTarget pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowSolidTarget(String label) {#createYellowSolidTarget-java.lang.String-}
+```
+public static NoteTag createYellowSolidTarget(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowSolidTarget pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowSquare() {#createYellowSquare--}
+```
+public static NoteTag createYellowSquare()
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowSquare pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowSquare(String label) {#createYellowSquare-java.lang.String-}
+```
+public static NoteTag createYellowSquare(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowSquare pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowStar() {#createYellowStar--}
+```
+public static NoteTag createYellowStar()
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowStar pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowStar(String label) {#createYellowStar-java.lang.String-}
+```
+public static NoteTag createYellowStar(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowStar pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowSun() {#createYellowSun--}
+```
+public static NoteTag createYellowSun()
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowSun pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowSun(String label) {#createYellowSun-java.lang.String-}
+```
+public static NoteTag createYellowSun(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowSun pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowTarget() {#createYellowTarget--}
+```
+public static NoteTag createYellowTarget()
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowTarget pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowTarget(String label) {#createYellowTarget-java.lang.String-}
+```
+public static NoteTag createYellowTarget(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowTarget pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowTriangle() {#createYellowTriangle--}
+```
+public static NoteTag createYellowTriangle()
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowTriangle pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowTriangle(String label) {#createYellowTriangle-java.lang.String-}
+```
+public static NoteTag createYellowTriangle(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowTriangle pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowUmbrella() {#createYellowUmbrella--}
+```
+public static NoteTag createYellowUmbrella()
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowUmbrella pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowUmbrella(String label) {#createYellowUmbrella-java.lang.String-}
+```
+public static NoteTag createYellowUmbrella(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowUmbrella pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowUpArrow() {#createYellowUpArrow--}
+```
+public static NoteTag createYellowUpArrow()
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowUpArrow pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowUpArrow(String label) {#createYellowUpArrow-java.lang.String-}
+```
+public static NoteTag createYellowUpArrow(String label)
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowUpArrow pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowX() {#createYellowX--}
+```
+public static NoteTag createYellowX()
+```
+
+
+\* Maakt een nieuwe notitie-tag met YellowX pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowX(String label) {#createYellowX-java.lang.String-}
+```
+public static NoteTag createYellowX(String label)
+```
+
+
+* Maakt een nieuw notitie-tag met YellowX-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowXWithDots() {#createYellowXWithDots--}
+```
+public static NoteTag createYellowXWithDots()
+```
+
+
+* Maakt een nieuw notitie-tag met YellowXWithDots-pictogram en standaardlabel.
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### createYellowXWithDots(String label) {#createYellowXWithDots-java.lang.String-}
+```
+public static NoteTag createYellowXWithDots(String label)
+```
+
+
+* Maakt een nieuw notitie-tag met YellowXWithDots-pictogram en opgegeven label.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| label | java.lang.String | Het label van de tag. |
+
+**Returns:**
+[NoteTag](../../com.aspose.note/notetag) - The [NoteTag](../../com.aspose.note/notetag).
+### equals(NoteTag other) {#equals-com.aspose.note.NoteTag-}
+```
+public boolean equals(NoteTag other)
+```
+
+
+Bepaalt of het opgegeven object gelijk is aan het huidige object.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| other | [NoteTag](../../com.aspose.note/notetag) | Het object. |
+
+**Returns:**
+boolean - De `bool`.
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Bepaalt of het opgegeven object gelijk is aan het huidige object.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| obj | java.lang.Object | Het object. |
+
+**Returns:**
+boolean - De `bool`.
+### getCompletedTime() {#getCompletedTime--}
+```
+public final Date getCompletedTime()
+```
+
+
+Haalt het voltooid tijdstip op of stelt het in.
+
+Waarde: De `Nullable{DateTime}`.
+
+**Returns:**
+java.util.Date
+### getCreationTime() {#getCreationTime--}
+```
+public final Date getCreationTime()
+```
+
+
+Haalt het aanmaaktijdstip op of stelt het in.
+
+Waarde: De java.util.Date.
+
+**Returns:**
+java.util.Date
+### getFontColor() {#getFontColor--}
+```
+public Color getFontColor()
+```
+
+
+Haalt de letterkleur op of stelt deze in.
+
+**Returns:**
+java.awt.Color
+### getHighlight() {#getHighlight--}
+```
+public Color getHighlight()
+```
+
+
+Haalt de markeerkleur op of stelt deze in.
+
+**Returns:**
+java.awt.Color
+### getIcon() {#getIcon--}
+```
+public final int getIcon()
+```
+
+
+Haalt het pictogram op of stelt dit in.
+
+Waarde: De [TagIcon](../../com.aspose.note.infrastructure/tagicon).
+
+**Returns:**
+int
+### getLabel() {#getLabel--}
+```
+public String getLabel()
+```
+
+
+Haalt de labeltekst op.
+
+**Returns:**
+java.lang.String
+### getStatus() {#getStatus--}
+```
+public final int getStatus()
+```
+
+
+Haalt de status op of stelt deze in.
+
+Waarde: De [TagStatus](../../com.aspose.note/tagstatus).
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als een hash-functie voor het type.
+
+**Returns:**
+int - De `int`.
+### setCreationTime(Date value) {#setCreationTime-java.util.Date-}
+```
+public final void setCreationTime(Date value)
+```
+
+
+Haalt het aanmaaktijdstip op of stelt het in.
+
+Waarde: De java.util.Date.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Date |  |
+
+### setFontColor(Color value) {#setFontColor-java.awt.Color-}
+```
+public void setFontColor(Color value)
+```
+
+
+Haalt de letterkleur op of stelt deze in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.awt.Color |  |
+
+### setHighlight(Color value) {#setHighlight-java.awt.Color-}
+```
+public void setHighlight(Color value)
+```
+
+
+Haalt de markeerkleur op of stelt deze in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.awt.Color |  |
+
+### setIcon(int value) {#setIcon-int-}
+```
+public final void setIcon(int value)
+```
+
+
+Haalt het pictogram op of stelt dit in.
+
+Waarde: De [TagIcon](../../com.aspose.note.infrastructure/tagicon).
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+
+### setLabel(String value) {#setLabel-java.lang.String-}
+```
+public void setLabel(String value)
+```
+
+
+Stelt de labeltekst in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+

--- a/netherlands/java/com.aspose.note/notetask/_index.md
+++ b/netherlands/java/com.aspose.note/notetask/_index.md
@@ -1,0 +1,196 @@
+---
+title: "NoteTask"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een notitaak voor."
+type: docs
+weight: 55
+url: /nl/java/com.aspose.note/notetask/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.note.TagExtended, [com.aspose.note.CheckBox](../../com.aspose.note/checkbox)
+```
+public final class NoteTask extends CheckBox
+```
+
+Stelt een notitaak voor.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [createCustomFollowUpDate(Date dueDate)](#createCustomFollowUpDate-java.util.Date-) | Maakt een nieuwe notitaak met NoFollowUpDateFlag-pictogram en opgegeven vervaldatum. |
+| [createFollowUpNextWeek()](#createFollowUpNextWeek--) | \* Maakt een nieuwe notitag met FollowUpNextWeekFlag-pictogram. |
+| [createFollowUpThisWeek()](#createFollowUpThisWeek--) | \* Maakt een nieuwe notitag met FollowUpThisWeekFlag-pictogram. |
+| [createFollowUpToday()](#createFollowUpToday--) | \* Maakt een nieuwe notitag met FollowUpTodayFlag-pictogram. |
+| [createFollowUpTomorrow()](#createFollowUpTomorrow--) | \* Maakt een nieuwe notitag met FollowUpTomorrowFlag-pictogram. |
+| [createNoFollowUpDate()](#createNoFollowUpDate--) | \* Maakt een nieuwe notitag met NoFollowUpDateFlag-pictogram. |
+| [equals(NoteTask other)](#equals-com.aspose.note.NoteTask-) | Bepaalt of het opgegeven object gelijk is aan het huidige object. |
+| [equals(Object obj)](#equals-java.lang.Object-) | Bepaalt of het opgegeven object gelijk is aan het huidige object. |
+| [getDueDate()](#getDueDate--) | Haalt of stelt de vervaldatum in. |
+| [getIcon()](#getIcon--) | Haalt het pictogram op of stelt dit in. |
+| [getLabel()](#getLabel--) |  |
+| [hashCode()](#hashCode--) | Dient als een hash-functie voor het type. |
+| [setDueDate(Date value)](#setDueDate-java.util.Date-) | Haalt of stelt de vervaldatum in. |
+| [setOpen()](#setOpen--) | Stelt de tag in op open status. |
+### createCustomFollowUpDate(Date dueDate) {#createCustomFollowUpDate-java.util.Date-}
+```
+public static NoteTask createCustomFollowUpDate(Date dueDate)
+```
+
+
+Maakt een nieuwe notitaak met NoFollowUpDateFlag-pictogram en opgegeven vervaldatum.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| dueDate | java.util.Date | De vervaldatum. |
+
+**Returns:**
+[NoteTask](../../com.aspose.note/notetask) - The [NoteTask](../../com.aspose.note/notetask).
+### createFollowUpNextWeek() {#createFollowUpNextWeek--}
+```
+public static NoteTask createFollowUpNextWeek()
+```
+
+
+\* Maakt een nieuwe notitag met FollowUpNextWeekFlag-pictogram.
+
+**Returns:**
+[NoteTask](../../com.aspose.note/notetask) - The [NoteTask](../../com.aspose.note/notetask).
+### createFollowUpThisWeek() {#createFollowUpThisWeek--}
+```
+public static NoteTask createFollowUpThisWeek()
+```
+
+
+\* Maakt een nieuwe notitag met FollowUpThisWeekFlag-pictogram.
+
+**Returns:**
+[NoteTask](../../com.aspose.note/notetask) - The [NoteTask](../../com.aspose.note/notetask).
+### createFollowUpToday() {#createFollowUpToday--}
+```
+public static NoteTask createFollowUpToday()
+```
+
+
+\* Maakt een nieuwe notitag met FollowUpTodayFlag-pictogram.
+
+**Returns:**
+[NoteTask](../../com.aspose.note/notetask) - The [NoteTask](../../com.aspose.note/notetask).
+### createFollowUpTomorrow() {#createFollowUpTomorrow--}
+```
+public static NoteTask createFollowUpTomorrow()
+```
+
+
+\* Maakt een nieuwe notitag met FollowUpTomorrowFlag-pictogram.
+
+**Returns:**
+[NoteTask](../../com.aspose.note/notetask) - The [NoteTask](../../com.aspose.note/notetask).
+### createNoFollowUpDate() {#createNoFollowUpDate--}
+```
+public static NoteTask createNoFollowUpDate()
+```
+
+
+\* Maakt een nieuwe notitag met NoFollowUpDateFlag-pictogram.
+
+**Returns:**
+[NoteTask](../../com.aspose.note/notetask) - The [NoteTask](../../com.aspose.note/notetask).
+### equals(NoteTask other) {#equals-com.aspose.note.NoteTask-}
+```
+public boolean equals(NoteTask other)
+```
+
+
+Bepaalt of het opgegeven object gelijk is aan het huidige object.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| other | [NoteTask](../../com.aspose.note/notetask) | Het object. |
+
+**Returns:**
+boolean - De `bool`.
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Bepaalt of het opgegeven object gelijk is aan het huidige object.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| obj | java.lang.Object | Het object. |
+
+**Returns:**
+boolean - De `bool`.
+### getDueDate() {#getDueDate--}
+```
+public Date getDueDate()
+```
+
+
+Haalt of stelt de vervaldatum in.
+
+Waarde: De `DateTime`.
+
+**Returns:**
+java.util.Date
+### getIcon() {#getIcon--}
+```
+public int getIcon()
+```
+
+
+Haalt het pictogram op of stelt dit in.
+
+Waarde: De [TagIcon](../../com.aspose.note.infrastructure/tagicon).
+
+**Returns:**
+int
+### getLabel() {#getLabel--}
+```
+public String getLabel()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als een hash-functie voor het type.
+
+**Returns:**
+int - De `int`.
+### setDueDate(Date value) {#setDueDate-java.util.Date-}
+```
+public void setDueDate(Date value)
+```
+
+
+Haalt of stelt de vervaldatum in.
+
+Waarde: De `DateTime`.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Date |  |
+
+### setOpen() {#setOpen--}
+```
+public void setOpen()
+```
+
+
+Stelt de tag in op open status.
+

--- a/netherlands/java/com.aspose.note/numberformat/_index.md
+++ b/netherlands/java/com.aspose.note/numberformat/_index.md
@@ -1,0 +1,104 @@
+---
+title: "NumberFormat"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Specificeert het nummeringsformaat dat kan worden gebruikt voor een groep automatisch genummerde objecten."
+type: docs
+weight: 63
+url: /nl/java/com.aspose.note/numberformat/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class NumberFormat extends System.Enum
+```
+
+Specificeert het nummeropmaakformaat dat kan worden gebruikt voor een groep automatisch genummerde objecten. De volledige lijst wordt gespecificeerd op `[MSDN][]`
+
+
+[MSDN]: https://msdn.microsoft.com/en-us/library/dd923798%28v=office.12%29.aspx
+## Velden
+
+| Veld | Beschrijving |
+| --- | --- |
+| [ChineseCounting](#ChineseCounting) | Specificeert dat de reeks bestaat uit opeenvolgende getallen uit het Chinese telstelsel. |
+| [ChineseCountingThousand](#ChineseCountingThousand) | Specificeert dat de reeks bestaat uit opeenvolgende getallen volgens het Chinese telstelsel voor duizenden. |
+| [DecimalNumbers](#DecimalNumbers) | Specificeert dat de reeks bestaat uit decimale nummering. |
+| [LowerLetter](#LowerLetter) | Specificeert dat de reeks bestaat uit één of meer herhalingen van een enkele letter van het Latijnse alfabet in kleine letters. |
+| [LowerRoman](#LowerRoman) | Specificeert dat de reeks bestaat uit Romeinse cijfers in kleine letters. |
+| [TaiwaneseCounting](#TaiwaneseCounting) | Specificeert dat de reeks bestaat uit opeenvolgende getallen volgens het Taiwanese telstelsel. |
+| [TaiwaneseCountingThousand](#TaiwaneseCountingThousand) | Specificeert dat de reeks bestaat uit opeenvolgende getallen volgens het Taiwanese telstelsel voor duizenden. |
+| [UpperLetter](#UpperLetter) | Specificeert dat de reeks bestaat uit één of meer herhalingen van een enkele letter van het Latijnse alfabet in hoofdletters. |
+| [UpperRoman](#UpperRoman) | Specificeert dat de reeks bestaat uit Romeinse cijfers in hoofdletters. |
+### ChineseCounting {#ChineseCounting}
+```
+public static final byte ChineseCounting
+```
+
+
+Specificeert dat de reeks bestaat uit opeenvolgende getallen uit het Chinese telstelsel.
+
+### ChineseCountingThousand {#ChineseCountingThousand}
+```
+public static final byte ChineseCountingThousand
+```
+
+
+Specificeert dat de reeks bestaat uit opeenvolgende getallen volgens het Chinese telstelsel voor duizenden.
+
+### DecimalNumbers {#DecimalNumbers}
+```
+public static final byte DecimalNumbers
+```
+
+
+Specificeert dat de reeks bestaat uit decimale nummering. Voorbeeld: 1, 2, 3, \\u2026, 8, 9, 10, 11, 12, \\u2026, 18, 19, 20, 21.
+
+### LowerLetter {#LowerLetter}
+```
+public static final byte LowerLetter
+```
+
+
+Specificeert dat de reeks bestaat uit één of meer herhalingen van een enkele letter van het Latijnse alfabet in kleine letters. Voorbeeld: a, b, c, \\u2026, y, z, aa, bb, cc, \\u2026, yy, zz, aaa, bbb, ccc.
+
+### LowerRoman {#LowerRoman}
+```
+public static final byte LowerRoman
+```
+
+
+Specificeert dat de reeks bestaat uit Romeinse cijfers in kleine letters. Voorbeeld: i, ii, iii, iv, \\u2026, xviii, xix, xx, xxi.
+
+### TaiwaneseCounting {#TaiwaneseCounting}
+```
+public static final byte TaiwaneseCounting
+```
+
+
+Specificeert dat de reeks bestaat uit opeenvolgende getallen volgens het Taiwanese telstelsel.
+
+### TaiwaneseCountingThousand {#TaiwaneseCountingThousand}
+```
+public static final byte TaiwaneseCountingThousand
+```
+
+
+Specificeert dat de reeks bestaat uit opeenvolgende getallen volgens het Taiwanese telstelsel voor duizenden.
+
+### UpperLetter {#UpperLetter}
+```
+public static final byte UpperLetter
+```
+
+
+Specificeert dat de reeks bestaat uit één of meer herhalingen van een enkele letter van het Latijnse alfabet in hoofdletters. Voorbeeld: A, B, C, \\u2026, Y, Z, AA, BB, CC, \\u2026, YY, ZZ, AAA, BBB, CCC.
+
+### UpperRoman {#UpperRoman}
+```
+public static final byte UpperRoman
+```
+
+
+Specificeert dat de reeks bestaat uit Romeinse cijfers in hoofdletters. Voorbeeld: I, II, III, IV, \\u2026, XVIII, XIX, XX, XXI.
+

--- a/netherlands/java/com.aspose.note/numberlist/_index.md
+++ b/netherlands/java/com.aspose.note/numberlist/_index.md
@@ -1,0 +1,341 @@
+---
+title: "NumberList"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt de genummerde of opsomminglijst voor."
+type: docs
+weight: 64
+url: /nl/java/com.aspose.note/numberlist/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class NumberList
+```
+
+Stelt de genummerde of opsomminglijst voor.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [NumberList(String bulletedSymbol, String font, int fontSize)](#NumberList-java.lang.String-java.lang.String-int-) | Initialiseert een nieuw exemplaar van de `NumberList`-klasse. |
+| [NumberList(String format, byte numberFormat, String font, int fontSize)](#NumberList-java.lang.String-byte-java.lang.String-int-) | Initialiseert een nieuw exemplaar van de `NumberList`-klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [equals(NumberList other)](#equals-com.aspose.note.NumberList-) | Bepaalt of het opgegeven object gelijk is aan het huidige object. |
+| [equals(Object obj)](#equals-java.lang.Object-) | Bepaalt of het opgegeven object gelijk is aan het huidige object. |
+| [getFont()](#getFont--) | Haalt de naam van het lettertype op of stelt deze in. |
+| [getFontColor()](#getFontColor--) | Haalt de letterkleur op of stelt deze in. |
+| [getFontSize()](#getFontSize--) | Haalt de lettergrootte op of stelt deze in. |
+| [getFormat()](#getFormat--) | Haalt het formaat van de regelkop op of stelt dit in. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | Haalt op of stelt de laatst gewijzigde tijd in. |
+| [getNumberFormat()](#getNumberFormat--) | Haalt het getalformaat op dat wordt gebruikt voor een groep automatisch genummerde objecten, of stelt dit in. |
+| [getNumberedListHeader(int sequenceNumber)](#getNumberedListHeader-int-) | Haalt de genummerde lijstkop op. |
+| [getRestart()](#getRestart--) | Haalt de numerieke waarde op die de automatische nummerwaarde van het lijstitem overschrijft, of stelt deze in. |
+| [hashCode()](#hashCode--) | Dient als een hash-functie voor het type. |
+| [isBold()](#isBold--) | Haalt een waarde op of stelt deze in die aangeeft of de tekststijl vetgedrukt is. |
+| [isItalic()](#isItalic--) | Haalt een waarde op of stelt deze in die aangeeft of de tekststijl cursief is. |
+| [setBold(boolean value)](#setBold-boolean-) | Haalt een waarde op of stelt deze in die aangeeft of de tekststijl vetgedrukt is. |
+| [setFont(String value)](#setFont-java.lang.String-) | Haalt de naam van het lettertype op of stelt deze in. |
+| [setFontColor(Color value)](#setFontColor-java.awt.Color-) | Haalt de letterkleur op of stelt deze in. |
+| [setFontSize(int value)](#setFontSize-int-) | Haalt de lettergrootte op of stelt deze in. |
+| [setFormat(String value)](#setFormat-java.lang.String-) | Haalt het formaat van de regelkop op of stelt dit in. |
+| [setItalic(boolean value)](#setItalic-boolean-) | Haalt een waarde op of stelt deze in die aangeeft of de tekststijl cursief is. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | Haalt op of stelt de laatst gewijzigde tijd in. |
+| [setNumberFormat(Byte value)](#setNumberFormat-java.lang.Byte-) | Haalt het getalformaat op dat wordt gebruikt voor een groep automatisch genummerde objecten, of stelt dit in. |
+| [setRestart(int value)](#setRestart-int-) | Haalt de numerieke waarde op die de automatische nummerwaarde van het lijstitem overschrijft, of stelt deze in. |
+### NumberList(String bulletedSymbol, String font, int fontSize) {#NumberList-java.lang.String-java.lang.String-int-}
+```
+public NumberList(String bulletedSymbol, String font, int fontSize)
+```
+
+
+Initialiseert een nieuw exemplaar van de `NumberList`-klasse. Deze instantie vertegenwoordigt een opsomming met opsommingstekens.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| bulletedSymbol | java.lang.String | Een symbool dat een opsommingsteken vertegenwoordigt. |
+| font | java.lang.String | Een lettertype voor het opsommingsteken. |
+| fontSize | int | Een lettergrootte voor het opsommingsteken. |
+
+### NumberList(String format, byte numberFormat, String font, int fontSize) {#NumberList-java.lang.String-byte-java.lang.String-int-}
+```
+public NumberList(String format, byte numberFormat, String font, int fontSize)
+```
+
+
+Initialiseert een nieuw exemplaar van de `NumberList`-klasse. Deze instantie vertegenwoordigt een genummerde lijst.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| format | java.lang.String | Het formaat van de genummerde kop. |
+| numberFormat | byte | Het formaat van het nummer in de koptekst. |
+| font | java.lang.String | Een lettertype voor de genummerde koptekst. |
+| fontSize | int | Een lettergrootte voor de genummerde koptekst. |
+
+### equals(NumberList other) {#equals-com.aspose.note.NumberList-}
+```
+public boolean equals(NumberList other)
+```
+
+
+Bepaalt of het opgegeven object gelijk is aan het huidige object.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| other | [NumberList](../../com.aspose.note/numberlist) | Het object. |
+
+**Returns:**
+boolean - De `bool`.
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Bepaalt of het opgegeven object gelijk is aan het huidige object.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| obj | java.lang.Object | Het object. |
+
+**Returns:**
+boolean - De `bool`.
+### getFont() {#getFont--}
+```
+public String getFont()
+```
+
+
+Haalt de naam van het lettertype op of stelt deze in.
+
+**Returns:**
+java.lang.String
+### getFontColor() {#getFontColor--}
+```
+public Color getFontColor()
+```
+
+
+Haalt de letterkleur op of stelt deze in.
+
+**Returns:**
+java.awt.Color
+### getFontSize() {#getFontSize--}
+```
+public int getFontSize()
+```
+
+
+Haalt de lettergrootte op of stelt deze in.
+
+**Returns:**
+int
+### getFormat() {#getFormat--}
+```
+public String getFormat()
+```
+
+
+Haalt het formaat van de regelkop op of stelt het in. Voor opsommingslijsten vertegenwoordigt het een opsommingsteken.
+
+**Returns:**
+java.lang.String
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+Haalt op of stelt de laatst gewijzigde tijd in.
+
+**Returns:**
+java.util.Date
+### getNumberFormat() {#getNumberFormat--}
+```
+public Byte getNumberFormat()
+```
+
+
+Haalt het getalformaat op dat wordt gebruikt voor een groep automatisch genummerde objecten, of stelt het in. Moet null zijn voor opsommingslijsten.
+
+**Returns:**
+java.lang.Byte
+### getNumberedListHeader(int sequenceNumber) {#getNumberedListHeader-int-}
+```
+public String getNumberedListHeader(int sequenceNumber)
+```
+
+
+Haalt de genummerde lijstkop op.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| sequenceNumber | int | Het volgnummer in de genummerde lijst. |
+
+**Returns:**
+java.lang.String - Een tekenreeksrepresentatie van het opgegeven volgnummer.
+### getRestart() {#getRestart--}
+```
+public int getRestart()
+```
+
+
+Haalt de numerieke waarde op die de automatische nummerwaarde van het lijstitem overschrijft, of stelt deze in.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als een hash-functie voor het type.
+
+**Returns:**
+int - De `int`.
+### isBold() {#isBold--}
+```
+public boolean isBold()
+```
+
+
+Haalt een waarde op of stelt deze in die aangeeft of de tekststijl vetgedrukt is.
+
+**Returns:**
+boolean
+### isItalic() {#isItalic--}
+```
+public boolean isItalic()
+```
+
+
+Haalt een waarde op of stelt deze in die aangeeft of de tekststijl cursief is.
+
+**Returns:**
+boolean
+### setBold(boolean value) {#setBold-boolean-}
+```
+public void setBold(boolean value)
+```
+
+
+Haalt een waarde op of stelt deze in die aangeeft of de tekststijl vetgedrukt is.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+### setFont(String value) {#setFont-java.lang.String-}
+```
+public void setFont(String value)
+```
+
+
+Haalt de naam van het lettertype op of stelt deze in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+
+### setFontColor(Color value) {#setFontColor-java.awt.Color-}
+```
+public void setFontColor(Color value)
+```
+
+
+Haalt de letterkleur op of stelt deze in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.awt.Color |  |
+
+### setFontSize(int value) {#setFontSize-int-}
+```
+public void setFontSize(int value)
+```
+
+
+Haalt de lettergrootte op of stelt deze in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+
+### setFormat(String value) {#setFormat-java.lang.String-}
+```
+public void setFormat(String value)
+```
+
+
+Haalt het formaat van de regelkop op of stelt het in. Voor opsommingslijsten vertegenwoordigt het een opsommingsteken.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+
+### setItalic(boolean value) {#setItalic-boolean-}
+```
+public void setItalic(boolean value)
+```
+
+
+Haalt een waarde op of stelt deze in die aangeeft of de tekststijl cursief is.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+Haalt op of stelt de laatst gewijzigde tijd in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Date |  |
+
+### setNumberFormat(Byte value) {#setNumberFormat-java.lang.Byte-}
+```
+public void setNumberFormat(Byte value)
+```
+
+
+Haalt het getalformaat op dat wordt gebruikt voor een groep automatisch genummerde objecten, of stelt het in. Moet null zijn voor opsommingslijsten.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.Byte |  |
+
+### setRestart(int value) {#setRestart-int-}
+```
+public void setRestart(int value)
+```
+
+
+Haalt de numerieke waarde op die de automatische nummerwaarde van het lijstitem overschrijft, of stelt deze in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+

--- a/netherlands/java/com.aspose.note/onesaveoptions/_index.md
+++ b/netherlands/java/com.aspose.note/onesaveoptions/_index.md
@@ -1,0 +1,58 @@
+---
+title: "OneSaveOptions"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Staat toe extra opties op te geven bij het opslaan van een document in OneNote-indeling."
+type: docs
+weight: 65
+url: /nl/java/com.aspose.note/onesaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.SaveOptions](../../com.aspose.note/saveoptions)
+```
+public final class OneSaveOptions extends SaveOptions
+```
+
+Staat toe extra opties op te geven bij het opslaan van een document in OneNote-indeling.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [OneSaveOptions()](#OneSaveOptions--) | Initialiseert een nieuw exemplaar van de `OneSaveOptions`-klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getDocumentPassword()](#getDocumentPassword--) | Haalt een wachtwoord op of stelt een wachtwoord in om de documentinhoud te versleutelen. |
+| [setDocumentPassword(String value)](#setDocumentPassword-java.lang.String-) | Haalt een wachtwoord op of stelt een wachtwoord in om de documentinhoud te versleutelen. |
+### OneSaveOptions() {#OneSaveOptions--}
+```
+public OneSaveOptions()
+```
+
+
+Initialiseert een nieuw exemplaar van de `OneSaveOptions`-klasse.
+
+### getDocumentPassword() {#getDocumentPassword--}
+```
+public String getDocumentPassword()
+```
+
+
+Haalt een wachtwoord op of stelt een wachtwoord in om de documentinhoud te versleutelen.
+
+**Returns:**
+java.lang.String
+### setDocumentPassword(String value) {#setDocumentPassword-java.lang.String-}
+```
+public void setDocumentPassword(String value)
+```
+
+
+Haalt een wachtwoord op of stelt een wachtwoord in om de documentinhoud te versleutelen.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+

--- a/netherlands/java/com.aspose.note/outline/_index.md
+++ b/netherlands/java/com.aspose.note/outline/_index.md
@@ -1,0 +1,261 @@
+---
+title: "Outline"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een overzicht voor."
+type: docs
+weight: 66
+url: /nl/java/com.aspose.note/outline/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode, com.aspose.note.IndentatedNode
+
+**All Implemented Interfaces:**
+[com.aspose.note.IPageChildNode](../../com.aspose.note/ipagechildnode)
+```
+public final class Outline extends IndentatedNode<IOutlineChildNode,Outline> implements IPageChildNode
+```
+
+Stelt een overzicht voor.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [Outline()](#Outline--) | Initialiseert een nieuw exemplaar van de [Outline](../../com.aspose.note/outline) klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | Accepteert de bezoeker van de node. |
+| [getDescendantsCannotBeMoved()](#getDescendantsCannotBeMoved--) | Haalt op of afstammelingen van de outline verplaatst kunnen worden. |
+| [getHorizontalOffset()](#getHorizontalOffset--) | Haalt op of stelt de horizontale offset in. |
+| [getInternalIndentPosition()](#getInternalIndentPosition--) |  |
+| [getLastModifiedTime()](#getLastModifiedTime--) | Haalt op of stelt de laatst gewijzigde tijd in. |
+| [getMaxHeight()](#getMaxHeight--) | Haalt op of stelt de maximale hoogte in. |
+| [getMaxWidth()](#getMaxWidth--) | Haalt op of stelt de maximale breedte in. |
+| [getMinWidth()](#getMinWidth--) | Haalt op of stelt de minimale breedte in. |
+| [getReservedWidth()](#getReservedWidth--) | Haalt op of stelt de gereserveerde breedte in. |
+| [getVerticalOffset()](#getVerticalOffset--) | Haalt op of stelt de verticale offset in. |
+| [setDescendantsCannotBeMoved(boolean value)](#setDescendantsCannotBeMoved-boolean-) | Haalt op of afstammelingen van de outline verplaatst kunnen worden. |
+| [setHorizontalOffset(float value)](#setHorizontalOffset-float-) | Haalt op of stelt de horizontale offset in. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | Haalt op of stelt de laatst gewijzigde tijd in. |
+| [setMaxHeight(float value)](#setMaxHeight-float-) | Haalt op of stelt de maximale hoogte in. |
+| [setMaxWidth(float value)](#setMaxWidth-float-) | Haalt op of stelt de maximale breedte in. |
+| [setMinWidth(float value)](#setMinWidth-float-) | Haalt op of stelt de minimale breedte in. |
+| [setReservedWidth(float value)](#setReservedWidth-float-) | Haalt op of stelt de gereserveerde breedte in. |
+| [setVerticalOffset(float value)](#setVerticalOffset-float-) | Haalt op of stelt de verticale offset in. |
+### Outline() {#Outline--}
+```
+public Outline()
+```
+
+
+Initialiseert een nieuw exemplaar van de [Outline](../../com.aspose.note/outline) klasse.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+Accepteert de bezoeker van de node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | Het object van een klasse die afgeleid is van de `DocumentVisitor`. |
+
+### getDescendantsCannotBeMoved() {#getDescendantsCannotBeMoved--}
+```
+public boolean getDescendantsCannotBeMoved()
+```
+
+
+Haalt op of afstammelingen van de outline verplaatst kunnen worden.
+
+**Returns:**
+boolean
+### getHorizontalOffset() {#getHorizontalOffset--}
+```
+public float getHorizontalOffset()
+```
+
+
+Haalt op of stelt de horizontale offset in.
+
+**Returns:**
+float
+### getInternalIndentPosition() {#getInternalIndentPosition--}
+```
+public int getInternalIndentPosition()
+```
+
+
+Haalt de hoeveelheid items op die opgeteld moeten worden in de RgOutlineIndentDistance-array om de inspronggrootte te verkrijgen.
+
+**Returns:**
+int
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+Haalt op of stelt de laatst gewijzigde tijd in.
+
+**Returns:**
+java.util.Date
+### getMaxHeight() {#getMaxHeight--}
+```
+public float getMaxHeight()
+```
+
+
+Haalt op of stelt de maximale hoogte in.
+
+**Returns:**
+float
+### getMaxWidth() {#getMaxWidth--}
+```
+public float getMaxWidth()
+```
+
+
+Haalt op of stelt de maximale breedte in.
+
+**Returns:**
+float
+### getMinWidth() {#getMinWidth--}
+```
+public float getMinWidth()
+```
+
+
+Haalt op of stelt de minimale breedte in.
+
+**Returns:**
+float
+### getReservedWidth() {#getReservedWidth--}
+```
+public float getReservedWidth()
+```
+
+
+Haalt op of stelt de gereserveerde breedte in.
+
+**Returns:**
+float
+### getVerticalOffset() {#getVerticalOffset--}
+```
+public float getVerticalOffset()
+```
+
+
+Haalt op of stelt de verticale offset in.
+
+**Returns:**
+float
+### setDescendantsCannotBeMoved(boolean value) {#setDescendantsCannotBeMoved-boolean-}
+```
+public void setDescendantsCannotBeMoved(boolean value)
+```
+
+
+Haalt op of afstammelingen van de outline verplaatst kunnen worden.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+### setHorizontalOffset(float value) {#setHorizontalOffset-float-}
+```
+public void setHorizontalOffset(float value)
+```
+
+
+Haalt op of stelt de horizontale offset in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+Haalt op of stelt de laatst gewijzigde tijd in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Date |  |
+
+### setMaxHeight(float value) {#setMaxHeight-float-}
+```
+public void setMaxHeight(float value)
+```
+
+
+Haalt op of stelt de maximale hoogte in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+
+### setMaxWidth(float value) {#setMaxWidth-float-}
+```
+public void setMaxWidth(float value)
+```
+
+
+Haalt op of stelt de maximale breedte in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+
+### setMinWidth(float value) {#setMinWidth-float-}
+```
+public void setMinWidth(float value)
+```
+
+
+Haalt op of stelt de minimale breedte in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+
+### setReservedWidth(float value) {#setReservedWidth-float-}
+```
+public void setReservedWidth(float value)
+```
+
+
+Haalt op of stelt de gereserveerde breedte in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+
+### setVerticalOffset(float value) {#setVerticalOffset-float-}
+```
+public void setVerticalOffset(float value)
+```
+
+
+Haalt op of stelt de verticale offset in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+

--- a/netherlands/java/com.aspose.note/outlineelement/_index.md
+++ b/netherlands/java/com.aspose.note/outlineelement/_index.md
@@ -1,0 +1,151 @@
+---
+title: "OutlineElement"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een OutlineElement voor."
+type: docs
+weight: 67
+url: /nl/java/com.aspose.note/outlineelement/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode, com.aspose.note.IndentatedNode
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineChildNode](../../com.aspose.note/ioutlinechildnode), [com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode)
+```
+public final class OutlineElement extends IndentatedNode<IOutlineElementChildNode,OutlineElement> implements IOutlineChildNode, IOutlineElementChildNode
+```
+
+Stelt een OutlineElement voor.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [OutlineElement()](#OutlineElement--) | Initialiseert een nieuw exemplaar van de `OutlineElement`-klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | Accepteert de bezoeker van de node. |
+| [getAuthorMostRecent()](#getAuthorMostRecent--) | Haalt de meest recente auteur van een outline-element op. |
+| [getAuthorOriginal()](#getAuthorOriginal--) | Haalt de oorspronkelijke auteur van een outline-element op. |
+| [getCreationTime()](#getCreationTime--) | Haalt het aanmaaktijdstip op of stelt het in. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | Haalt op of stelt de laatst gewijzigde tijd in. |
+| [getNumberList()](#getNumberList--) | Haalt de stijl op of stelt de stijl in voor de kop van een genummerde lijst. |
+| [setCreationTime(Date value)](#setCreationTime-java.util.Date-) | Haalt het aanmaaktijdstip op of stelt het in. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | Haalt op of stelt de laatst gewijzigde tijd in. |
+| [setNumberList(NumberList value)](#setNumberList-com.aspose.note.NumberList-) | Haalt de stijl op of stelt de stijl in voor de kop van een genummerde lijst. |
+### OutlineElement() {#OutlineElement--}
+```
+public OutlineElement()
+```
+
+
+Initialiseert een nieuw exemplaar van de `OutlineElement`-klasse.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+Accepteert de bezoeker van de node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | Het object van een klasse die afgeleid is van de `DocumentVisitor`. |
+
+### getAuthorMostRecent() {#getAuthorMostRecent--}
+```
+public final String getAuthorMostRecent()
+```
+
+
+Haalt de meest recente auteur van een outline-element op.
+
+Waarde: De meest recente auteur.
+
+**Returns:**
+java.lang.String
+### getAuthorOriginal() {#getAuthorOriginal--}
+```
+public final String getAuthorOriginal()
+```
+
+
+Haalt de oorspronkelijke auteur van een outline-element op.
+
+Waarde: De oorspronkelijke auteur.
+
+**Returns:**
+java.lang.String
+### getCreationTime() {#getCreationTime--}
+```
+public Date getCreationTime()
+```
+
+
+Haalt het aanmaaktijdstip op of stelt het in.
+
+**Returns:**
+java.util.Date
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+Haalt op of stelt de laatst gewijzigde tijd in.
+
+**Returns:**
+java.util.Date
+### getNumberList() {#getNumberList--}
+```
+public NumberList getNumberList()
+```
+
+
+Haalt de stijl op of stelt de stijl in voor de kop van een genummerde lijst.
+
+**Returns:**
+[NumberList](../../com.aspose.note/numberlist)
+### setCreationTime(Date value) {#setCreationTime-java.util.Date-}
+```
+public void setCreationTime(Date value)
+```
+
+
+Haalt het aanmaaktijdstip op of stelt het in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Date |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+Haalt op of stelt de laatst gewijzigde tijd in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Date |  |
+
+### setNumberList(NumberList value) {#setNumberList-com.aspose.note.NumberList-}
+```
+public void setNumberList(NumberList value)
+```
+
+
+Haalt de stijl op of stelt de stijl in voor de kop van een genummerde lijst.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| value | [NumberList](../../com.aspose.note/numberlist) |  |
+

--- a/netherlands/java/com.aspose.note/outlinegroup/_index.md
+++ b/netherlands/java/com.aspose.note/outlinegroup/_index.md
@@ -1,0 +1,50 @@
+---
+title: "OutlineGroup"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een OutlineGroup voor."
+type: docs
+weight: 68
+url: /nl/java/com.aspose.note/outlinegroup/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode, com.aspose.note.IndentatedNode
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineChildNode](../../com.aspose.note/ioutlinechildnode), [com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode)
+```
+public final class OutlineGroup extends IndentatedNode<IOutlineChildNode,OutlineGroup> implements IOutlineChildNode, IOutlineElementChildNode
+```
+
+Stelt een OutlineGroup voor.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [OutlineGroup()](#OutlineGroup--) | Initialiseert een nieuw exemplaar van de `OutlineGroup` klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | Accepteert de bezoeker van de node. |
+### OutlineGroup() {#OutlineGroup--}
+```
+public OutlineGroup()
+```
+
+
+Initialiseert een nieuw exemplaar van de `OutlineGroup` klasse.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+Accepteert de bezoeker van de node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | Het object van een klasse die afgeleid is van de `DocumentVisitor`. |
+

--- a/netherlands/java/com.aspose.note/page/_index.md
+++ b/netherlands/java/com.aspose.note/page/_index.md
@@ -1,0 +1,385 @@
+---
+title: "Page"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een pagina voor."
+type: docs
+weight: 69
+url: /nl/java/com.aspose.note/page/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode
+```
+public final class Page extends CompositeNode<IPageChildNode>
+```
+
+Stelt een pagina voor.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [Page()](#Page--) | Initialiseert een nieuw exemplaar van de `Page`-klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | Accepteert de bezoeker van de node. |
+| [deepClone()](#deepClone--) | Kopieert de pagina. |
+| [deepClone(boolean cloneHistory)](#deepClone-boolean-) | Kopieert de pagina. |
+| [getAuthor()](#getAuthor--) | Haalt de auteur op of stelt deze in. |
+| [getBackgroundColor()](#getBackgroundColor--) | Haalt de achtergrondkleur van de pagina op of stelt deze in. |
+| [getCreationTime()](#getCreationTime--) | Haalt het aanmaaktijdstip op of stelt het in. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | Haalt op of stelt de laatst gewijzigde tijd in. |
+| [getLevel()](#getLevel--) | Haalt het niveau op of stelt dit in. |
+| [getMargin()](#getMargin--) | Haalt de marge op of stelt deze in. |
+| [getPageContentRevisionSummary()](#getPageContentRevisionSummary--) | Haalt de revisiesamenvatting voor de pagina en zijn onderliggende knooppunten op of stelt deze in. |
+| [getPageLayoutSize()](#getPageLayoutSize--) | Haalt de lay-outgrootte van de pagina op die in de editor wordt weergegeven. |
+| [getSizeType()](#getSizeType--) | Haalt het type grootte van een pagina op of stelt dit in. |
+| [getTitle()](#getTitle--) | Haalt op of stelt de titel in. |
+| [isConflictPage()](#isConflictPage--) | Haalt op of stelt een waarde in die aangeeft of deze pagina een conflictpagina is. |
+| [setAuthor(String value)](#setAuthor-java.lang.String-) | Haalt de auteur op of stelt deze in. |
+| [setBackgroundColor(Color value)](#setBackgroundColor-java.awt.Color-) | Haalt de achtergrondkleur van de pagina op of stelt deze in. |
+| [setConflictPage(boolean value)](#setConflictPage-boolean-) | Haalt op of stelt een waarde in die aangeeft of deze pagina een conflictpagina is. |
+| [setCreationTime(Date value)](#setCreationTime-java.util.Date-) | Haalt het aanmaaktijdstip op of stelt het in. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | Haalt op of stelt de laatst gewijzigde tijd in. |
+| [setLevel(byte value)](#setLevel-byte-) | Haalt het niveau op of stelt dit in. |
+| [setMargin(Margins value)](#setMargin-com.aspose.note.Margins-) | Haalt de marge op of stelt deze in. |
+| [setPageContentRevisionSummary(RevisionSummary value)](#setPageContentRevisionSummary-com.aspose.note.RevisionSummary-) | Haalt de revisiesamenvatting voor de pagina en zijn onderliggende knooppunten op of stelt deze in. |
+| [setPageLayoutSize(Dimension2D value)](#setPageLayoutSize-java.awt.geom.Dimension2D-) | Stelt de lay-outgrootte van de pagina in die in de editor wordt weergegeven. |
+| [setSizeType(int value)](#setSizeType-int-) | Haalt het type grootte van een pagina op of stelt dit in. |
+| [setTitle(Title value)](#setTitle-com.aspose.note.Title-) | Haalt op of stelt de titel in. |
+### Page() {#Page--}
+```
+public Page()
+```
+
+
+Initialiseert een nieuw exemplaar van de `Page`-klasse.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+Accepteert de bezoeker van de node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | Het object van een klasse die afgeleid is van de `DocumentVisitor`. |
+
+### deepClone() {#deepClone--}
+```
+public final Page deepClone()
+```
+
+
+Kopieert de pagina.
+
+**Returns:**
+[Page](../../com.aspose.note/page) - A clone of the page.
+### deepClone(boolean cloneHistory) {#deepClone-boolean-}
+```
+public final Page deepClone(boolean cloneHistory)
+```
+
+
+Kopieert de pagina.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| cloneHistory | boolean | Specificeert of de geschiedenis van de pagina gekloond moet worden.. |
+
+**Returns:**
+[Page](../../com.aspose.note/page) - A clone of the page.
+### getAuthor() {#getAuthor--}
+```
+public String getAuthor()
+```
+
+
+Haalt de auteur op of stelt deze in.
+
+**Returns:**
+java.lang.String
+### getBackgroundColor() {#getBackgroundColor--}
+```
+public final Color getBackgroundColor()
+```
+
+
+Haalt de achtergrondkleur van de pagina op of stelt deze in.
+
+**Returns:**
+java.awt.Color
+### getCreationTime() {#getCreationTime--}
+```
+public Date getCreationTime()
+```
+
+
+Haalt het aanmaaktijdstip op of stelt het in.
+
+**Returns:**
+java.util.Date
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+Haalt op of stelt de laatst gewijzigde tijd in.
+
+**Returns:**
+java.util.Date
+### getLevel() {#getLevel--}
+```
+public byte getLevel()
+```
+
+
+Haalt het niveau op of stelt dit in.
+
+**Returns:**
+byte
+### getMargin() {#getMargin--}
+```
+public Margins getMargin()
+```
+
+
+Haalt de marge op of stelt deze in.
+
+**Returns:**
+[Margins](../../com.aspose.note/margins)
+### getPageContentRevisionSummary() {#getPageContentRevisionSummary--}
+```
+public RevisionSummary getPageContentRevisionSummary()
+```
+
+
+Haalt de revisiesamenvatting voor de pagina en zijn onderliggende knooppunten op of stelt deze in.
+
+**Returns:**
+[RevisionSummary](../../com.aspose.note/revisionsummary)
+### getPageLayoutSize() {#getPageLayoutSize--}
+```
+public final Dimension2D getPageLayoutSize()
+```
+
+
+Haalt de lay-outgrootte van de pagina op die in de editor wordt weergegeven.
+
+--------------------
+
+Deze waarde wordt door de Microsoft OneNote‑applicatie gebruikt om de onderliggende paginalay-out weer te geven wanneer het document wordt geopend. Het heeft verder geen invloed op het afdrukken en opslaan van het document. Wanneer de eigenschap Page.SizeType is ingesteld op PageSizeType.SizeByContent, geeft deze eigenschap de werkelijke grootte van de inhoud terug.
+
+**Returns:**
+java.awt.geom.Dimension2D
+### getSizeType() {#getSizeType--}
+```
+public final int getSizeType()
+```
+
+
+Haalt het type grootte van een pagina op of stelt dit in.
+
+--------------------
+
+Standaard wordt een pagina automatisch aangepast in grootte. De standaardwaarde is [PageSizeType.SizeByContent](../../com.aspose.note/pagesizetype\\#SizeByContent).
+
+**Returns:**
+int
+### getTitle() {#getTitle--}
+```
+public Title getTitle()
+```
+
+
+Haalt op of stelt de titel in.
+
+Waarde: De `Title`.
+
+**Returns:**
+[Title](../../com.aspose.note/title)
+### isConflictPage() {#isConflictPage--}
+```
+public final boolean isConflictPage()
+```
+
+
+Haalt op of stelt een waarde in die aangeeft of deze pagina een conflictpagina is.
+
+--------------------
+
+De conflictpagina ontstaat wanneer twee gebruikers proberen dezelfde inhoud bij te werken. In dit geval worden de wijzigingen van de eerste gebruiker zoals gewoonlijk geschreven. Maar de wijzigingen van de andere gebruiker kunnen niet worden samengevoegd. Daarom wordt er gewoon een kopie van de pagina gemaakt en gemarkeerd als conflict.
+
+In deze versie worden conflicten opgelost ten gunste van de wijzigingen van de eerste gebruiker. Als een document conflictpagina's bevat, worden deze weergegeven in de geschiedenis, maar overgeslagen bij het opslaan. Het is mogelijk deze vlag te resetten om deze pagina's in de geschiedenis op te slaan als gewone pagina's.
+
+Een gedetailleerd voorbeeld van het manipuleren van een conflictpagina is te vinden in de online documentatie.
+
+**Returns:**
+boolean
+### setAuthor(String value) {#setAuthor-java.lang.String-}
+```
+public void setAuthor(String value)
+```
+
+
+Haalt de auteur op of stelt deze in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+
+### setBackgroundColor(Color value) {#setBackgroundColor-java.awt.Color-}
+```
+public final void setBackgroundColor(Color value)
+```
+
+
+Haalt de achtergrondkleur van de pagina op of stelt deze in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.awt.Color |  |
+
+### setConflictPage(boolean value) {#setConflictPage-boolean-}
+```
+public final void setConflictPage(boolean value)
+```
+
+
+Haalt op of stelt een waarde in die aangeeft of deze pagina een conflictpagina is.
+
+--------------------
+
+De conflictpagina ontstaat wanneer twee gebruikers proberen dezelfde inhoud bij te werken. In dit geval worden de wijzigingen van de eerste gebruiker zoals gewoonlijk geschreven. Maar de wijzigingen van de andere gebruiker kunnen niet worden samengevoegd. Daarom wordt er gewoon een kopie van de pagina gemaakt en gemarkeerd als conflict.
+
+In deze versie worden conflicten opgelost ten gunste van de wijzigingen van de eerste gebruiker. Als een document conflictpagina's bevat, worden deze weergegeven in de geschiedenis, maar overgeslagen bij het opslaan. Het is mogelijk deze vlag te resetten om deze pagina's in de geschiedenis op te slaan als gewone pagina's.
+
+Een gedetailleerd voorbeeld van het manipuleren van een conflictpagina is te vinden in de online documentatie.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+### setCreationTime(Date value) {#setCreationTime-java.util.Date-}
+```
+public void setCreationTime(Date value)
+```
+
+
+Haalt het aanmaaktijdstip op of stelt het in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Date |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+Haalt op of stelt de laatst gewijzigde tijd in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Date |  |
+
+### setLevel(byte value) {#setLevel-byte-}
+```
+public void setLevel(byte value)
+```
+
+
+Haalt het niveau op of stelt dit in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | byte |  |
+
+### setMargin(Margins value) {#setMargin-com.aspose.note.Margins-}
+```
+public void setMargin(Margins value)
+```
+
+
+Haalt de marge op of stelt deze in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| value | [Margins](../../com.aspose.note/margins) |  |
+
+### setPageContentRevisionSummary(RevisionSummary value) {#setPageContentRevisionSummary-com.aspose.note.RevisionSummary-}
+```
+public void setPageContentRevisionSummary(RevisionSummary value)
+```
+
+
+Haalt de revisiesamenvatting voor de pagina en zijn onderliggende knooppunten op of stelt deze in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| value | [RevisionSummary](../../com.aspose.note/revisionsummary) |  |
+
+### setPageLayoutSize(Dimension2D value) {#setPageLayoutSize-java.awt.geom.Dimension2D-}
+```
+public final void setPageLayoutSize(Dimension2D value)
+```
+
+
+Stelt de lay-outgrootte van de pagina in die in de editor wordt weergegeven.
+
+--------------------
+
+Deze waarde wordt door de Microsoft OneNote‑applicatie gebruikt om de onderliggende paginalay-out weer te geven wanneer het document wordt geopend. Het heeft verder geen invloed op het afdrukken en opslaan van het document. Wanneer de eigenschap Page.SizeType is ingesteld op PageSizeType.SizeByContent, geeft deze eigenschap de werkelijke grootte van de inhoud terug.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.awt.geom.Dimension2D |  |
+
+### setSizeType(int value) {#setSizeType-int-}
+```
+public final void setSizeType(int value)
+```
+
+
+Haalt het type grootte van een pagina op of stelt dit in.
+
+--------------------
+
+Standaard wordt een pagina automatisch aangepast in grootte. De standaardwaarde is [PageSizeType.SizeByContent](../../com.aspose.note/pagesizetype\\#SizeByContent).
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+
+### setTitle(Title value) {#setTitle-com.aspose.note.Title-}
+```
+public void setTitle(Title value)
+```
+
+
+Haalt op of stelt de titel in.
+
+Waarde: De `Title`.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| value | [Title](../../com.aspose.note/title) |  |
+

--- a/netherlands/java/com.aspose.note/pagehistory/_index.md
+++ b/netherlands/java/com.aspose.note/pagehistory/_index.md
@@ -1,0 +1,260 @@
+---
+title: "PageHistory"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt de paginageschiedenis voor."
+type: docs
+weight: 70
+url: /nl/java/com.aspose.note/pagehistory/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+com.aspose.ms.System.Collections.Generic.IGenericList
+```
+public class PageHistory implements System.Collections.Generic.IGenericList<Page>
+```
+
+Stelt de paginageschiedenis voor.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [PageHistory(Page page)](#PageHistory-com.aspose.note.Page-) | Initialiseert een nieuw exemplaar van de `PageHistory`-klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [addItem(Page item)](#addItem-com.aspose.note.Page-) | Voegt de paginaversie toe aan het einde van de `PageHistory`. |
+| [addRange(System.Collections.Generic.IGenericEnumerable&lt;Page&gt; items)](#addRange-com.aspose.ms.System.Collections.Generic.IGenericEnumerable-com.aspose.note.Page--) | Voegt de paginaversies toe aan het einde van de `PageHistory`. |
+| [clear()](#clear--) | Leegt de paginageschiedenis. |
+| [containsItem(Page item)](#containsItem-com.aspose.note.Page-) | Bepaalt of de paginageschiedenis de paginaversie bevat. |
+| [copyToTArray(Page[] array, int arrayIndex)](#copyToTArray-com.aspose.note.Page---int-) | Kopieert de paginaversies naar een array, beginnend bij een bepaalde index.. |
+| [getCurrent()](#getCurrent--) | Haalt de huidige paginaversie op. |
+| [get_Item(int index)](#get-Item-int-) | Haalt op of stelt de paginaversie in op de opgegeven index van de `PageHistory`. |
+| [indexOfItem(Page item)](#indexOfItem-com.aspose.note.Page-) | Bepaalt de index van een specifieke paginaversie in de paginageschiedenis. |
+| [insertItem(int index, Page item)](#insertItem-int-com.aspose.note.Page-) | Voegt een paginaversie in de paginageschiedenis in. |
+| [isReadOnly()](#isReadOnly--) | Haalt een waarde op die aangeeft of de paginageschiedenis alleen-lezen is. |
+| [iterator()](#iterator--) | Retourneert een enumerator die door de kindknopen van de `PageHistory` iterereert. |
+| [removeAt(int index)](#removeAt-int-) | Verwijdert de paginaversie op de opgegeven index van de `PageHistory`. |
+| [removeItem(Page item)](#removeItem-com.aspose.note.Page-) | Verwijdert de paginaversie uit de `PageHistory`. |
+| [removeRange(int index, int count)](#removeRange-int-int-) | Verwijdert een reeks paginaversies uit de `PageHistory`. |
+| [set_Item(int index, Page value)](#set-Item-int-com.aspose.note.Page-) | Haalt op of stelt de paginaversie in op de opgegeven index van de `PageHistory`. |
+| [size()](#size--) | Haalt het aantal paginaversies op in de paginageschiedenis. |
+### PageHistory(Page page) {#PageHistory-com.aspose.note.Page-}
+```
+public PageHistory(Page page)
+```
+
+
+Initialiseert een nieuw exemplaar van de `PageHistory`-klasse.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.note/page) | De huidige paginaversie. |
+
+### addItem(Page item) {#addItem-com.aspose.note.Page-}
+```
+public void addItem(Page item)
+```
+
+
+Voegt de paginaversie toe aan het einde van de `PageHistory`.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| item | [Page](../../com.aspose.note/page) | De paginaversie. |
+
+### addRange(System.Collections.Generic.IGenericEnumerable&lt;Page&gt; items) {#addRange-com.aspose.ms.System.Collections.Generic.IGenericEnumerable-com.aspose.note.Page--}
+```
+public void addRange(System.Collections.Generic.IGenericEnumerable<Page> items)
+```
+
+
+Voegt de paginaversies toe aan het einde van de `PageHistory`.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| items | com.aspose.ms.System.Collections.Generic.IGenericEnumerable&lt;com.aspose.note.Page&gt; | De `IEnumerable\{Page\}` collectie van paginaversies. |
+
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Leegt de paginageschiedenis.
+
+### containsItem(Page item) {#containsItem-com.aspose.note.Page-}
+```
+public boolean containsItem(Page item)
+```
+
+
+Bepaalt of de paginageschiedenis de paginaversie bevat.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| item | [Page](../../com.aspose.note/page) | De paginaversie. |
+
+**Returns:**
+boolean - De `bool`.
+### copyToTArray(Page[] array, int arrayIndex) {#copyToTArray-com.aspose.note.Page---int-}
+```
+public void copyToTArray(Page[] array, int arrayIndex)
+```
+
+
+Kopieert de paginaversies naar een array, beginnend bij een bepaalde index..
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| array | [Page\[\]](../../com.aspose.note/page) | De doelarray. |
+| arrayIndex | int | De array-index. |
+
+### getCurrent() {#getCurrent--}
+```
+public Page getCurrent()
+```
+
+
+Haalt de huidige paginaversie op.
+
+**Returns:**
+[Page](../../com.aspose.note/page)
+### get_Item(int index) {#get-Item-int-}
+```
+public Page get_Item(int index)
+```
+
+
+Haalt op of stelt de paginaversie in op de opgegeven index van de `PageHistory`.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| index | int | De index. |
+
+**Returns:**
+[Page](../../com.aspose.note/page) - The page version.
+### indexOfItem(Page item) {#indexOfItem-com.aspose.note.Page-}
+```
+public int indexOfItem(Page item)
+```
+
+
+Bepaalt de index van een specifieke paginaversie in de paginageschiedenis.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| item | [Page](../../com.aspose.note/page) | De paginaversie. |
+
+**Returns:**
+int - De `int`.
+### insertItem(int index, Page item) {#insertItem-int-com.aspose.note.Page-}
+```
+public void insertItem(int index, Page item)
+```
+
+
+Voegt een paginaversie in de paginageschiedenis in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| index | int | De index. |
+| item | [Page](../../com.aspose.note/page) | De paginaversie. |
+
+### isReadOnly() {#isReadOnly--}
+```
+public boolean isReadOnly()
+```
+
+
+Haalt een waarde op die aangeeft of de paginageschiedenis alleen-lezen is.
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public System.Collections.Generic.IGenericEnumerator<Page> iterator()
+```
+
+
+Retourneert een enumerator die door de kindknopen van de `PageHistory` iterereert.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;com.aspose.note.Page&gt; - De `IEnumerator`.
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+Verwijdert de paginaversie op de opgegeven index van de `PageHistory`.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| index | int | De index. |
+
+### removeItem(Page item) {#removeItem-com.aspose.note.Page-}
+```
+public boolean removeItem(Page item)
+```
+
+
+Verwijdert de paginaversie uit de `PageHistory`.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| item | [Page](../../com.aspose.note/page) | De paginaversie. |
+
+**Returns:**
+boolean - De `bool`.
+### removeRange(int index, int count) {#removeRange-int-int-}
+```
+public void removeRange(int index, int count)
+```
+
+
+Verwijdert een reeks paginaversies uit de `PageHistory`.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| index | int | De index. |
+| count | int | Het aantal. |
+
+### set_Item(int index, Page value) {#set-Item-int-com.aspose.note.Page-}
+```
+public void set_Item(int index, Page value)
+```
+
+
+Haalt op of stelt de paginaversie in op de opgegeven index van de `PageHistory`.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| index | int | De index. |
+| value | [Page](../../com.aspose.note/page) |  |
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+Haalt het aantal paginaversies op in de paginageschiedenis.
+
+**Returns:**
+int

--- a/netherlands/java/com.aspose.note/pagesavingargs/_index.md
+++ b/netherlands/java/com.aspose.note/pagesavingargs/_index.md
@@ -1,0 +1,31 @@
+---
+title: "PageSavingArgs"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Levert gegevens voor het PageSaving event."
+type: docs
+weight: 71
+url: /nl/java/com.aspose.note/pagesavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.ResourceSavingArgs](../../com.aspose.note/resourcesavingargs)
+```
+public class PageSavingArgs extends ResourceSavingArgs
+```
+
+Levert gegevens voor het PageSaving event.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getPageIndex()](#getPageIndex--) | Huidige paginapositie. |
+### getPageIndex() {#getPageIndex--}
+```
+public final int getPageIndex()
+```
+
+
+Huidige paginapositie.
+
+**Returns:**
+int

--- a/netherlands/java/com.aspose.note/pagesettings/_index.md
+++ b/netherlands/java/com.aspose.note/pagesettings/_index.md
@@ -1,0 +1,64 @@
+---
+title: "PageSettings"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt de lay-outinstellingen voor een pagina voor."
+type: docs
+weight: 72
+url: /nl/java/com.aspose.note/pagesettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSettings
+```
+
+Stelt de lay-outinstellingen voor een pagina voor.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getA4()](#getA4--) | Haalt de instellingen op voor de A4-pagina. |
+| [getA4NoHeightLimit()](#getA4NoHeightLimit--) | Haalt de instellingen op voor de A4-pagina met onbeperkte hoogte. |
+| [getLetter()](#getLetter--) | Haalt de instellingen op voor de Letter-pagina. |
+| [getLetterNoHeightLimit()](#getLetterNoHeightLimit--) | Haalt de instellingen op voor de Letter-pagina met onbeperkte hoogte. |
+### getA4() {#getA4--}
+```
+public static PageSettings getA4()
+```
+
+
+Haalt de instellingen op voor de A4-pagina.
+
+**Returns:**
+[PageSettings](../../com.aspose.note/pagesettings)
+### getA4NoHeightLimit() {#getA4NoHeightLimit--}
+```
+public static PageSettings getA4NoHeightLimit()
+```
+
+
+Haalt de instellingen op voor de A4-pagina met onbeperkte hoogte.
+
+**Returns:**
+[PageSettings](../../com.aspose.note/pagesettings)
+### getLetter() {#getLetter--}
+```
+public static PageSettings getLetter()
+```
+
+
+Haalt de instellingen op voor de Letter-pagina.
+
+**Returns:**
+[PageSettings](../../com.aspose.note/pagesettings)
+### getLetterNoHeightLimit() {#getLetterNoHeightLimit--}
+```
+public static PageSettings getLetterNoHeightLimit()
+```
+
+
+Haalt de instellingen op voor de Letter-pagina met onbeperkte hoogte.
+
+**Returns:**
+[PageSettings](../../com.aspose.note/pagesettings)

--- a/netherlands/java/com.aspose.note/pagesizetype/_index.md
+++ b/netherlands/java/com.aspose.note/pagesizetype/_index.md
@@ -1,0 +1,164 @@
+---
+title: "PageSizeType"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Specificeert de grootte van het paginaknooppunttype."
+type: docs
+weight: 73
+url: /nl/java/com.aspose.note/pagesizetype/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class PageSizeType extends System.Enum
+```
+
+Specificeert de grootte van het paginaknooppunttype.
+## Velden
+
+| Veld | Beschrijving |
+| --- | --- |
+| [ANSILetter](#ANSILetter) | ANSI letter (8,5\" x 11\"). |
+| [ANSITabloid](#ANSITabloid) | ANSI tabloid (11\" x 17\"). |
+| [Billfold](#Billfold) | Portemonnee (3,75\" x 6,75\"). |
+| [Custom](#Custom) | Aangepaste grootte. |
+| [ISOA3](#ISOA3) | ISO A3 (297 mm x 420 mm). |
+| [ISOA4](#ISOA4) | ISO A4 (210 mm x 297 mm). |
+| [ISOA5](#ISOA5) | ISO A5 (148mm x 210mm). |
+| [ISOA6](#ISOA6) | ISO A6 (105mm x 148mm). |
+| [IndexCard](#IndexCard) | Indexkaart (3" x 5"). |
+| [JISB4](#JISB4) | JIS B4 (257mm x 364mm). |
+| [JISB5](#JISB5) | JIS B5 (182mm x 257mm). |
+| [JISB6](#JISB6) | JIS B6 (128mm x 182mm). |
+| [JapanesePostcard](#JapanesePostcard) | Japanse ansichtkaart (100mm x 148mm). |
+| [SizeByContent](#SizeByContent) | De pagina heeft geen vaste grootte. |
+| [USLegal](#USLegal) | VS |
+| [USStatement](#USStatement) | VS |
+### ANSILetter {#ANSILetter}
+```
+public static final int ANSILetter
+```
+
+
+ANSI letter (8,5\" x 11\").
+
+### ANSITabloid {#ANSITabloid}
+```
+public static final int ANSITabloid
+```
+
+
+ANSI tabloid (11\" x 17\").
+
+### Billfold {#Billfold}
+```
+public static final int Billfold
+```
+
+
+Portemonnee (3,75\" x 6,75\").
+
+### Custom {#Custom}
+```
+public static final int Custom
+```
+
+
+Aangepaste grootte.
+
+### ISOA3 {#ISOA3}
+```
+public static final int ISOA3
+```
+
+
+ISO A3 (297 mm x 420 mm).
+
+### ISOA4 {#ISOA4}
+```
+public static final int ISOA4
+```
+
+
+ISO A4 (210 mm x 297 mm).
+
+### ISOA5 {#ISOA5}
+```
+public static final int ISOA5
+```
+
+
+ISO A5 (148mm x 210mm).
+
+### ISOA6 {#ISOA6}
+```
+public static final int ISOA6
+```
+
+
+ISO A6 (105mm x 148mm).
+
+### IndexCard {#IndexCard}
+```
+public static final int IndexCard
+```
+
+
+Indexkaart (3" x 5").
+
+### JISB4 {#JISB4}
+```
+public static final int JISB4
+```
+
+
+JIS B4 (257mm x 364mm).
+
+### JISB5 {#JISB5}
+```
+public static final int JISB5
+```
+
+
+JIS B5 (182mm x 257mm).
+
+### JISB6 {#JISB6}
+```
+public static final int JISB6
+```
+
+
+JIS B6 (128mm x 182mm).
+
+### JapanesePostcard {#JapanesePostcard}
+```
+public static final int JapanesePostcard
+```
+
+
+Japanse ansichtkaart (100mm x 148mm).
+
+### SizeByContent {#SizeByContent}
+```
+public static final int SizeByContent
+```
+
+
+De pagina heeft geen vaste grootte. Hij schaalt automatisch om alle inhoud erin te passen.
+
+### USLegal {#USLegal}
+```
+public static final int USLegal
+```
+
+
+VS legal (8.5" x 14").
+
+### USStatement {#USStatement}
+```
+public static final int USStatement
+```
+
+
+VS statement (5.5" x 8.5").
+

--- a/netherlands/java/com.aspose.note/pagesplittingalgorithm/_index.md
+++ b/netherlands/java/com.aspose.note/pagesplittingalgorithm/_index.md
@@ -1,0 +1,27 @@
+---
+title: "PageSplittingAlgorithm"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Basisklasse voor het splitsen van een object voor het geval het niet in de oorspronkelijke pagina past."
+type: docs
+weight: 74
+url: /nl/java/com.aspose.note/pagesplittingalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class PageSplittingAlgorithm
+```
+
+Basisklasse voor het splitsen van een object als het niet in de oorspronkelijke pagina past.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [PageSplittingAlgorithm()](#PageSplittingAlgorithm--) |  |
+### PageSplittingAlgorithm() {#PageSplittingAlgorithm--}
+```
+public PageSplittingAlgorithm()
+```
+
+

--- a/netherlands/java/com.aspose.note/paragraphstyle/_index.md
+++ b/netherlands/java/com.aspose.note/paragraphstyle/_index.md
@@ -1,0 +1,90 @@
+---
+title: "ParagraphStyle"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Tekststijlinstellingen die gebruikt worden als er geen overeenkomend TextStyle-object in de collectie is, of als dit object geen benodigde instelling specificeert."
+type: docs
+weight: 75
+url: /nl/java/com.aspose.note/paragraphstyle/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.note.Style
+
+**All Implemented Interfaces:**
+com.aspose.ms.System.IEquatable, java.lang.Cloneable
+```
+public final class ParagraphStyle extends Style<ParagraphStyle> implements System.IEquatable<ParagraphStyle>, Cloneable
+```
+
+Tekststijlinstellingen die gebruikt worden als er geen overeenkomend TextStyle-object in de [RichText.getStyles](../../com.aspose.note/richtext\\#getStyles) collectie is, of als dit object geen benodigde instelling specificeert.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [ParagraphStyle()](#ParagraphStyle--) | Initialiseert een nieuw exemplaar van de [ParagraphStyle](../../com.aspose.note/paragraphstyle) klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [equals(ParagraphStyle other)](#equals-com.aspose.note.ParagraphStyle-) | Bepaalt of het opgegeven object gelijk is aan het huidige object. |
+| [equals(Object obj)](#equals-java.lang.Object-) | Bepaalt of het opgegeven object gelijk is aan het huidige object. |
+| [getDefault()](#getDefault--) | Haalt de ParagraphStyle op met standaardinstellingen. |
+| [hashCode()](#hashCode--) | Dient als een hash-functie voor het type. |
+### ParagraphStyle() {#ParagraphStyle--}
+```
+public ParagraphStyle()
+```
+
+
+Initialiseert een nieuw exemplaar van de [ParagraphStyle](../../com.aspose.note/paragraphstyle) klasse.
+
+### equals(ParagraphStyle other) {#equals-com.aspose.note.ParagraphStyle-}
+```
+public final boolean equals(ParagraphStyle other)
+```
+
+
+Bepaalt of het opgegeven object gelijk is aan het huidige object.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| other | [ParagraphStyle](../../com.aspose.note/paragraphstyle) | Het object. |
+
+**Returns:**
+boolean - De `boolean`.
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Bepaalt of het opgegeven object gelijk is aan het huidige object.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| obj | java.lang.Object | Het object. |
+
+**Returns:**
+boolean - De `boolean`.
+### getDefault() {#getDefault--}
+```
+public static ParagraphStyle getDefault()
+```
+
+
+Haalt de ParagraphStyle op met standaardinstellingen.
+
+**Returns:**
+[ParagraphStyle](../../com.aspose.note/paragraphstyle)
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als een hash-functie voor het type.
+
+**Returns:**
+int - De `int`.

--- a/netherlands/java/com.aspose.note/pdfimagecompression/_index.md
+++ b/netherlands/java/com.aspose.note/pdfimagecompression/_index.md
@@ -1,0 +1,56 @@
+---
+title: "PdfImageCompression"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Specificeert het type compressie dat op afbeeldingen in het PDF‑bestand wordt toegepast."
+type: docs
+weight: 76
+url: /nl/java/com.aspose.note/pdfimagecompression/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class PdfImageCompression extends System.Enum
+```
+
+Specificeert het type compressie dat op afbeeldingen in het PDF‑bestand wordt toegepast.
+## Velden
+
+| Veld | Beschrijving |
+| --- | --- |
+| [Auto](#Auto) | Selecteert automatisch de meest geschikte compressie voor elke afbeelding. |
+| [Flate](#Flate) | Flate compressie (verliesloos). |
+| [Jpeg](#Jpeg) | Jpeg-compressie. |
+| [None](#None) | Er wordt geen compressie gebruikt bij het opslaan van afbeeldingen. |
+### Auto {#Auto}
+```
+public static final int Auto
+```
+
+
+Selecteert automatisch de meest geschikte compressie voor elke afbeelding.
+
+### Flate {#Flate}
+```
+public static final int Flate
+```
+
+
+Flate compressie (verliesloos).
+
+### Jpeg {#Jpeg}
+```
+public static final int Jpeg
+```
+
+
+Jpeg-compressie. Ondersteunt geen transparantie.
+
+### None {#None}
+```
+public static final int None
+```
+
+
+Er wordt geen compressie gebruikt bij het opslaan van afbeeldingen.
+

--- a/netherlands/java/com.aspose.note/pdfsaveoptions/_index.md
+++ b/netherlands/java/com.aspose.note/pdfsaveoptions/_index.md
@@ -1,0 +1,145 @@
+---
+title: "PdfSaveOptions"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Staat toe extra opties op te geven bij het renderen van documentpagina's naar PDF."
+type: docs
+weight: 77
+url: /nl/java/com.aspose.note/pdfsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.SaveOptions](../../com.aspose.note/saveoptions)
+```
+public final class PdfSaveOptions extends SaveOptions
+```
+
+Staat toe extra opties op te geven bij het renderen van documentpagina's naar PDF.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [PdfSaveOptions()](#PdfSaveOptions--) | Initialiseert een nieuw exemplaar van de `PdfSaveOptions` klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getImageCompression()](#getImageCompression--) | Haalt het type compressie op dat wordt toegepast op afbeeldingen in het PDF‑bestand. |
+| [getJpegQuality()](#getJpegQuality--) | Haalt een waarde op die de kwaliteit van de JPEG‑afbeeldingen in het PDF‑document bepaalt. |
+| [getPageSettings()](#getPageSettings--) | Haalt op of stelt de pagina-instellingen in voor elke pagina in het document. |
+| [getPageSplittingAlgorithm()](#getPageSplittingAlgorithm--) | Haalt op of stelt het algoritme in dat wordt gebruikt voor het splitsen van pagina's. |
+| [setImageCompression(int value)](#setImageCompression-int-) | Stelt het type compressie in dat wordt toegepast op afbeeldingen in het PDF‑bestand. |
+| [setJpegQuality(int value)](#setJpegQuality-int-) | Stelt een waarde in die de kwaliteit van de JPEG‑afbeeldingen in het PDF‑document bepaalt. |
+| [setPageSettings(PageSettings value)](#setPageSettings-com.aspose.note.PageSettings-) | Haalt op of stelt de pagina-instellingen in voor elke pagina in het document. |
+| [setPageSplittingAlgorithm(PageSplittingAlgorithm value)](#setPageSplittingAlgorithm-com.aspose.note.PageSplittingAlgorithm-) | Haalt op of stelt het algoritme in dat wordt gebruikt voor het splitsen van pagina's. |
+### PdfSaveOptions() {#PdfSaveOptions--}
+```
+public PdfSaveOptions()
+```
+
+
+Initialiseert een nieuw exemplaar van de `PdfSaveOptions` klasse.
+
+### getImageCompression() {#getImageCompression--}
+```
+public final int getImageCompression()
+```
+
+
+Haalt het type compressie op dat wordt toegepast op afbeeldingen in het PDF‑bestand.
+
+**Returns:**
+int
+### getJpegQuality() {#getJpegQuality--}
+```
+public final int getJpegQuality()
+```
+
+
+Haalt een waarde op die de kwaliteit van de JPEG‑afbeeldingen in het PDF‑document bepaalt. De waarde kan variëren van 0 tot 100, waarbij 0 de slechtste kwaliteit maar maximale compressie betekent en 100 de beste kwaliteit maar minimale compressie.
+
+--------------------
+
+De standaardwaarde is 90.
+
+**Returns:**
+int
+### getPageSettings() {#getPageSettings--}
+```
+public PageSettings getPageSettings()
+```
+
+
+Haalt op of stelt de pagina-instellingen in voor elke pagina in het document. Standaard hangt dit af van CurrentUICulture, \*US-culturen hebben de letter‑instelling, andere hebben A4‑instellingen.
+
+**Returns:**
+[PageSettings](../../com.aspose.note/pagesettings)
+### getPageSplittingAlgorithm() {#getPageSplittingAlgorithm--}
+```
+public PageSplittingAlgorithm getPageSplittingAlgorithm()
+```
+
+
+Haalt op of stelt het algoritme in dat wordt gebruikt voor het splitsen van pagina's.
+
+Waarde: De `PageSplittingAlgorithm`.
+
+**Returns:**
+[PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm)
+### setImageCompression(int value) {#setImageCompression-int-}
+```
+public final void setImageCompression(int value)
+```
+
+
+Stelt het type compressie in dat wordt toegepast op afbeeldingen in het PDF‑bestand.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+
+### setJpegQuality(int value) {#setJpegQuality-int-}
+```
+public final void setJpegQuality(int value)
+```
+
+
+Stelt een waarde in die de kwaliteit van de JPEG‑afbeeldingen in het PDF‑document bepaalt. De waarde kan variëren van 0 tot 100, waarbij 0 de slechtste kwaliteit maar maximale compressie betekent en 100 de beste kwaliteit maar minimale compressie.
+
+--------------------
+
+De standaardwaarde is 90.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+
+### setPageSettings(PageSettings value) {#setPageSettings-com.aspose.note.PageSettings-}
+```
+public void setPageSettings(PageSettings value)
+```
+
+
+Haalt op of stelt de pagina-instellingen in voor elke pagina in het document. Standaard hangt dit af van CurrentUICulture, \*US-culturen hebben de letter‑instelling, andere hebben A4‑instellingen.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| value | [PageSettings](../../com.aspose.note/pagesettings) |  |
+
+### setPageSplittingAlgorithm(PageSplittingAlgorithm value) {#setPageSplittingAlgorithm-com.aspose.note.PageSplittingAlgorithm-}
+```
+public void setPageSplittingAlgorithm(PageSplittingAlgorithm value)
+```
+
+
+Haalt op of stelt het algoritme in dat wordt gebruikt voor het splitsen van pagina's.
+
+Waarde: De `PageSplittingAlgorithm`.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| value | [PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm) |  |
+

--- a/netherlands/java/com.aspose.note/printoptions/_index.md
+++ b/netherlands/java/com.aspose.note/printoptions/_index.md
@@ -1,0 +1,145 @@
+---
+title: "PrintOptions"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Opties die worden gebruikt om een document af te drukken."
+type: docs
+weight: 78
+url: /nl/java/com.aspose.note/printoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PrintOptions
+```
+
+Opties die worden gebruikt om een document af te drukken.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [PrintOptions()](#PrintOptions--) | Initialiseert een nieuw exemplaar van de `PrintOptions`-klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getDocumentName()](#getDocumentName--) | Haalt of stelt de documentnaam in die moet worden weergegeven (bijvoorbeeld in een afdrukstatusdialoogvenster of printerwachtrij) tijdens het afdrukken van het document. |
+| [getPageSplittingAlgorithm()](#getPageSplittingAlgorithm--) | Haalt op of stelt het algoritme in dat wordt gebruikt voor het splitsen van pagina's. |
+| [getPrinterSettings()](#getPrinterSettings--) | Haalt of stelt de printerinstellingen in. |
+| [getResolution()](#getResolution--) | Haalt of stelt de resolutie voor de gegenereerde afbeeldingen in, in dots per inch. |
+| [setDocumentName(String value)](#setDocumentName-java.lang.String-) | Haalt of stelt de documentnaam in die moet worden weergegeven (bijvoorbeeld in een afdrukstatusdialoogvenster of printerwachtrij) tijdens het afdrukken van het document. |
+| [setPageSplittingAlgorithm(PageSplittingAlgorithm value)](#setPageSplittingAlgorithm-com.aspose.note.PageSplittingAlgorithm-) | Haalt op of stelt het algoritme in dat wordt gebruikt voor het splitsen van pagina's. |
+| [setPrinterSettings(AttributeSet value)](#setPrinterSettings-javax.print.attribute.AttributeSet-) | Haalt of stelt de printerinstellingen in. |
+| [setResolution(float value)](#setResolution-float-) | Haalt of stelt de resolutie voor de gegenereerde afbeeldingen in, in dots per inch. |
+### PrintOptions() {#PrintOptions--}
+```
+public PrintOptions()
+```
+
+
+Initialiseert een nieuw exemplaar van de `PrintOptions`-klasse.
+
+### getDocumentName() {#getDocumentName--}
+```
+public String getDocumentName()
+```
+
+
+Haalt of stelt de documentnaam in die moet worden weergegeven (bijvoorbeeld in een afdrukstatusdialoogvenster of printerwachtrij) tijdens het afdrukken van het document.
+
+**Returns:**
+java.lang.String
+### getPageSplittingAlgorithm() {#getPageSplittingAlgorithm--}
+```
+public PageSplittingAlgorithm getPageSplittingAlgorithm()
+```
+
+
+Haalt op of stelt het algoritme in dat wordt gebruikt voor het splitsen van pagina's.
+
+Waarde: De `PageSplittingAlgorithm`.
+
+**Returns:**
+[PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm)
+### getPrinterSettings() {#getPrinterSettings--}
+```
+public AttributeSet getPrinterSettings()
+```
+
+
+Haalt of stelt de printerinstellingen in.
+
+**Returns:**
+javax.print.attribute.AttributeSet
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+Haalt of stelt de resolutie voor de gegenereerde afbeeldingen in, in dots per inch.
+
+--------------------
+
+De standaardwaarde is 96.
+
+**Returns:**
+float
+### setDocumentName(String value) {#setDocumentName-java.lang.String-}
+```
+public void setDocumentName(String value)
+```
+
+
+Haalt of stelt de documentnaam in die moet worden weergegeven (bijvoorbeeld in een afdrukstatusdialoogvenster of printerwachtrij) tijdens het afdrukken van het document.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+
+### setPageSplittingAlgorithm(PageSplittingAlgorithm value) {#setPageSplittingAlgorithm-com.aspose.note.PageSplittingAlgorithm-}
+```
+public void setPageSplittingAlgorithm(PageSplittingAlgorithm value)
+```
+
+
+Haalt op of stelt het algoritme in dat wordt gebruikt voor het splitsen van pagina's.
+
+Waarde: De `PageSplittingAlgorithm`.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| value | [PageSplittingAlgorithm](../../com.aspose.note/pagesplittingalgorithm) |  |
+
+### setPrinterSettings(AttributeSet value) {#setPrinterSettings-javax.print.attribute.AttributeSet-}
+```
+public void setPrinterSettings(AttributeSet value)
+```
+
+
+Haalt of stelt de printerinstellingen in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | javax.print.attribute.AttributeSet |  |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+Haalt of stelt de resolutie voor de gegenereerde afbeeldingen in, in dots per inch.
+
+--------------------
+
+De standaardwaarde is 96.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+

--- a/netherlands/java/com.aspose.note/resourceexporttype/_index.md
+++ b/netherlands/java/com.aspose.note/resourceexporttype/_index.md
@@ -1,0 +1,39 @@
+---
+title: "ResourceExportType"
+second_title: "Aspose.Note for Java API-referentie"
+description: 
+type: docs
+weight: 79
+url: /nl/java/com.aspose.note/resourceexporttype/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class ResourceExportType extends System.Enum
+```
+## Velden
+
+| Veld | Beschrijving |
+| --- | --- |
+| [ExportAsStream](#ExportAsStream) |  |
+| [ExportEmbedded](#ExportEmbedded) |  |
+| [NoExport](#NoExport) |  |
+### ExportAsStream {#ExportAsStream}
+```
+public static final int ExportAsStream
+```
+
+
+### ExportEmbedded {#ExportEmbedded}
+```
+public static final int ExportEmbedded
+```
+
+
+### NoExport {#NoExport}
+```
+public static final int NoExport
+```
+
+

--- a/netherlands/java/com.aspose.note/resourcesavingargs/_index.md
+++ b/netherlands/java/com.aspose.note/resourcesavingargs/_index.md
@@ -1,0 +1,117 @@
+---
+title: "ResourceSavingArgs"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Levert gegevens voor het ResourceSaving event."
+type: docs
+weight: 80
+url: /nl/java/com.aspose.note/resourcesavingargs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ResourceSavingArgs
+```
+
+Levert gegevens voor het ResourceSaving event.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getDocument()](#getDocument--) | Haalt het opslagdocument op. |
+| [getFileName()](#getFileName--) | Haalt de bestandsnaam op. |
+| [getKeepStreamOpen()](#getKeepStreamOpen--) | Haalt of stelt een waarde in die aangeeft of de stream open moet blijven. |
+| [getStream()](#getStream--) | Haalt of stelt de stream in die wordt gebruikt om de bron op te slaan. |
+| [getUri()](#getUri--) | Haalt of stelt de uri in om toegang te krijgen tot de opgeslagen bron. |
+| [setKeepStreamOpen(boolean value)](#setKeepStreamOpen-boolean-) | Haalt of stelt een waarde in die aangeeft of de stream open moet blijven. |
+| [setStream(OutputStream value)](#setStream-java.io.OutputStream-) | Haalt of stelt de stream in die wordt gebruikt om de bron op te slaan. |
+| [setUri(String value)](#setUri-java.lang.String-) | Haalt of stelt de uri in om toegang te krijgen tot de opgeslagen bron. |
+### getDocument() {#getDocument--}
+```
+public final Document getDocument()
+```
+
+
+Haalt het opslagdocument op.
+
+**Returns:**
+[Document](../../com.aspose.note/document)
+### getFileName() {#getFileName--}
+```
+public final String getFileName()
+```
+
+
+Haalt de bestandsnaam op.
+
+**Returns:**
+java.lang.String
+### getKeepStreamOpen() {#getKeepStreamOpen--}
+```
+public final boolean getKeepStreamOpen()
+```
+
+
+Haalt of stelt een waarde in die aangeeft of de stream open moet blijven.
+
+**Returns:**
+boolean
+### getStream() {#getStream--}
+```
+public final OutputStream getStream()
+```
+
+
+Haalt of stelt de stream in die wordt gebruikt om de bron op te slaan.
+
+**Returns:**
+java.io.OutputStream
+### getUri() {#getUri--}
+```
+public final String getUri()
+```
+
+
+Haalt of stelt de uri in om toegang te krijgen tot de opgeslagen bron.
+
+**Returns:**
+java.lang.String
+### setKeepStreamOpen(boolean value) {#setKeepStreamOpen-boolean-}
+```
+public final void setKeepStreamOpen(boolean value)
+```
+
+
+Haalt of stelt een waarde in die aangeeft of de stream open moet blijven.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+### setStream(OutputStream value) {#setStream-java.io.OutputStream-}
+```
+public final void setStream(OutputStream value)
+```
+
+
+Haalt of stelt de stream in die wordt gebruikt om de bron op te slaan.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.io.OutputStream |  |
+
+### setUri(String value) {#setUri-java.lang.String-}
+```
+public final void setUri(String value)
+```
+
+
+Haalt of stelt de uri in om toegang te krijgen tot de opgeslagen bron.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+

--- a/netherlands/java/com.aspose.note/revisionsummary/_index.md
+++ b/netherlands/java/com.aspose.note/revisionsummary/_index.md
@@ -1,0 +1,81 @@
+---
+title: "RevisionSummary"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een samenvatting voor de revisie van knooppunten voor."
+type: docs
+weight: 81
+url: /nl/java/com.aspose.note/revisionsummary/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RevisionSummary
+```
+
+Stelt een samenvatting voor van de revisie van een knoop.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [RevisionSummary()](#RevisionSummary--) |  |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getAuthorMostRecent()](#getAuthorMostRecent--) | Haalt op of stelt de meest recente auteur in. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | Haalt op of stelt de laatst gewijzigde tijd in. |
+| [setAuthorMostRecent(String value)](#setAuthorMostRecent-java.lang.String-) | Haalt op of stelt de meest recente auteur in. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | Haalt op of stelt de laatst gewijzigde tijd in. |
+### RevisionSummary() {#RevisionSummary--}
+```
+public RevisionSummary()
+```
+
+
+### getAuthorMostRecent() {#getAuthorMostRecent--}
+```
+public String getAuthorMostRecent()
+```
+
+
+Haalt op of stelt de meest recente auteur in.
+
+**Returns:**
+java.lang.String
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+Haalt op of stelt de laatst gewijzigde tijd in.
+
+**Returns:**
+java.util.Date
+### setAuthorMostRecent(String value) {#setAuthorMostRecent-java.lang.String-}
+```
+public void setAuthorMostRecent(String value)
+```
+
+
+Haalt op of stelt de meest recente auteur in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+Haalt op of stelt de laatst gewijzigde tijd in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Date |  |
+

--- a/netherlands/java/com.aspose.note/richtext/_index.md
+++ b/netherlands/java/com.aspose.note/richtext/_index.md
@@ -1,0 +1,804 @@
+---
+title: "RichText"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een rich text voor."
+type: docs
+weight: 82
+url: /nl/java/com.aspose.note/richtext/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node)
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode), [com.aspose.note.ITaggable](../../com.aspose.note/itaggable), com.aspose.ms.System.Collections.Generic.IGenericEnumerable
+```
+public class RichText extends Node implements IOutlineElementChildNode, ITaggable, System.Collections.Generic.IGenericEnumerable<Character>
+```
+
+Stelt een rich text voor.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [RichText()](#RichText--) | Initialiseert een nieuw exemplaar van de [RichText](../../com.aspose.note/richtext)-klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | Accepteert de bezoeker van de node. |
+| [append(String value)](#append-java.lang.String-) | Voegt een tekenreeks toe aan het laatste tekstbereik. |
+| [append(String value, TextStyle style)](#append-java.lang.String-com.aspose.note.TextStyle-) | Voegt een tekenreeks toe aan het einde. |
+| [appendFront(String value)](#appendFront-java.lang.String-) | Voegt een tekenreeks toe aan het begin van het eerste tekstbereik. |
+| [appendFront(String value, TextStyle style)](#appendFront-java.lang.String-com.aspose.note.TextStyle-) | Voegt een tekenreeks toe aan het begin. |
+| [clear()](#clear--) | Wis de inhoud van deze instantie. |
+| [getAlignment()](#getAlignment--) | Haalt de uitlijning op. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | Haalt de laatst gewijzigde tijd op. |
+| [getLength()](#getLength--) |  |
+| [getLineSpacing()](#getLineSpacing--) | Haalt de regelafstand op. |
+| [getParagraphStyle()](#getParagraphStyle--) | Haalt de alinea-stijl op. |
+| [getSpaceAfter()](#getSpaceAfter--) | Haalt de minimale hoeveelheid ruimte erna op. |
+| [getSpaceBefore()](#getSpaceBefore--) | Haalt de minimale hoeveelheid ruimte ervoor op. |
+| [getStyles()](#getStyles--) | Haalt de stijlen op. |
+| [getTags()](#getTags--) | Haalt de lijst met alle tags van een alinea op. |
+| [getText()](#getText--) | Haalt de tekst op. |
+| [getTextRuns()](#getTextRuns--) |  |
+| [indexOf(char value)](#indexOf-char-) | Retourneert de nulgebaseerde index van de eerste voorkoming van het opgegeven Unicode‑teken in deze tekenreeks. |
+| [indexOf(char value, int startIndex)](#indexOf-char-int-) | Retourneert de nulgebaseerde index van de eerste voorkoming van het opgegeven Unicode‑teken in deze tekenreeks. |
+| [indexOf(char value, int startIndex, int count)](#indexOf-char-int-int-) | Retourneert de nulgebaseerde index van de eerste voorkoming van het opgegeven teken in deze instantie. |
+| [indexOf(String value)](#indexOf-java.lang.String-) | Retourneert de nulgebaseerde index van de eerste voorkoming van de opgegeven tekenreeks in deze instantie. |
+| [indexOf(String value, int startIndex)](#indexOf-java.lang.String-int-) | Retourneert de nulgebaseerde index van de eerste voorkoming van de opgegeven tekenreeks in deze instantie. |
+| [indexOf(String value, int startIndex, int count)](#indexOf-java.lang.String-int-int-) | Retourneert de nulgebaseerde index van de eerste voorkoming van de opgegeven tekenreeks in deze instantie. |
+| [indexOf(String value, int startIndex, int count, short comparisonType)](#indexOf-java.lang.String-int-int-short-) | Retourneert de nulgebaseerde index van de eerste voorkoming van de opgegeven tekenreeks in de huidige instantie. |
+| [indexOf(String value, short comparisonType)](#indexOf-java.lang.String-short-) | Retourneert de nulgebaseerde index van de eerste voorkoming van de opgegeven tekenreeks in de huidige instantie. |
+| [indexOf_Rename_Namesake(String value, int startIndex, short comparisonType)](#indexOf-Rename-Namesake-java.lang.String-int-short-) | Retourneert de nulgebaseerde index van de eerste voorkoming van de opgegeven tekenreeks in de huidige instantie. |
+| [insert(int startIndex, String value)](#insert-int-java.lang.String-) | Voegt een opgegeven tekenreeks in op een opgegeven indexpositie in deze instantie. |
+| [insert(int startIndex, String value, TextStyle style)](#insert-int-java.lang.String-com.aspose.note.TextStyle-) | Voegt een opgegeven tekenreeks met opgegeven stijl in op een opgegeven indexpositie in deze instantie. |
+| [iterator()](#iterator--) |  |
+| [remove(int startIndex)](#remove-int-) | Verwijdert alle tekens in de huidige instantie, beginnend op een opgegeven positie en doorgaan tot de laatste positie. |
+| [remove(int startIndex, int count)](#remove-int-int-) | Verwijdert een opgegeven aantal tekens in de huidige instantie beginnend op een opgegeven positie. |
+| [replace(char oldChar, char newChar)](#replace-char-char-) | Vervangt alle voorkomens van een opgegeven Unicode‑teken in deze instantie door een ander opgegeven Unicode‑teken. |
+| [replace(String oldValue, String newValue)](#replace-java.lang.String-java.lang.String-) | Vervangt alle voorkomens van een opgegeven tekenreeks in de huidige instantie door een andere opgegeven tekenreeks. |
+| [replace(String oldValue, String newValue, TextStyle style)](#replace-java.lang.String-java.lang.String-com.aspose.note.TextStyle-) | Vervangt alle voorkomens van een opgegeven tekenreeks in de huidige instantie door een andere opgegeven tekenreeks in opgegeven stijl. |
+| [setAlignment(int value)](#setAlignment-int-) | Stelt de uitlijning in. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | Stelt de laatst gewijzigde tijd in. |
+| [setLineSpacing(float value)](#setLineSpacing-float-) |  |
+| [setLineSpacing(Float value)](#setLineSpacing-java.lang.Float-) | Stelt de regelafstand in. |
+| [setParagraphStyle(ParagraphStyle value)](#setParagraphStyle-com.aspose.note.ParagraphStyle-) | Stelt de alinea‑stijl in. |
+| [setSpaceAfter(float value)](#setSpaceAfter-float-) |  |
+| [setSpaceAfter(Float value)](#setSpaceAfter-java.lang.Float-) | Stelt de minimale hoeveelheid ruimte erna in. |
+| [setSpaceBefore(float value)](#setSpaceBefore-float-) |  |
+| [setSpaceBefore(Float value)](#setSpaceBefore-java.lang.Float-) | Stelt de minimale hoeveelheid ruimte vóór in. |
+| [setText(String value)](#setText-java.lang.String-) | Stelt de tekst in. |
+| [trim()](#trim--) | Verwijdert alle leidende en volgende witruimtetekens. |
+| [trim(char trimChar)](#trim-char-) | Verwijdert alle leidende en volgende instanties van een teken. |
+| [trim(char[] trimChars)](#trim-char...-) | Verwijdert alle leidende en volgende voorkomens van een reeks tekens die in een array zijn gespecificeerd. |
+| [trimEnd()](#trimEnd--) | Verwijdert alle volgende witruimtetekens. |
+| [trimEnd(char trimChar)](#trimEnd-char-) | Verwijdert alle volgende voorkomens van een teken. |
+| [trimEnd(char[] trimChars)](#trimEnd-char...-) | Verwijdert alle volgende voorkomens van een reeks tekens die in een array zijn gespecificeerd. |
+| [trimStart()](#trimStart--) | Verwijdert alle leidende witruimtetekens. |
+| [trimStart(char trimChar)](#trimStart-char-) | Verwijdert alle leidende voorkomens van een gespecificeerd teken. |
+| [trimStart(char[] trimChars)](#trimStart-char...-) | Verwijdert alle leidende voorkomens van een reeks tekens die in een array zijn gespecificeerd. |
+### RichText() {#RichText--}
+```
+public RichText()
+```
+
+
+Initialiseert een nieuw exemplaar van de [RichText](../../com.aspose.note/richtext)-klasse.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+Accepteert de bezoeker van de node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | Het object van een klasse afgeleid van de [DocumentVisitor](../../com.aspose.note/documentvisitor). |
+
+### append(String value) {#append-java.lang.String-}
+```
+public RichText append(String value)
+```
+
+
+Voegt een tekenreeks toe aan het laatste tekstbereik.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String | De toegevoegde waarde. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### append(String value, TextStyle style) {#append-java.lang.String-com.aspose.note.TextStyle-}
+```
+public final RichText append(String value, TextStyle style)
+```
+
+
+Voegt een tekenreeks toe aan het einde.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String | De toegevoegde waarde. |
+| style | [TextStyle](../../com.aspose.note/textstyle) | De stijl van de toegevoegde tekenreeks. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### appendFront(String value) {#appendFront-java.lang.String-}
+```
+public RichText appendFront(String value)
+```
+
+
+Voegt een tekenreeks toe aan het begin van het eerste tekstbereik.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String | De toegevoegde waarde. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### appendFront(String value, TextStyle style) {#appendFront-java.lang.String-com.aspose.note.TextStyle-}
+```
+public RichText appendFront(String value, TextStyle style)
+```
+
+
+Voegt een tekenreeks toe aan het begin.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String | De toegevoegde waarde. |
+| style | [TextStyle](../../com.aspose.note/textstyle) | De stijl van de toegevoegde tekenreeks. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### clear() {#clear--}
+```
+public final RichText clear()
+```
+
+
+Wis de inhoud van deze instantie.
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+Haalt de uitlijning op.
+
+**Returns:**
+int
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+Haalt de laatst gewijzigde tijd op.
+
+**Returns:**
+java.util.Date
+### getLength() {#getLength--}
+```
+public final int getLength()
+```
+
+
+
+
+**Returns:**
+int
+### getLineSpacing() {#getLineSpacing--}
+```
+public Float getLineSpacing()
+```
+
+
+Haalt de regelafstand op.
+
+**Returns:**
+java.lang.Float
+### getParagraphStyle() {#getParagraphStyle--}
+```
+public final ParagraphStyle getParagraphStyle()
+```
+
+
+Haalt de alinea-stijl op. Deze instellingen worden gebruikt als er geen overeenkomend TextStyle-object in de [getStyles](../../com.aspose.note/richtext\#getStyles) collectie is, of dit object geen benodigde instelling specificeert.
+
+**Returns:**
+[ParagraphStyle](../../com.aspose.note/paragraphstyle)
+### getSpaceAfter() {#getSpaceAfter--}
+```
+public Float getSpaceAfter()
+```
+
+
+Haalt de minimale hoeveelheid ruimte erna op.
+
+**Returns:**
+java.lang.Float
+### getSpaceBefore() {#getSpaceBefore--}
+```
+public Float getSpaceBefore()
+```
+
+
+Haalt de minimale hoeveelheid ruimte ervoor op.
+
+**Returns:**
+java.lang.Float
+### getStyles() {#getStyles--}
+```
+public System.Collections.Generic.IGenericEnumerable<TextStyle> getStyles()
+```
+
+
+Haalt de stijlen op.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerable&lt;com.aspose.note.TextStyle&gt;
+### getTags() {#getTags--}
+```
+public final System.Collections.Generic.List<ITag> getTags()
+```
+
+
+Haalt de lijst met alle tags van een alinea op.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List&lt;com.aspose.note.ITag&gt;
+### getText() {#getText--}
+```
+public final String getText()
+```
+
+
+Haalt de tekst op. De tekenreeks MAG GEEN tekens bevatten met de waarde 10 (regelvoeding).
+
+**Returns:**
+java.lang.String
+### getTextRuns() {#getTextRuns--}
+```
+public final System.Collections.Generic.IGenericEnumerable<TextRun> getTextRuns()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerable&lt;com.aspose.note.TextRun&gt;
+### indexOf(char value) {#indexOf-char-}
+```
+public final int indexOf(char value)
+```
+
+
+Retourneert de nulgebaseerde index van de eerste voorkoming van het opgegeven Unicode‑teken in deze tekenreeks.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | char | De waarde. |
+
+**Returns:**
+int - De `int`.
+### indexOf(char value, int startIndex) {#indexOf-char-int-}
+```
+public final int indexOf(char value, int startIndex)
+```
+
+
+Retourneert de nul-gebaseerde index van de eerste voorkoming van het opgegeven Unicode-teken in deze tekenreeks. De zoekopdracht begint op een opgegeven tekenpositie.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | char | De waarde. |
+| startIndex | int | De startpositie van de zoekopdracht |
+
+**Returns:**
+int - De `int`.
+### indexOf(char value, int startIndex, int count) {#indexOf-char-int-int-}
+```
+public final int indexOf(char value, int startIndex, int count)
+```
+
+
+Retourneert de nul-gebaseerde index van de eerste voorkoming van het opgegeven teken in deze instantie. De zoekopdracht begint op een opgegeven tekenpositie en onderzoekt een opgegeven aantal tekenposities.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | char | De waarde. |
+| startIndex | int | De startpositie van de zoekopdracht |
+| count | int | Het aantal. |
+
+**Returns:**
+int - De `int`.
+### indexOf(String value) {#indexOf-java.lang.String-}
+```
+public final int indexOf(String value)
+```
+
+
+Retourneert de nulgebaseerde index van de eerste voorkoming van de opgegeven tekenreeks in deze instantie.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String | De waarde. |
+
+**Returns:**
+int - De `int`.
+### indexOf(String value, int startIndex) {#indexOf-java.lang.String-int-}
+```
+public final int indexOf(String value, int startIndex)
+```
+
+
+Geeft de nulgebaseerde index van de eerste voorkomen van de opgegeven tekenreeks in deze instantie terug. De zoekopdracht begint op een opgegeven tekenpositie.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String | De waarde. |
+| startIndex | int | De startpositie van de zoekopdracht |
+
+**Returns:**
+int - De `int`.
+### indexOf(String value, int startIndex, int count) {#indexOf-java.lang.String-int-int-}
+```
+public final int indexOf(String value, int startIndex, int count)
+```
+
+
+Geeft de nulgebaseerde index van de eerste voorkomen van de opgegeven tekenreeks in deze instantie terug. De zoekopdracht begint op een opgegeven tekenpositie en onderzoekt een opgegeven aantal tekenposities.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String | De waarde. |
+| startIndex | int | De startpositie van de zoekopdracht |
+| count | int | Het aantal. |
+
+**Returns:**
+int - De `int`.
+### indexOf(String value, int startIndex, int count, short comparisonType) {#indexOf-java.lang.String-int-int-short-}
+```
+public final int indexOf(String value, int startIndex, int count, short comparisonType)
+```
+
+
+Retourneert de nulgebaseerde index van de eerste voorkoming van de opgegeven tekenreeks in de huidige instantie.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String | De waarde. |
+| startIndex | int | De startpositie van de zoekopdracht |
+| count | int | Het aantal. |
+| comparisonType | short | Het type zoekopdracht dat moet worden gebruikt voor de opgegeven tekenreeks |
+
+**Returns:**
+int - De `int`.
+### indexOf(String value, short comparisonType) {#indexOf-java.lang.String-short-}
+```
+public final int indexOf(String value, short comparisonType)
+```
+
+
+Geeft de nulgebaseerde index van de eerste voorkomen van de opgegeven tekenreeks in de huidige instantie terug. Een parameter specificeert het type zoekopdracht dat moet worden gebruikt voor de opgegeven tekenreeks.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String | De waarde. |
+| comparisonType | short | Het type zoekopdracht dat moet worden gebruikt voor de opgegeven tekenreeks |
+
+**Returns:**
+int - De `int`.
+### indexOf_Rename_Namesake(String value, int startIndex, short comparisonType) {#indexOf-Rename-Namesake-java.lang.String-int-short-}
+```
+public final int indexOf_Rename_Namesake(String value, int startIndex, short comparisonType)
+```
+
+
+Geeft de nulgebaseerde index van de eerste voorkomen van de opgegeven tekenreeks in de huidige instantie terug. Parameters geven de startzoekpositie in de huidige tekenreeks en het type zoekopdracht dat moet worden gebruikt voor de opgegeven tekenreeks.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String | De waarde. |
+| startIndex | int | De startpositie van de zoekopdracht |
+| comparisonType | short | Het type zoekopdracht dat moet worden gebruikt voor de opgegeven tekenreeks |
+
+**Returns:**
+int - De `int`.
+### insert(int startIndex, String value) {#insert-int-java.lang.String-}
+```
+public final RichText insert(int startIndex, String value)
+```
+
+
+Voegt een opgegeven tekenreeks in op een opgegeven indexpositie in deze instantie.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| startIndex | int | De startindex. |
+| waarde | java.lang.String | De waarde. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### insert(int startIndex, String value, TextStyle style) {#insert-int-java.lang.String-com.aspose.note.TextStyle-}
+```
+public final RichText insert(int startIndex, String value, TextStyle style)
+```
+
+
+Voegt een opgegeven tekenreeks met opgegeven stijl in op een opgegeven indexpositie in deze instantie.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| startIndex | int | De startindex. |
+| waarde | java.lang.String | De waarde. |
+| style | [TextStyle](../../com.aspose.note/textstyle) | De stijl. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### iterator() {#iterator--}
+```
+public System.Collections.Generic.IGenericEnumerator<Character> iterator()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;java.lang.Character&gt;
+### remove(int startIndex) {#remove-int-}
+```
+public final RichText remove(int startIndex)
+```
+
+
+Verwijdert alle tekens in de huidige instantie, beginnend op een opgegeven positie en doorgaan tot de laatste positie.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| startIndex | int | De startindex. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### remove(int startIndex, int count) {#remove-int-int-}
+```
+public final RichText remove(int startIndex, int count)
+```
+
+
+Verwijdert een opgegeven aantal tekens in de huidige instantie beginnend op een opgegeven positie.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| startIndex | int | De startindex. |
+| count | int | Het aantal. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### replace(char oldChar, char newChar) {#replace-char-char-}
+```
+public final RichText replace(char oldChar, char newChar)
+```
+
+
+Vervangt alle voorkomens van een opgegeven Unicode‑teken in deze instantie door een ander opgegeven Unicode‑teken.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| oldChar | char | Het oude teken. |
+| newChar | char | Het nieuwe teken. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### replace(String oldValue, String newValue) {#replace-java.lang.String-java.lang.String-}
+```
+public final RichText replace(String oldValue, String newValue)
+```
+
+
+Vervangt alle voorkomens van een opgegeven tekenreeks in de huidige instantie door een andere opgegeven tekenreeks.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| oldValue | java.lang.String | De oude waarde. |
+| newValue | java.lang.String | De nieuwe waarde. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### replace(String oldValue, String newValue, TextStyle style) {#replace-java.lang.String-java.lang.String-com.aspose.note.TextStyle-}
+```
+public final RichText replace(String oldValue, String newValue, TextStyle style)
+```
+
+
+Vervangt alle voorkomens van een opgegeven tekenreeks in de huidige instantie door een andere opgegeven tekenreeks in opgegeven stijl.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| oldValue | java.lang.String | De oude waarde. |
+| newValue | java.lang.String | De nieuwe waarde. |
+| style | [TextStyle](../../com.aspose.note/textstyle) | De stijl van de nieuwe waarde. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+Stelt de uitlijning in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+Stelt de laatst gewijzigde tijd in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Date |  |
+
+### setLineSpacing(float value) {#setLineSpacing-float-}
+```
+public void setLineSpacing(float value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+
+### setLineSpacing(Float value) {#setLineSpacing-java.lang.Float-}
+```
+public void setLineSpacing(Float value)
+```
+
+
+Stelt de regelafstand in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.Float |  |
+
+### setParagraphStyle(ParagraphStyle value) {#setParagraphStyle-com.aspose.note.ParagraphStyle-}
+```
+public final void setParagraphStyle(ParagraphStyle value)
+```
+
+
+Stelt de alinea‑stijl in. Deze instellingen worden gebruikt als er geen overeenkomend TextStyle‑object in de [getStyles](../../com.aspose.note/richtext\#getStyles)‑collectie bestaat of dit object geen benodigde instelling opgeeft.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| value | [ParagraphStyle](../../com.aspose.note/paragraphstyle) |  |
+
+### setSpaceAfter(float value) {#setSpaceAfter-float-}
+```
+public void setSpaceAfter(float value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+
+### setSpaceAfter(Float value) {#setSpaceAfter-java.lang.Float-}
+```
+public void setSpaceAfter(Float value)
+```
+
+
+Stelt de minimale hoeveelheid ruimte erna in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.Float |  |
+
+### setSpaceBefore(float value) {#setSpaceBefore-float-}
+```
+public void setSpaceBefore(float value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+
+### setSpaceBefore(Float value) {#setSpaceBefore-java.lang.Float-}
+```
+public void setSpaceBefore(Float value)
+```
+
+
+Stelt de minimale hoeveelheid ruimte vóór in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.Float |  |
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public final void setText(String value)
+```
+
+
+Stelt de tekst in. De tekenreeks MAG GEEN tekens met de waarde 10 (regelvoeding) bevatten.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+
+### trim() {#trim--}
+```
+public final RichText trim()
+```
+
+
+Verwijdert alle leidende en volgende witruimtetekens.
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trim(char trimChar) {#trim-char-}
+```
+public final RichText trim(char trimChar)
+```
+
+
+Verwijdert alle leidende en volgende instanties van een teken.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| trimChar | char | Het trimteken. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trim(char[] trimChars) {#trim-char...-}
+```
+public final RichText trim(char[] trimChars)
+```
+
+
+Verwijdert alle leidende en volgende voorkomens van een reeks tekens die in een array zijn gespecificeerd.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| trimChars | char[] | De trimtekens. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trimEnd() {#trimEnd--}
+```
+public final RichText trimEnd()
+```
+
+
+Verwijdert alle volgende witruimtetekens.
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trimEnd(char trimChar) {#trimEnd-char-}
+```
+public final RichText trimEnd(char trimChar)
+```
+
+
+Verwijdert alle volgende voorkomens van een teken.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| trimChar | char | Het trimteken. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trimEnd(char[] trimChars) {#trimEnd-char...-}
+```
+public final RichText trimEnd(char[] trimChars)
+```
+
+
+Verwijdert alle volgende voorkomens van een reeks tekens die in een array zijn gespecificeerd.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| trimChars | char[] | De trimtekens. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trimStart() {#trimStart--}
+```
+public final RichText trimStart()
+```
+
+
+Verwijdert alle leidende witruimtetekens.
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trimStart(char trimChar) {#trimStart-char-}
+```
+public final RichText trimStart(char trimChar)
+```
+
+
+Verwijdert alle leidende voorkomens van een gespecificeerd teken.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| trimChar | char | Het trimteken. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).
+### trimStart(char[] trimChars) {#trimStart-char...-}
+```
+public final RichText trimStart(char[] trimChars)
+```
+
+
+Verwijdert alle leidende voorkomens van een reeks tekens die in een array zijn gespecificeerd.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| trimChars | char[] | De trimtekens. |
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext) - The [RichText](../../com.aspose.note/richtext).

--- a/netherlands/java/com.aspose.note/saveformat/_index.md
+++ b/netherlands/java/com.aspose.note/saveformat/_index.md
@@ -1,0 +1,92 @@
+---
+title: "SaveFormat"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Geeft het formaat aan waarin het document wordt opgeslagen."
+type: docs
+weight: 83
+url: /nl/java/com.aspose.note/saveformat/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class SaveFormat extends System.Enum
+```
+
+Geeft het formaat aan waarin het document wordt opgeslagen.
+## Velden
+
+| Veld | Beschrijving |
+| --- | --- |
+| [Bmp](#Bmp) | Geeft aan dat de uitvoer een BMP-bestand is. |
+| [Gif](#Gif) | Geeft aan dat de uitvoer een GIF-bestand is. |
+| [Html](#Html) | Geeft aan dat de uitvoer een HTML-bestand is. |
+| [Jpeg](#Jpeg) | Geeft aan dat de uitvoer een JPEG-bestand is. |
+| [One](#One) | Geeft aan dat de uitvoer een OneNote-bestand is. |
+| [Pdf](#Pdf) | Geeft aan dat de uitvoer een PDF-bestand is. |
+| [Png](#Png) | Geeft aan dat de uitvoer een PNG-bestand is. |
+| [Tiff](#Tiff) | Geeft aan dat de uitvoer een TIFF-bestand is. |
+### Bmp {#Bmp}
+```
+public static final int Bmp
+```
+
+
+Geeft aan dat de uitvoer een BMP-bestand is.
+
+### Gif {#Gif}
+```
+public static final int Gif
+```
+
+
+Geeft aan dat de uitvoer een GIF-bestand is.
+
+### Html {#Html}
+```
+public static final int Html
+```
+
+
+Geeft aan dat de uitvoer een HTML-bestand is.
+
+### Jpeg {#Jpeg}
+```
+public static final int Jpeg
+```
+
+
+Geeft aan dat de uitvoer een JPEG-bestand is.
+
+### One {#One}
+```
+public static final int One
+```
+
+
+Geeft aan dat de uitvoer een OneNote-bestand is.
+
+### Pdf {#Pdf}
+```
+public static final int Pdf
+```
+
+
+Geeft aan dat de uitvoer een PDF-bestand is.
+
+### Png {#Png}
+```
+public static final int Png
+```
+
+
+Geeft aan dat de uitvoer een PNG-bestand is.
+
+### Tiff {#Tiff}
+```
+public static final int Tiff
+```
+
+
+Geeft aan dat de uitvoer een TIFF-bestand is.
+

--- a/netherlands/java/com.aspose.note/saveformatconverter/_index.md
+++ b/netherlands/java/com.aspose.note/saveformatconverter/_index.md
@@ -1,0 +1,79 @@
+---
+title: "SaveFormatConverter"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De converter voor het opslagformaat."
+type: docs
+weight: 84
+url: /nl/java/com.aspose.note/saveformatconverter/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SaveFormatConverter
+```
+
+De converter voor het opslagformaat.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [SaveFormatConverter()](#SaveFormatConverter--) |  |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [convert(String value)](#convert-java.lang.String-) | De conversie. |
+| [deduceDocumentFileExtension(int format)](#deduceDocumentFileExtension-int-) |  |
+| [deduceNotebookFileExtension(int format)](#deduceNotebookFileExtension-int-) |  |
+### SaveFormatConverter() {#SaveFormatConverter--}
+```
+public SaveFormatConverter()
+```
+
+
+### convert(String value) {#convert-java.lang.String-}
+```
+public static int convert(String value)
+```
+
+
+De conversie.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String | De waarde. |
+
+**Returns:**
+int - De `SaveFormat`.
+### deduceDocumentFileExtension(int format) {#deduceDocumentFileExtension-int-}
+```
+public static String deduceDocumentFileExtension(int format)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| format | int |  |
+
+**Returns:**
+java.lang.String
+### deduceNotebookFileExtension(int format) {#deduceNotebookFileExtension-int-}
+```
+public static String deduceNotebookFileExtension(int format)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| format | int |  |
+
+**Returns:**
+java.lang.String

--- a/netherlands/java/com.aspose.note/saveoptions/_index.md
+++ b/netherlands/java/com.aspose.note/saveoptions/_index.md
@@ -1,0 +1,106 @@
+---
+title: "SaveOptions"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Een abstracte basisklasse die documentopslagopties voor een bepaald formaat voorstelt."
+type: docs
+weight: 85
+url: /nl/java/com.aspose.note/saveoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class SaveOptions
+```
+
+Een abstracte basisklasse die documentopslagopties voor een bepaald formaat voorstelt.
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getFontsSubsystem()](#getFontsSubsystem--) | Haalt de lettertype-instellingen op die tijdens het opslaan worden gebruikt of stelt deze in. |
+| [getPageCount()](#getPageCount--) | Haalt het aantal pagina's op dat moet worden opgeslagen of stelt dit in. |
+| [getPageIndex()](#getPageIndex--) | Haalt de index van de eerste pagina die moet worden opgeslagen op of stelt deze in. |
+| [getSaveFormat()](#getSaveFormat--) | Haalt het formaat op waarin het document wordt opgeslagen of stelt dit in. |
+| [setFontsSubsystem(FontsSubsystem value)](#setFontsSubsystem-com.aspose.note.fonts.FontsSubsystem-) | Haalt de lettertype-instellingen op die tijdens het opslaan worden gebruikt of stelt deze in. |
+| [setPageCount(int value)](#setPageCount-int-) | Haalt het aantal pagina's op dat moet worden opgeslagen of stelt dit in. |
+| [setPageIndex(int value)](#setPageIndex-int-) | Haalt de index van de eerste pagina die moet worden opgeslagen op of stelt deze in. |
+### getFontsSubsystem() {#getFontsSubsystem--}
+```
+public final FontsSubsystem getFontsSubsystem()
+```
+
+
+Haalt de lettertype-instellingen op die tijdens het opslaan worden gebruikt of stelt deze in.
+
+**Returns:**
+[FontsSubsystem](../../com.aspose.note.fonts/fontssubsystem)
+### getPageCount() {#getPageCount--}
+```
+public final int getPageCount()
+```
+
+
+Haalt het aantal pagina's op dat moet worden opgeslagen of stelt dit in. Standaard is \{@link int\#Int32Extensions.MaxValue\} wat betekent dat alle pagina's van het document worden gerenderd.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public final int getPageIndex()
+```
+
+
+Haalt de index van de eerste pagina die moet worden opgeslagen op of stelt deze in. Standaard is 0.
+
+**Returns:**
+int
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Haalt het formaat op waarin het document wordt opgeslagen of stelt dit in.
+
+**Returns:**
+int
+### setFontsSubsystem(FontsSubsystem value) {#setFontsSubsystem-com.aspose.note.fonts.FontsSubsystem-}
+```
+public final void setFontsSubsystem(FontsSubsystem value)
+```
+
+
+Haalt de lettertype-instellingen op die tijdens het opslaan worden gebruikt of stelt deze in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| value | [FontsSubsystem](../../com.aspose.note.fonts/fontssubsystem) |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public final void setPageCount(int value)
+```
+
+
+Haalt het aantal pagina's op dat moet worden opgeslagen of stelt dit in. Standaard is \{@link int\#Int32Extensions.MaxValue\} wat betekent dat alle pagina's van het document worden gerenderd.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public final void setPageIndex(int value)
+```
+
+
+Haalt de index van de eerste pagina die moet worden opgeslagen op of stelt deze in. Standaard is 0.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | int |  |
+

--- a/netherlands/java/com.aspose.note/style/_index.md
+++ b/netherlands/java/com.aspose.note/style/_index.md
@@ -1,0 +1,325 @@
+---
+title: "Stijl"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Deze klasse bevat gemeenschappelijke eigenschappen van  en  klassen."
+type: docs
+weight: 86
+url: /nl/java/com.aspose.note/style/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Style<T>
+```
+
+Deze klasse bevat gemeenschappelijke eigenschappen van [ParagraphStyle](../../com.aspose.note/paragraphstyle) en [TextStyle](../../com.aspose.note/textstyle) klassen.
+
+T :
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [Style()](#Style--) |  |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getFontColor()](#getFontColor--) | Haalt de letterkleur op of stelt deze in. |
+| [getFontName()](#getFontName--) | Haalt de naam van het lettertype op of stelt deze in. |
+| [getFontSize()](#getFontSize--) | Haalt de lettergrootte op of stelt deze in. |
+| [getFontStyle()](#getFontStyle--) | Haalt de lettertype‑stijl op. |
+| [getHighlight()](#getHighlight--) | Haalt de markeerkleur op of stelt deze in. |
+| [hashCode()](#hashCode--) | Dient als een hash-functie voor het type. |
+| [isBold()](#isBold--) | Haalt een waarde op of stelt deze in die aangeeft of de tekststijl vetgedrukt is. |
+| [isItalic()](#isItalic--) | Haalt een waarde op of stelt deze in die aangeeft of de tekststijl cursief is. |
+| [isStrikethrough()](#isStrikethrough--) | Haalt een waarde op of stelt deze in die aangeeft of de tekststijl doorgestreept is. |
+| [isSubscript()](#isSubscript--) | Haalt een waarde op of stelt deze in die aangeeft of de tekststijl subscript is. |
+| [isSuperscript()](#isSuperscript--) | Haalt een waarde op of stelt deze in die aangeeft of de tekststijl superscript is. |
+| [isUnderline()](#isUnderline--) | Haalt een waarde op of stelt deze in die aangeeft of de tekststijl onderstreept is. |
+| [setBold(boolean value)](#setBold-boolean-) | Haalt een waarde op of stelt deze in die aangeeft of de tekststijl vetgedrukt is. |
+| [setFontColor(Color value)](#setFontColor-java.awt.Color-) | Haalt de letterkleur op of stelt deze in. |
+| [setFontName(String value)](#setFontName-java.lang.String-) | Haalt de naam van het lettertype op of stelt deze in. |
+| [setFontSize(Integer value)](#setFontSize-java.lang.Integer-) | Haalt de lettergrootte op of stelt deze in. |
+| [setHighlight(Color value)](#setHighlight-java.awt.Color-) | Haalt de markeerkleur op of stelt deze in. |
+| [setItalic(boolean value)](#setItalic-boolean-) | Haalt een waarde op of stelt deze in die aangeeft of de tekststijl cursief is. |
+| [setStrikethrough(boolean value)](#setStrikethrough-boolean-) | Haalt een waarde op of stelt deze in die aangeeft of de tekststijl doorgestreept is. |
+| [setSubscript(boolean value)](#setSubscript-boolean-) | Haalt een waarde op of stelt deze in die aangeeft of de tekststijl subscript is. |
+| [setSuperscript(boolean value)](#setSuperscript-boolean-) | Haalt een waarde op of stelt deze in die aangeeft of de tekststijl superscript is. |
+| [setUnderline(boolean value)](#setUnderline-boolean-) | Haalt een waarde op of stelt deze in die aangeeft of de tekststijl onderstreept is. |
+### Style() {#Style--}
+```
+public Style()
+```
+
+
+### getFontColor() {#getFontColor--}
+```
+public final Color getFontColor()
+```
+
+
+Haalt de letterkleur op of stelt deze in.
+
+**Returns:**
+java.awt.Color
+### getFontName() {#getFontName--}
+```
+public final String getFontName()
+```
+
+
+Haalt de naam van het lettertype op of stelt deze in.
+
+**Returns:**
+java.lang.String
+### getFontSize() {#getFontSize--}
+```
+public final Integer getFontSize()
+```
+
+
+Haalt de lettergrootte op of stelt deze in.
+
+**Returns:**
+java.lang.Integer
+### getFontStyle() {#getFontStyle--}
+```
+public final int getFontStyle()
+```
+
+
+Haalt de lettertype‑stijl op.
+
+**Returns:**
+int
+### getHighlight() {#getHighlight--}
+```
+public final Color getHighlight()
+```
+
+
+Haalt de markeerkleur op of stelt deze in.
+
+**Returns:**
+java.awt.Color
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als een hash-functie voor het type.
+
+**Returns:**
+int - De `int`.
+### isBold() {#isBold--}
+```
+public final boolean isBold()
+```
+
+
+Haalt een waarde op of stelt deze in die aangeeft of de tekststijl vetgedrukt is.
+
+**Returns:**
+boolean
+### isItalic() {#isItalic--}
+```
+public final boolean isItalic()
+```
+
+
+Haalt een waarde op of stelt deze in die aangeeft of de tekststijl cursief is.
+
+**Returns:**
+boolean
+### isStrikethrough() {#isStrikethrough--}
+```
+public final boolean isStrikethrough()
+```
+
+
+Haalt een waarde op of stelt deze in die aangeeft of de tekststijl doorgestreept is.
+
+**Returns:**
+boolean
+### isSubscript() {#isSubscript--}
+```
+public final boolean isSubscript()
+```
+
+
+Haalt een waarde op of stelt deze in die aangeeft of de tekststijl subscript is.
+
+**Returns:**
+boolean
+### isSuperscript() {#isSuperscript--}
+```
+public final boolean isSuperscript()
+```
+
+
+Haalt een waarde op of stelt deze in die aangeeft of de tekststijl superscript is.
+
+**Returns:**
+boolean
+### isUnderline() {#isUnderline--}
+```
+public final boolean isUnderline()
+```
+
+
+Haalt een waarde op of stelt deze in die aangeeft of de tekststijl onderstreept is.
+
+**Returns:**
+boolean
+### setBold(boolean value) {#setBold-boolean-}
+```
+public final T setBold(boolean value)
+```
+
+
+Haalt een waarde op of stelt deze in die aangeeft of de tekststijl vetgedrukt is.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+**Returns:**
+T
+### setFontColor(Color value) {#setFontColor-java.awt.Color-}
+```
+public final T setFontColor(Color value)
+```
+
+
+Haalt de letterkleur op of stelt deze in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.awt.Color |  |
+
+**Returns:**
+T
+### setFontName(String value) {#setFontName-java.lang.String-}
+```
+public final T setFontName(String value)
+```
+
+
+Haalt de naam van het lettertype op of stelt deze in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+
+**Returns:**
+T
+### setFontSize(Integer value) {#setFontSize-java.lang.Integer-}
+```
+public final T setFontSize(Integer value)
+```
+
+
+Haalt de lettergrootte op of stelt deze in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.Integer |  |
+
+**Returns:**
+T
+### setHighlight(Color value) {#setHighlight-java.awt.Color-}
+```
+public final T setHighlight(Color value)
+```
+
+
+Haalt de markeerkleur op of stelt deze in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.awt.Color |  |
+
+**Returns:**
+T
+### setItalic(boolean value) {#setItalic-boolean-}
+```
+public final T setItalic(boolean value)
+```
+
+
+Haalt een waarde op of stelt deze in die aangeeft of de tekststijl cursief is.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+**Returns:**
+T
+### setStrikethrough(boolean value) {#setStrikethrough-boolean-}
+```
+public final T setStrikethrough(boolean value)
+```
+
+
+Haalt een waarde op of stelt deze in die aangeeft of de tekststijl doorgestreept is.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+**Returns:**
+T
+### setSubscript(boolean value) {#setSubscript-boolean-}
+```
+public final T setSubscript(boolean value)
+```
+
+
+Haalt een waarde op of stelt deze in die aangeeft of de tekststijl subscript is.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+**Returns:**
+T
+### setSuperscript(boolean value) {#setSuperscript-boolean-}
+```
+public final T setSuperscript(boolean value)
+```
+
+
+Haalt een waarde op of stelt deze in die aangeeft of de tekststijl superscript is.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+**Returns:**
+T
+### setUnderline(boolean value) {#setUnderline-boolean-}
+```
+public final T setUnderline(boolean value)
+```
+
+
+Haalt een waarde op of stelt deze in die aangeeft of de tekststijl onderstreept is.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+**Returns:**
+T

--- a/netherlands/java/com.aspose.note/table/_index.md
+++ b/netherlands/java/com.aspose.note/table/_index.md
@@ -1,0 +1,122 @@
+---
+title: "Table"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een tabel voor."
+type: docs
+weight: 87
+url: /nl/java/com.aspose.note/table/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode
+
+**All Implemented Interfaces:**
+[com.aspose.note.IOutlineElementChildNode](../../com.aspose.note/ioutlineelementchildnode), [com.aspose.note.ITaggable](../../com.aspose.note/itaggable)
+```
+public final class Table extends CompositeNode<TableRow> implements IOutlineElementChildNode, ITaggable
+```
+
+Stelt een tabel voor.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [Table()](#Table--) | Initialiseert een nieuw exemplaar van de `Table`-klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | Accepteert de bezoeker van de node. |
+| [getColumns()](#getColumns--) | Haalt de kolommen van de tabel op. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | Haalt op of stelt de laatst gewijzigde tijd in. |
+| [getTags()](#getTags--) | Haalt de lijst met alle tags van een tabel op. |
+| [isBordersVisible()](#isBordersVisible--) | Haalt een waarde op die aangeeft of de tabelrand zichtbaar is. |
+| [setBordersVisible(boolean value)](#setBordersVisible-boolean-) | Stelt een waarde in die aangeeft of de tabelrand zichtbaar is. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | Haalt op of stelt de laatst gewijzigde tijd in. |
+### Table() {#Table--}
+```
+public Table()
+```
+
+
+Initialiseert een nieuw exemplaar van de `Table`-klasse.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+Accepteert de bezoeker van de node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | Het object van een klasse die afgeleid is van de `DocumentVisitor`. |
+
+### getColumns() {#getColumns--}
+```
+public System.Collections.Generic.IGenericList<TableColumn> getColumns()
+```
+
+
+Haalt de kolommen van de tabel op.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericList&lt;com.aspose.note.TableColumn&gt;
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+Haalt op of stelt de laatst gewijzigde tijd in.
+
+**Returns:**
+java.util.Date
+### getTags() {#getTags--}
+```
+public final System.Collections.Generic.List<ITag> getTags()
+```
+
+
+Haalt de lijst met alle tags van een tabel op.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.List&lt;com.aspose.note.ITag&gt;
+### isBordersVisible() {#isBordersVisible--}
+```
+public boolean isBordersVisible()
+```
+
+
+Haalt een waarde op die aangeeft of de tabelrand zichtbaar is.
+
+**Returns:**
+boolean
+### setBordersVisible(boolean value) {#setBordersVisible-boolean-}
+```
+public void setBordersVisible(boolean value)
+```
+
+
+Stelt een waarde in die aangeeft of de tabelrand zichtbaar is.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+Haalt op of stelt de laatst gewijzigde tijd in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Date |  |
+

--- a/netherlands/java/com.aspose.note/tablecell/_index.md
+++ b/netherlands/java/com.aspose.note/tablecell/_index.md
@@ -1,0 +1,119 @@
+---
+title: "TableCell"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een tabelcel voor."
+type: docs
+weight: 88
+url: /nl/java/com.aspose.note/tablecell/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode, com.aspose.note.IndentatedNode
+```
+public final class TableCell extends IndentatedNode<IOutlineChildNode,TableCell>
+```
+
+Stelt een tabelcel voor.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [TableCell()](#TableCell--) | Initialiseert een nieuw exemplaar van de `TableCell`-klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | Accepteert de bezoeker van de node. |
+| [getBackgroundColor()](#getBackgroundColor--) | Haalt de achtergrondkleur op. |
+| [getInternalIndentPosition()](#getInternalIndentPosition--) |  |
+| [getLastModifiedTime()](#getLastModifiedTime--) | Haalt op of stelt de laatst gewijzigde tijd in. |
+| [getMaxWidth()](#getMaxWidth--) | Haalt de maximale breedte op. |
+| [setBackgroundColor(Color value)](#setBackgroundColor-java.awt.Color-) | Stelt de achtergrondkleur in. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | Haalt op of stelt de laatst gewijzigde tijd in. |
+### TableCell() {#TableCell--}
+```
+public TableCell()
+```
+
+
+Initialiseert een nieuw exemplaar van de `TableCell`-klasse.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+Accepteert de bezoeker van de node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | Het object van een klasse die afgeleid is van de `DocumentVisitor`. |
+
+### getBackgroundColor() {#getBackgroundColor--}
+```
+public Color getBackgroundColor()
+```
+
+
+Haalt de achtergrondkleur op.
+
+**Returns:**
+java.awt.Color
+### getInternalIndentPosition() {#getInternalIndentPosition--}
+```
+public int getInternalIndentPosition()
+```
+
+
+Haalt de hoeveelheid items op die opgeteld moeten worden in de RgOutlineIndentDistance-array om de inspronggrootte te verkrijgen.
+
+**Returns:**
+int
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+Haalt op of stelt de laatst gewijzigde tijd in.
+
+**Returns:**
+java.util.Date
+### getMaxWidth() {#getMaxWidth--}
+```
+public float getMaxWidth()
+```
+
+
+Haalt de maximale breedte op.
+
+**Returns:**
+float
+### setBackgroundColor(Color value) {#setBackgroundColor-java.awt.Color-}
+```
+public void setBackgroundColor(Color value)
+```
+
+
+Stelt de achtergrondkleur in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.awt.Color |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+Haalt op of stelt de laatst gewijzigde tijd in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Date |  |
+

--- a/netherlands/java/com.aspose.note/tablecolumn/_index.md
+++ b/netherlands/java/com.aspose.note/tablecolumn/_index.md
@@ -1,0 +1,81 @@
+---
+title: "TableColumn"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een tabelkolom voor."
+type: docs
+weight: 89
+url: /nl/java/com.aspose.note/tablecolumn/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TableColumn
+```
+
+Stelt een tabelkolom voor.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [TableColumn()](#TableColumn--) |  |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getLockedWidth()](#getLockedWidth--) | Haalt een waarde op die aangeeft of een tabelkolom een vaste breedte heeft en niet automatisch wordt aangepast aan de tabelinhoud. |
+| [getWidth()](#getWidth--) | Haalt de breedte op. |
+| [setLockedWidth(boolean value)](#setLockedWidth-boolean-) | Stelt een waarde in die aangeeft of een tabelkolom een vaste breedte heeft en niet automatisch wordt aangepast aan de tabelinhoud. |
+| [setWidth(float value)](#setWidth-float-) | Stelt de breedte in. |
+### TableColumn() {#TableColumn--}
+```
+public TableColumn()
+```
+
+
+### getLockedWidth() {#getLockedWidth--}
+```
+public boolean getLockedWidth()
+```
+
+
+Haalt een waarde op die aangeeft of een tabelkolom een vaste breedte heeft en niet automatisch wordt aangepast aan de tabelinhoud. Standaard is de kolombreedte niet vergrendeld.
+
+**Returns:**
+boolean
+### getWidth() {#getWidth--}
+```
+public float getWidth()
+```
+
+
+Haalt de breedte op.
+
+**Returns:**
+float
+### setLockedWidth(boolean value) {#setLockedWidth-boolean-}
+```
+public void setLockedWidth(boolean value)
+```
+
+
+Stelt een waarde in die aangeeft of een tabelkolom een vaste breedte heeft en niet automatisch wordt aangepast aan de tabelinhoud. Standaard is de kolombreedte niet vergrendeld.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+### setWidth(float value) {#setWidth-float-}
+```
+public void setWidth(float value)
+```
+
+
+Stelt de breedte in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+

--- a/netherlands/java/com.aspose.note/tablerow/_index.md
+++ b/netherlands/java/com.aspose.note/tablerow/_index.md
@@ -1,0 +1,72 @@
+---
+title: "TableRow"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een tabelrij voor."
+type: docs
+weight: 90
+url: /nl/java/com.aspose.note/tablerow/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase), com.aspose.note.CompositeNode
+```
+public final class TableRow extends CompositeNode<TableCell>
+```
+
+Stelt een tabelrij voor.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [TableRow()](#TableRow--) | Initialiseert een nieuw exemplaar van de `TableRow`‑klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | Accepteert de bezoeker van de node. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | Haalt op of stelt de laatst gewijzigde tijd in. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | Haalt op of stelt de laatst gewijzigde tijd in. |
+### TableRow() {#TableRow--}
+```
+public TableRow()
+```
+
+
+Initialiseert een nieuw exemplaar van de `TableRow`‑klasse.
+
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+Accepteert de bezoeker van de node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | Het object van een klasse die afgeleid is van de `DocumentVisitor`. |
+
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+Haalt op of stelt de laatst gewijzigde tijd in.
+
+**Returns:**
+java.util.Date
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+Haalt op of stelt de laatst gewijzigde tijd in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Date |  |
+

--- a/netherlands/java/com.aspose.note/tagstatus/_index.md
+++ b/netherlands/java/com.aspose.note/tagstatus/_index.md
@@ -1,0 +1,47 @@
+---
+title: "TagStatus"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Specificeert de status van de notitie‑tagknoop."
+type: docs
+weight: 91
+url: /nl/java/com.aspose.note/tagstatus/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class TagStatus extends System.Enum
+```
+
+Specificeert de status van de notitie‑tagknoop.
+## Velden
+
+| Veld | Beschrijving |
+| --- | --- |
+| [Completed](#Completed) | De notitag is voltooid. |
+| [Disabled](#Disabled) | De notitag is uitgeschakeld. |
+| [Open](#Open) | De notitag is geopend. |
+### Completed {#Completed}
+```
+public static final int Completed
+```
+
+
+De notitag is voltooid.
+
+### Disabled {#Disabled}
+```
+public static final int Disabled
+```
+
+
+De notitag is uitgeschakeld.
+
+### Open {#Open}
+```
+public static final int Open
+```
+
+
+De notitag is geopend.
+

--- a/netherlands/java/com.aspose.note/textrun/_index.md
+++ b/netherlands/java/com.aspose.note/textrun/_index.md
@@ -1,0 +1,137 @@
+---
+title: "TextRun"
+second_title: "Aspose.Note for Java API-referentie"
+description: "De klasse die een stuk tekst met bijbehorende opmaak voorstelt."
+type: docs
+weight: 92
+url: /nl/java/com.aspose.note/textrun/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextRun
+```
+
+De klasse die een stuk tekst met bijbehorende opmaak voorstelt.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [TextRun(String text, TextStyle style)](#TextRun-java.lang.String-com.aspose.note.TextStyle-) | Initialiseert een nieuw exemplaar van de [TextRun](../../com.aspose.note/textrun) klasse. |
+| [TextRun(String text)](#TextRun-java.lang.String-) | Initialiseert een nieuw exemplaar van de [TextRun](../../com.aspose.note/textrun) klasse met de standaardstijl. |
+| [TextRun(TextStyle style)](#TextRun-com.aspose.note.TextStyle-) | Initialiseert een nieuw exemplaar van de [TextRun](../../com.aspose.note/textrun) klasse met lege tekst. |
+| [TextRun()](#TextRun--) | Initialiseert een nieuw exemplaar van de [TextRun](../../com.aspose.note/textrun) klasse met lege tekst en standaardstijl. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [getLength()](#getLength--) | Haalt de lengte van de bijbehorende tekst op. |
+| [getStyle()](#getStyle--) | Haalt de stijl op. |
+| [getText()](#getText--) | Haalt de tekst op. |
+| [setStyle(TextStyle value)](#setStyle-com.aspose.note.TextStyle-) | Stelt de stijl in. |
+| [setText(String value)](#setText-java.lang.String-) | Stelt de tekst in. |
+### TextRun(String text, TextStyle style) {#TextRun-java.lang.String-com.aspose.note.TextStyle-}
+```
+public TextRun(String text, TextStyle style)
+```
+
+
+Initialiseert een nieuw exemplaar van de [TextRun](../../com.aspose.note/textrun) klasse.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| tekst | java.lang.String | De bijbehorende tekst. |
+| style | [TextStyle](../../com.aspose.note/textstyle) | De stijl. |
+
+### TextRun(String text) {#TextRun-java.lang.String-}
+```
+public TextRun(String text)
+```
+
+
+Initialiseert een nieuw exemplaar van de [TextRun](../../com.aspose.note/textrun) klasse met de standaardstijl.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| tekst | java.lang.String | De bijbehorende tekst. |
+
+### TextRun(TextStyle style) {#TextRun-com.aspose.note.TextStyle-}
+```
+public TextRun(TextStyle style)
+```
+
+
+Initialiseert een nieuw exemplaar van de [TextRun](../../com.aspose.note/textrun) klasse met lege tekst.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| style | [TextStyle](../../com.aspose.note/textstyle) | De stijl. |
+
+### TextRun() {#TextRun--}
+```
+public TextRun()
+```
+
+
+Initialiseert een nieuw exemplaar van de [TextRun](../../com.aspose.note/textrun) klasse met lege tekst en standaardstijl.
+
+### getLength() {#getLength--}
+```
+public final int getLength()
+```
+
+
+Haalt de lengte van de bijbehorende tekst op.
+
+**Returns:**
+int
+### getStyle() {#getStyle--}
+```
+public final TextStyle getStyle()
+```
+
+
+Haalt de stijl op.
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### getText() {#getText--}
+```
+public final String getText()
+```
+
+
+Haalt de tekst op.
+
+**Returns:**
+java.lang.String
+### setStyle(TextStyle value) {#setStyle-com.aspose.note.TextStyle-}
+```
+public final void setStyle(TextStyle value)
+```
+
+
+Stelt de stijl in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| value | [TextStyle](../../com.aspose.note/textstyle) |  |
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public final void setText(String value)
+```
+
+
+Stelt de tekst in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+

--- a/netherlands/java/com.aspose.note/textstyle/_index.md
+++ b/netherlands/java/com.aspose.note/textstyle/_index.md
@@ -1,0 +1,255 @@
+---
+title: "TextStyle"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Specificeert de tekststijl."
+type: docs
+weight: 93
+url: /nl/java/com.aspose.note/textstyle/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.note.Style
+```
+public final class TextStyle extends Style<TextStyle>
+```
+
+Specificeert de tekststijl.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [TextStyle()](#TextStyle--) | Initialiseert een nieuw exemplaar van de `TextStyle` klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [equals(TextStyle other)](#equals-com.aspose.note.TextStyle-) | Bepaalt of het opgegeven object gelijk is aan het huidige object. |
+| [equals(Object obj)](#equals-java.lang.Object-) | Bepaalt of het opgegeven object gelijk is aan het huidige object. |
+| [getDefault()](#getDefault--) | Haalt de stijl op met de cultuur \"en-US\". |
+| [getDefaultMsOneNoteTitleDateStyle()](#getDefaultMsOneNoteTitleDateStyle--) | Haalt de standaardstijl op voor de titel datum in MS OneNote. |
+| [getDefaultMsOneNoteTitleTextStyle()](#getDefaultMsOneNoteTitleTextStyle--) | Haalt de standaardstijl op voor de titeltekst in MS OneNote. |
+| [getDefaultMsOneNoteTitleTimeStyle()](#getDefaultMsOneNoteTitleTimeStyle--) | Haalt de standaardstijl op voor de titel tijd in MS OneNote. |
+| [getHyperlinkAddress()](#getHyperlinkAddress--) | Haalt het hyperlinkadres op. |
+| [getLanguage()](#getLanguage--) | Haalt de taal van de tekst op. |
+| [hashCode()](#hashCode--) | Dient als een hash-functie voor het type. |
+| [isHidden()](#isHidden--) | Haalt een waarde op die aangeeft of de tekststijl verborgen is. |
+| [isHyperlink()](#isHyperlink--) | Haalt een waarde op die aangeeft of de tekststijl een hyperlink is. |
+| [isMathFormatting()](#isMathFormatting--) | Haalt een waarde op of stelt deze in die aangeeft of de tekststijl wiskundige opmaak heeft. |
+| [setHidden(boolean value)](#setHidden-boolean-) | Stelt een waarde in die aangeeft of de tekststijl verborgen is. |
+| [setHyperlink(boolean value)](#setHyperlink-boolean-) | Stelt een waarde in die aangeeft of de tekststijl een hyperlink is. |
+| [setHyperlinkAddress(String value)](#setHyperlinkAddress-java.lang.String-) | Stelt het hyperlinkadres in. |
+| [setLanguage(Locale value)](#setLanguage-java.util.Locale-) | Stelt de taal van de tekst in. |
+| [setMathFormatting(boolean value)](#setMathFormatting-boolean-) | Stelt een waarde in die aangeeft of de tekststijl wiskundige opmaak is. |
+### TextStyle() {#TextStyle--}
+```
+public TextStyle()
+```
+
+
+Initialiseert een nieuw exemplaar van de `TextStyle` klasse.
+
+### equals(TextStyle other) {#equals-com.aspose.note.TextStyle-}
+```
+public boolean equals(TextStyle other)
+```
+
+
+Bepaalt of het opgegeven object gelijk is aan het huidige object.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| other | [TextStyle](../../com.aspose.note/textstyle) | Het object. |
+
+**Returns:**
+boolean - De `bool`.
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Bepaalt of het opgegeven object gelijk is aan het huidige object.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| obj | java.lang.Object | Het object. |
+
+**Returns:**
+boolean - De `bool`.
+### getDefault() {#getDefault--}
+```
+public static TextStyle getDefault()
+```
+
+
+Haalt de stijl op met de cultuur \"en-US\".
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### getDefaultMsOneNoteTitleDateStyle() {#getDefaultMsOneNoteTitleDateStyle--}
+```
+public static TextStyle getDefaultMsOneNoteTitleDateStyle()
+```
+
+
+Haalt de standaardstijl op voor de titel datum in MS OneNote.
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### getDefaultMsOneNoteTitleTextStyle() {#getDefaultMsOneNoteTitleTextStyle--}
+```
+public static TextStyle getDefaultMsOneNoteTitleTextStyle()
+```
+
+
+Haalt de standaardstijl op voor de titeltekst in MS OneNote.
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### getDefaultMsOneNoteTitleTimeStyle() {#getDefaultMsOneNoteTitleTimeStyle--}
+```
+public static TextStyle getDefaultMsOneNoteTitleTimeStyle()
+```
+
+
+Haalt de standaardstijl op voor de titel tijd in MS OneNote.
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### getHyperlinkAddress() {#getHyperlinkAddress--}
+```
+public String getHyperlinkAddress()
+```
+
+
+Haalt het hyperlinkadres op. Moet worden ingesteld als de waarde van de [isHyperlink](../../com.aspose.note/textstyle\#isHyperlink--) eigenschap true is.
+
+**Returns:**
+java.lang.String
+### getLanguage() {#getLanguage--}
+```
+public Locale getLanguage()
+```
+
+
+Haalt de taal van de tekst op.
+
+**Returns:**
+java.util.Locale
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als een hash-functie voor het type.
+
+**Returns:**
+int - De `int`.
+### isHidden() {#isHidden--}
+```
+public boolean isHidden()
+```
+
+
+Haalt een waarde op die aangeeft of de tekststijl verborgen is.
+
+**Returns:**
+boolean
+### isHyperlink() {#isHyperlink--}
+```
+public boolean isHyperlink()
+```
+
+
+Haalt een waarde op die aangeeft of de tekststijl een hyperlink is.
+
+**Returns:**
+boolean
+### isMathFormatting() {#isMathFormatting--}
+```
+public boolean isMathFormatting()
+```
+
+
+Haalt een waarde op of stelt deze in die aangeeft of de tekststijl wiskundige opmaak heeft.
+
+**Returns:**
+boolean
+### setHidden(boolean value) {#setHidden-boolean-}
+```
+public TextStyle setHidden(boolean value)
+```
+
+
+Stelt een waarde in die aangeeft of de tekststijl verborgen is.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### setHyperlink(boolean value) {#setHyperlink-boolean-}
+```
+public TextStyle setHyperlink(boolean value)
+```
+
+
+Stelt een waarde in die aangeeft of de tekststijl een hyperlink is.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### setHyperlinkAddress(String value) {#setHyperlinkAddress-java.lang.String-}
+```
+public TextStyle setHyperlinkAddress(String value)
+```
+
+
+Stelt het hyperlinkadres in. Moet worden ingesteld als de waarde van de [isHyperlink](../../com.aspose.note/textstyle\#isHyperlink--) eigenschap true is.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.lang.String |  |
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### setLanguage(Locale value) {#setLanguage-java.util.Locale-}
+```
+public TextStyle setLanguage(Locale value)
+```
+
+
+Stelt de taal van de tekst in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Locale |  |
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)
+### setMathFormatting(boolean value) {#setMathFormatting-boolean-}
+```
+public TextStyle setMathFormatting(boolean value)
+```
+
+
+Stelt een waarde in die aangeeft of de tekststijl wiskundige opmaak is.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | boolean |  |
+
+**Returns:**
+[TextStyle](../../com.aspose.note/textstyle)

--- a/netherlands/java/com.aspose.note/tiffcompression/_index.md
+++ b/netherlands/java/com.aspose.note/tiffcompression/_index.md
@@ -1,0 +1,83 @@
+---
+title: "TiffCompression"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Specificeert welk type compressie te gebruiken bij het opslaan van een document in het TIFF-formaat."
+type: docs
+weight: 94
+url: /nl/java/com.aspose.note/tiffcompression/
+---
+
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class TiffCompression extends System.Enum
+```
+
+Specificeert welk type compressie te gebruiken bij het opslaan van een document in het TIFF-formaat.
+## Velden
+
+| Veld | Beschrijving |
+| --- | --- |
+| [Ccitt3](#Ccitt3) | Geeft CCITT Group 3-faxcodering aan. |
+| [Ccitt4](#Ccitt4) | Geeft CCITT Group 4-faxcodering aan. |
+| [Jpeg](#Jpeg) | Geeft JPEG DCT-compressie aan. |
+| [Lzw](#Lzw) | Geeft LZW-compressie aan. |
+| [None](#None) | Geeft geen compressie aan. |
+| [PackBits](#PackBits) | Geeft Macintosh RLE-compressie aan. |
+| [Rle](#Rle) | Geeft RLE-compressie aan. |
+### Ccitt3 {#Ccitt3}
+```
+public static final int Ccitt3
+```
+
+
+Geeft CCITT Group 3-faxcodering aan.
+
+### Ccitt4 {#Ccitt4}
+```
+public static final int Ccitt4
+```
+
+
+Geeft CCITT Group 4-faxcodering aan.
+
+### Jpeg {#Jpeg}
+```
+public static final int Jpeg
+```
+
+
+Geeft JPEG DCT-compressie aan.
+
+### Lzw {#Lzw}
+```
+public static final int Lzw
+```
+
+
+Geeft LZW-compressie aan.
+
+### None {#None}
+```
+public static final int None
+```
+
+
+Geeft geen compressie aan.
+
+### PackBits {#PackBits}
+```
+public static final int PackBits
+```
+
+
+Geeft Macintosh RLE-compressie aan.
+
+### Rle {#Rle}
+```
+public static final int Rle
+```
+
+
+Geeft RLE-compressie aan.
+

--- a/netherlands/java/com.aspose.note/title/_index.md
+++ b/netherlands/java/com.aspose.note/title/_index.md
@@ -1,0 +1,256 @@
+---
+title: "Title"
+second_title: "Aspose.Note for Java API-referentie"
+description: "Stelt een titel voor."
+type: docs
+weight: 95
+url: /nl/java/com.aspose.note/title/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.note.Node](../../com.aspose.note/node), [com.aspose.note.CompositeNodeBase](../../com.aspose.note/compositenodebase)
+
+**All Implemented Interfaces:**
+com.aspose.note.ICompositeNodeT, [com.aspose.note.IPageChildNode](../../com.aspose.note/ipagechildnode)
+```
+public final class Title extends CompositeNodeBase implements ICompositeNodeT<RichText>, IPageChildNode
+```
+
+Stelt een titel voor.
+## Constructors
+
+| Constructor | Beschrijving |
+| --- | --- |
+| [Title()](#Title--) | Initialiseert een nieuw exemplaar van de `Title`-klasse. |
+## Methoden
+
+| Methode | Beschrijving |
+| --- | --- |
+| [&lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass)](#-T1-getChildNodes-java.lang.Class-T1--) | Haalt alle kindknopen op op basis van het knooptype. |
+| [accept(DocumentVisitor visitor)](#accept-com.aspose.note.DocumentVisitor-) | Accepteert de bezoeker van de node. |
+| [getChildNodes(int type)](#getChildNodes-int-) |  |
+| [getHorizontalOffset()](#getHorizontalOffset--) | Haalt op of stelt de horizontale offset in. |
+| [getLastModifiedTime()](#getLastModifiedTime--) | Haalt op of stelt de laatst gewijzigde tijd in. |
+| [getTitleDate()](#getTitleDate--) | Haalt op of stelt een tekenreeksrepresentatie van de datum in de titel in. |
+| [getTitleText()](#getTitleText--) | Haalt op of stelt de tekst van de titel in. |
+| [getTitleTime()](#getTitleTime--) | Haalt op of stelt een tekenreeksrepresentatie van de tijd in de titel in. |
+| [getVerticalOffset()](#getVerticalOffset--) | Haalt op of stelt de verticale offset in. |
+| [isComposite()](#isComposite--) | Haalt een waarde op die aangeeft of dit knooppunt samengesteld is. |
+| [iterator()](#iterator--) | Retourneert een enumerator die door de onderliggende knooppunten van de [Title](../../com.aspose.note/title) iterereert. |
+| [setHorizontalOffset(float value)](#setHorizontalOffset-float-) | Haalt op of stelt de horizontale offset in. |
+| [setLastModifiedTime(Date value)](#setLastModifiedTime-java.util.Date-) | Haalt op of stelt de laatst gewijzigde tijd in. |
+| [setTitleDate(RichText value)](#setTitleDate-com.aspose.note.RichText-) | Haalt op of stelt een tekenreeksrepresentatie van de datum in de titel in. |
+| [setTitleText(RichText value)](#setTitleText-com.aspose.note.RichText-) | Haalt op of stelt de tekst van de titel in. |
+| [setTitleTime(RichText value)](#setTitleTime-com.aspose.note.RichText-) | Haalt op of stelt een tekenreeksrepresentatie van de tijd in de titel in. |
+| [setVerticalOffset(float value)](#setVerticalOffset-float-) | Haalt op of stelt de verticale offset in. |
+### Title() {#Title--}
+```
+public Title()
+```
+
+
+Initialiseert een nieuw exemplaar van de `Title`-klasse.
+
+### &lt;T1&gt;getChildNodes(Class&lt;T1&gt; typeParameterClass) {#-T1-getChildNodes-java.lang.Class-T1--}
+```
+public List<T1> <T1>getChildNodes(Class<T1> typeParameterClass)
+```
+
+
+Haalt alle kindknopen op op basis van het knooptype.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| typeParameterClass | java.lang.Class&lt;T1&gt; |  |
+
+**Returns:**
+java.util.List&lt;T1&gt; - Een lijst van kindknooppunten.
+
+`T1`: Het type van elementen in de geretourneerde lijst.
+### accept(DocumentVisitor visitor) {#accept-com.aspose.note.DocumentVisitor-}
+```
+public void accept(DocumentVisitor visitor)
+```
+
+
+Accepteert de bezoeker van de node.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| visitor | [DocumentVisitor](../../com.aspose.note/documentvisitor) | Het object van een klasse die afgeleid is van de `DocumentVisitor`. |
+
+### getChildNodes(int type) {#getChildNodes-int-}
+```
+public List<INode> getChildNodes(int type)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| type | int |  |
+
+**Returns:**
+java.util.List&lt;com.aspose.note.INode&gt;
+### getHorizontalOffset() {#getHorizontalOffset--}
+```
+public final float getHorizontalOffset()
+```
+
+
+Haalt op of stelt de horizontale offset in.
+
+**Returns:**
+float
+### getLastModifiedTime() {#getLastModifiedTime--}
+```
+public Date getLastModifiedTime()
+```
+
+
+Haalt op of stelt de laatst gewijzigde tijd in.
+
+**Returns:**
+java.util.Date
+### getTitleDate() {#getTitleDate--}
+```
+public final RichText getTitleDate()
+```
+
+
+Haalt op of stelt een tekenreeksrepresentatie van de datum in de titel in.
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext)
+### getTitleText() {#getTitleText--}
+```
+public RichText getTitleText()
+```
+
+
+Haalt op of stelt de tekst van de titel in.
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext)
+### getTitleTime() {#getTitleTime--}
+```
+public final RichText getTitleTime()
+```
+
+
+Haalt op of stelt een tekenreeksrepresentatie van de tijd in de titel in.
+
+**Returns:**
+[RichText](../../com.aspose.note/richtext)
+### getVerticalOffset() {#getVerticalOffset--}
+```
+public final float getVerticalOffset()
+```
+
+
+Haalt op of stelt de verticale offset in.
+
+**Returns:**
+float
+### isComposite() {#isComposite--}
+```
+public boolean isComposite()
+```
+
+
+Haalt een waarde op die aangeeft of dit knooppunt samengesteld is. Indien waar kan het knooppunt onderliggende knooppunten hebben.
+
+**Returns:**
+boolean
+### iterator() {#iterator--}
+```
+public final System.Collections.Generic.IGenericEnumerator<RichText> iterator()
+```
+
+
+Retourneert een enumerator die door de onderliggende knooppunten van de [Title](../../com.aspose.note/title) iterereert.
+
+**Returns:**
+com.aspose.ms.System.Collections.Generic.IGenericEnumerator&lt;com.aspose.note.RichText&gt; - De IEnumerator.
+### setHorizontalOffset(float value) {#setHorizontalOffset-float-}
+```
+public final void setHorizontalOffset(float value)
+```
+
+
+Haalt op of stelt de horizontale offset in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+
+### setLastModifiedTime(Date value) {#setLastModifiedTime-java.util.Date-}
+```
+public void setLastModifiedTime(Date value)
+```
+
+
+Haalt op of stelt de laatst gewijzigde tijd in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | java.util.Date |  |
+
+### setTitleDate(RichText value) {#setTitleDate-com.aspose.note.RichText-}
+```
+public final void setTitleDate(RichText value)
+```
+
+
+Haalt op of stelt een tekenreeksrepresentatie van de datum in de titel in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| value | [RichText](../../com.aspose.note/richtext) |  |
+
+### setTitleText(RichText value) {#setTitleText-com.aspose.note.RichText-}
+```
+public final void setTitleText(RichText value)
+```
+
+
+Haalt op of stelt de tekst van de titel in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| value | [RichText](../../com.aspose.note/richtext) |  |
+
+### setTitleTime(RichText value) {#setTitleTime-com.aspose.note.RichText-}
+```
+public final void setTitleTime(RichText value)
+```
+
+
+Haalt op of stelt een tekenreeksrepresentatie van de tijd in de titel in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| value | [RichText](../../com.aspose.note/richtext) |  |
+
+### setVerticalOffset(float value) {#setVerticalOffset-float-}
+```
+public final void setVerticalOffset(float value)
+```
+
+
+Haalt op of stelt de verticale offset in.
+
+**Parameters:**
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | float |  |
+


### PR DESCRIPTION
Automated translation of the JAVA API Reference to **Netherlands** (`nl`) generated by RDA.

- Pages translated: 107/107
- Errors: 0
- Source: `english/java`
- Output: `netherlands/java`

🤖 Generated by RDA